### PR TITLE
WI-001973: show the parent Preparation on the four generated sub-documents

### DIFF
--- a/one_fm/grd/doctype/medical_insurance/medical_insurance.json
+++ b/one_fm/grd/doctype/medical_insurance/medical_insurance.json
@@ -208,9 +208,9 @@
   {
    "fieldname": "preparation",
    "fieldtype": "Link",
-   "hidden": 1,
    "label": "Preparation",
-   "options": "Preparation"
+   "options": "Preparation",
+   "read_only": 1
   },
   {
    "allow_on_submit": 1,
@@ -289,7 +289,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-11-08 07:38:16.062987",
+ "modified": "2026-08-05 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Medical Insurance",

--- a/one_fm/grd/doctype/paci/paci.json
+++ b/one_fm/grd/doctype/paci/paci.json
@@ -239,9 +239,9 @@
   {
    "fieldname": "preparation",
    "fieldtype": "Link",
-   "hidden": 1,
    "label": "Preparation",
-   "options": "Preparation"
+   "options": "Preparation",
+   "read_only": 1
   },
   {
    "fetch_from": "employee.one_fm_civil_id",
@@ -313,7 +313,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2025-11-16 13:14:06.886454",
+ "modified": "2026-08-05 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "PACI",

--- a/one_fm/grd/doctype/preparation/test_preparation.py
+++ b/one_fm/grd/doctype/preparation/test_preparation.py
@@ -1,10 +1,30 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2021, ONE FM and Contributors
 # See license.txt
-from __future__ import unicode_literals
+import frappe
+from frappe.tests.utils import FrappeTestCase
 
-# import frappe
-import unittest
+# The sub-documents a submitted Preparation generates. Each one stores the parent's
+# name in `preparation`, set by the create_* functions in their own controllers.
+SUB_DOCUMENTS = ("Work Permit", "Medical Insurance", "Residency", "PACI")
 
-class TestPreparation(unittest.TestCase):
-	pass
+
+class TestPreparationLinkOnSubDocuments(FrappeTestCase):
+	"""WI-001973: a generated sub-document has to show which Preparation it came from.
+
+	Asserted through get_meta rather than the doctype JSON, because get_meta is what
+	the form renders from - so this also fails if a Property Setter hides the field
+	again from Customize Form, which is how it came to be hidden in the first place.
+	"""
+
+	def test_preparation_link_is_visible_and_read_only(self):
+		for doctype in SUB_DOCUMENTS:
+			with self.subTest(doctype=doctype):
+				field = frappe.get_meta(doctype).get_field("preparation")
+
+				self.assertIsNotNone(field, f"{doctype} has no Preparation field")
+				self.assertFalse(field.hidden, f"{doctype}: Preparation is hidden")
+				# Read only, not just visible: the link records which batch created the
+				# document, so it is history and must not be re-pointed by hand.
+				self.assertTrue(field.read_only, f"{doctype}: Preparation is editable")
+				self.assertEqual(field.options, "Preparation")

--- a/one_fm/grd/doctype/residency/residency.json
+++ b/one_fm/grd/doctype/residency/residency.json
@@ -435,9 +435,9 @@
   {
    "fieldname": "preparation",
    "fieldtype": "Link",
-   "hidden": 1,
    "label": "Preparation",
-   "options": "Preparation"
+   "options": "Preparation",
+   "read_only": 1
   },
   {
    "fieldname": "company_contact_number",
@@ -520,7 +520,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2025-12-08 16:34:24.973261",
+ "modified": "2026-08-05 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Residency",

--- a/one_fm/grd/doctype/work_permit/work_permit.json
+++ b/one_fm/grd/doctype/work_permit/work_permit.json
@@ -391,9 +391,9 @@
   {
    "fieldname": "preparation",
    "fieldtype": "Link",
-   "hidden": 1,
    "label": "Preparation",
-   "options": "Preparation"
+   "options": "Preparation",
+   "read_only": 1
   },
   {
    "depends_on": "eval:doc.workflow_state=='Pending By Supervisor' || doc.workflow_state=='Pending By PAM' || doc.workflow_state=='Pending By Operator'",
@@ -921,7 +921,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2026-06-04 07:30:21.125399",
+ "modified": "2026-08-05 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Work Permit",


### PR DESCRIPTION
[WI-001973](https://one-fm.com/app/work-item/WI-001973) — the parent Preparation Record has to be visible on every sub-document it generates.

## What was actually wrong

Nothing about the data. `Work Permit`, `Medical Insurance`, `Residency` and `PACI` have each stored the parent's name in `preparation` for years — `create_wp_renewal`, `create_mi_record`, `create_moi_record` and `create_PACI` all set it. The field was just `hidden: 1`, so the link existed in the database and nowhere on the form.

So this is four one-line changes: drop `hidden`, add `read_only`.

| DocType | before | after |
|---|---|---|
| Work Permit | `hidden: 1` | visible, `read_only: 1` |
| Medical Insurance | `hidden: 1` | visible, `read_only: 1` |
| Residency | `hidden: 1` | visible, `read_only: 1` |
| PACI | `hidden: 1` | visible, `read_only: 1` |

Read only, not just visible: the link records which batch created the document, so it is history and should not be re-pointed by hand.

This matches the BA site exactly — all four carry `preparation` visible with `read_only: 1` there, and the field already sits in a visible section next to Employee / Date of Application / Category on each form, so nothing needed re-ordering.

Two notes on scope:

- **Label stays "Preparation".** The AC calls it the "Preparation Record" field, but the doctype it links to is `Preparation` (`Preparation Record` is the child table inside it), and BA keeps the label as `Preparation`. Left as BA has it — say the word if the label should read differently.
- **AC-4 (a reapplied document keeps the reference) is not in this PR.** There is no Reapply button on Work Permit yet; that arrives with WI-001828, which is where carrying `preparation` onto the new attempt belongs.

## Verification

- `bench run-tests --module one_fm.grd.doctype.preparation.test_preparation --skip-before-tests` — **OK**
- The new test asserts through `frappe.get_meta`, not the doctype JSON, so it also fails if a Property Setter re-hides the field from Customize Form — which is the realistic way this regresses. Confirmed it fails on all four doctypes before the change and passes after.
- Checked the site for existing Property Setters on these four doctypes: only `naming_series` options, nothing touching `preparation`, so the doctype change is not shadowed.
- `test_work_permit` shows 3 pre-existing errors (`Could not find Fiscal Year: _Test Fiscal Year 2013`, a test-record artifact of `--skip-before-tests`). Verified identical with the change stashed — not caused here.

## To deploy

`bench migrate` (doctype sync only, no patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)