### PR TITLE
WI-001824: generate the right documents for the New Kuwaiti, Overseas and Local Transfer Actions

### DIFF
--- a/one_fm/grd/doctype/medical_insurance/medical_insurance.py
+++ b/one_fm/grd/doctype/medical_insurance/medical_insurance.py
@@ -5,7 +5,7 @@
 from __future__ import unicode_literals
 import frappe
 from frappe.model.document import Document
-from frappe.utils import today, get_url,getdate
+from frappe.utils import today, get_url,getdate, get_year_start
 from frappe import _
 from datetime import date
 from frappe.core.doctype.communication.email import make
@@ -69,7 +69,32 @@ def valid_work_permit_exists(preparation_name):
 def creat_medical_insurance_for_transfer(employee_name):
     employee = frappe.get_doc('Employee',employee_name)
     if employee:
-        create_mi_record(frappe.get_doc('Work Permit',{'employee':employee.employee}))
+        if transfer_insurance_already_open(employee.name):
+            return
+        # The employee's latest transfer permit, not whichever Work Permit the filter
+        # happened to return first - that could be a renewal from years ago, which has no
+        # insurance status to open a policy under.
+        create_mi_record(frappe.get_last_doc('Work Permit', filters={
+            'employee': employee.employee,
+            'work_permit_type': 'Local Transfer',
+        }))
+
+
+def transfer_insurance_already_open(employee):
+    """Is there already a Local Transfer policy open for this employee this year?
+
+    A Preparation opens the whole set of documents up front (WI-001824) and the Work
+    Permit reaching Completed asks for one as well, so without this the employee ends up
+    insured twice for the same transfer. Scoped to the current year to match
+    cancel_existing, so a genuine second transfer in a later year is still a new record.
+    """
+    return bool(frappe.get_all('Medical Insurance', limit=1, filters={
+        'employee': employee,
+        'insurance_status': 'Local Transfer',
+        'date_of_application': ['>=', get_year_start(today())],
+        'workflow_state': ['!=', 'Cancelled'],
+        'docstatus': ['<', 2],
+    }))
 
 
 def create_mi_record(WorkPermit):

--- a/one_fm/grd/doctype/medical_insurance/medical_insurance.py
+++ b/one_fm/grd/doctype/medical_insurance/medical_insurance.py
@@ -78,11 +78,21 @@ def create_mi_record(WorkPermit):
     if(WorkPermit.work_permit_type == "Renewal Non Kuwaiti"):
         Insurance_status = "Renewal"
         new_medical_insurance.date_of_application = WorkPermit.date_of_application #setting the same date of application of wp
-    elif(WorkPermit.work_permit_type == "New Non Kuwaiti"):#Overseas
+    elif(WorkPermit.work_permit_type == "Overseas"):
+        # An overseas hire has no insurance yet, so the policy is opened as New
+        # (WI-001881). Applied for the day the Work Permit was, which for an Overseas
+        # Work Permit is the day its Preparation was submitted.
         Insurance_status = "New"
+        new_medical_insurance.date_of_application = WorkPermit.date_of_application
     elif (WorkPermit.work_permit_type == "Local Transfer"):#for non kuwaiti <if it is for kuwait called new or renew and they don't have MI process
         Insurance_status = "Local Transfer" # the Insurance_status will be new for overseas only
         new_medical_insurance.date_of_application = today() #set the date of creation
+    else:
+        # Kuwaitis have no Medical Insurance process at all, so reaching here means a
+        # caller asked for one against a Work Permit type that does not have a status to
+        # open it under. Better to say so than to insert a row with a blank status.
+        frappe.throw(_("Medical Insurance cannot be opened for a {0} Work Permit ({1}).").format(
+            WorkPermit.work_permit_type, WorkPermit.name))
 
     new_medical_insurance.work_permit = WorkPermit.name
     new_medical_insurance.preparation = WorkPermit.preparation

--- a/one_fm/grd/doctype/paci/paci.py
+++ b/one_fm/grd/doctype/paci/paci.py
@@ -7,7 +7,7 @@ from frappe import _
 from frappe.model.document import Document
 from datetime import date
 from one_fm.api.notification import create_notification_log
-from frappe.utils import today, add_days, get_url, date_diff
+from frappe.utils import today, add_days, get_url, date_diff, get_year_start
 from frappe.utils import get_datetime, add_to_date, getdate, get_link_to_form, now_datetime, nowdate, cstr
 from frappe.core.doctype.communication.email import make
 from one_fm.processor import sendemail
@@ -131,7 +131,25 @@ def create_PACI_renewal(preparation_name):
 def create_PACI_for_transfer(employee_name):
     employee = frappe.get_doc('Employee',employee_name)
     if employee:
+        if transfer_civil_id_already_open(employee.name):
+            return
         create_PACI(frappe.get_doc('Employee',employee.employee),"Transfer")
+
+
+def transfer_civil_id_already_open(employee):
+    """Is there already a Transfer PACI open for this employee this year?
+
+    Called from two directions now: a Preparation opens the set up front (WI-001824), and
+    a Transfer Residency asks for one when it is submitted. Same year scope as
+    cancel_existing, so a later transfer still gets its own record.
+    """
+    return bool(frappe.get_all('PACI', limit=1, filters={
+        'employee': employee,
+        'category': 'Transfer',
+        'date_of_application': ['>=', get_year_start(today())],
+        'workflow_state': ['!=', 'Cancelled'],
+        'docstatus': ['<', 2],
+    }))
 
 def create_PACI(employee,Type,preparation_name = None):
         # Create New PACI: 1. New Overseas, 2. New Kuwaiti, 3. Transfer

--- a/one_fm/grd/doctype/paci/paci.py
+++ b/one_fm/grd/doctype/paci/paci.py
@@ -137,7 +137,10 @@ def create_PACI(employee,Type,preparation_name = None):
         # Create New PACI: 1. New Overseas, 2. New Kuwaiti, 3. Transfer
         if Type == "Renewal":
             start_day = add_days(employee.residency_expiry_date, -14)# MIGHT CHANGE
-        if Type == "Transfer":
+        else:
+            # Every other category - Transfer, and New Application for an overseas hire
+            # (WI-001881) - has no residency expiry to count back from, so the civil ID is
+            # applied for the day the record is opened.
             start_day = today()
         PACI_new = frappe.new_doc('PACI')
         PACI_new.employee = employee.name

--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -26,6 +26,32 @@ from one_fm.grd.doctype.paci import paci
 from one_fm.grd.doctype.fingerprint_appointment import fingerprint_appointment
 from one_fm.processor import sendemail
 
+# WI-001824: which documents each of the new Actions generates on submit. An Action
+# absent from here keeps its existing behaviour, which the renewal and extend paths
+# below still own.
+#
+# New Kuwaiti gets a Work Permit and nothing else: a Kuwaiti has no residency, no civil
+# ID application and no medical insurance process to open.
+#
+# A key means "open this document"; its value is the classification we have to hand the
+# creator. None where the creator works it out itself and its other callers rely on it
+# doing so - Medical Insurance maps the status off the Work Permit type, Residency maps
+# the category off the Action (see MOI_CATEGORY_BY_ACTION in residency.py). PACI writes
+# whatever it is given, so its category is named here. The values that result are the
+# mapping WI-001881 defines.
+NEW_ACTION_DOCUMENTS = {
+    "New Kuwaiti": {
+        "work_permit": "New Kuwaiti",
+    },
+    "Overseas": {
+        "work_permit": "Overseas",
+        "medical_insurance": None,
+        "residency": None,
+        "paci": "New Application",
+    },
+}
+
+
 class Preparation(Document):
     def update_total_amount(self):
         doc_total =  sum(i.total_amount or 0 for i in self.preparation_record if i)
@@ -109,7 +135,11 @@ class Preparation(Document):
         self.recall_create_moi_renewal_and_extend() # create moi record for all employee
         self.recall_create_paci() # create paci record for all
         # self.recall_create_fp()# create fp record for all
+        self.recall_create_documents_for_new_actions() # WI-001824: New Kuwaiti / Overseas
         self.send_notifications()
+
+    def recall_create_documents_for_new_actions(self):
+        create_documents_for_new_actions(self.name)
 
     def validate_mandatory_fields_on_submit(self):
         mandatory_fields = []
@@ -293,12 +323,72 @@ def get_grd_renewal_extension_cost(renewal_or_extend, no_of_years=False):
 		if result and len(result) > 0:
 			return result[0]
 
+def create_documents_for_new_actions(preparation_name):
+    """Generate the sub-documents the New Kuwaiti and Overseas Actions ask for (WI-001824).
+
+    One row at a time, and one row's failure does not stop the rest: the same contract
+    the renewal and extend paths already keep, so a single bad employee record cannot
+    cost the whole batch its documents.
+    """
+    preparation = frappe.get_doc('Preparation', preparation_name)
+
+    for row in preparation.preparation_record:
+        if row.renewal_or_extend not in NEW_ACTION_DOCUMENTS:
+            continue
+        try:
+            create_documents_for_row(row, preparation_name)
+        except Exception:
+            frappe.log_error(
+                title=f"Error creating GRD documents for {row.employee} in Preparation {preparation_name}",
+                message=frappe.get_traceback(),
+            )
+            continue
+
+
+def create_documents_for_row(row, preparation_name):
+    """Open the documents one Preparation row's Action calls for, in dependency order.
+
+    The Work Permit comes first because Medical Insurance is opened against it - it
+    reads the type, the application date and the passport expiry off the permit rather
+    than being told them.
+    """
+    plan = NEW_ACTION_DOCUMENTS[row.renewal_or_extend]
+    employee_doc = frappe.get_doc('Employee', row.employee)
+
+    work_permit_doc = work_permit.create_wp_from_preparation(
+        employee_doc, plan["work_permit"], preparation_name
+    )
+
+    if "medical_insurance" in plan:
+        medical_insurance.create_mi_record(work_permit_doc)
+
+    if "residency" in plan:
+        residency.create_moi_record(employee_doc, row.renewal_or_extend, preparation_name)
+
+    if "paci" in plan:
+        paci.create_PACI(employee_doc, plan["paci"], preparation_name)
+
+    return work_permit_doc
+
+
 def handle_creation_of_grd_docs(row,source):
     """
             Handle the creation of grd documents for  new rows just added after the submission of a preparation  document
     Args:
         row (dict): dict containing employee information
     """
+    # A row added after submit takes the same route as one that was there at submit,
+    # or the new Actions would silently create nothing here (WI-001824).
+    if row.renewal_or_extend in NEW_ACTION_DOCUMENTS:
+        try:
+            create_documents_for_row(row, source)
+        except Exception:
+            frappe.log_error(
+                title=f"Error creating New GRD documents for {row.employee}",
+                message=frappe.get_traceback(),
+            )
+        return
+
     try:
         employee_doc = frappe.get_doc("Employee",row.employee)
         work_permit.create_wp_renewal(employee_doc,row.renewal_or_extend,source)

--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -49,6 +49,16 @@ NEW_ACTION_DOCUMENTS = {
         "residency": None,
         "paci": "New Application",
     },
+    # The process map groups Local Transfer with Overseas and the non-Kuwaiti renewal:
+    # all four documents, opened by the Preparation itself. There is no Transfer Paper in
+    # that path, which is why the transfer side of the Work Permit lifecycle had to stop
+    # assuming one.
+    "Local Transfer": {
+        "work_permit": "Local Transfer",
+        "medical_insurance": None,
+        "residency": None,
+        "paci": "Transfer",
+    },
 }
 
 

--- a/one_fm/grd/doctype/preparation/test_preparation_new_actions.py
+++ b/one_fm/grd/doctype/preparation/test_preparation_new_actions.py
@@ -10,6 +10,10 @@ from one_fm.grd.doctype.preparation.preparation import (
 	NEW_ACTION_DOCUMENTS,
 	create_documents_for_row,
 )
+from one_fm.grd.doctype.medical_insurance.medical_insurance import (
+	creat_medical_insurance_for_transfer,
+)
+from one_fm.grd.doctype.paci.paci import create_PACI_for_transfer
 from one_fm.grd.doctype.residency.residency import create_moi_record
 
 SUB_DOCUMENTS = ("Work Permit", "Medical Insurance", "Residency", "PACI")
@@ -123,6 +127,81 @@ class TestNewActionDocuments(FrappeTestCase):
 				nowdate(),
 				f"{doctype} is not dated today",
 			)
+
+	def test_local_transfer_opens_all_four_with_their_categories(self):
+		preparation = self._preparation_with("Local Transfer")
+
+		create_documents_for_row(preparation.preparation_record[0], preparation.name)
+
+		opened = self._opened_for(preparation.name)
+		for doctype in SUB_DOCUMENTS:
+			self.assertEqual(len(opened[doctype]), 1, f"{doctype} was not opened exactly once")
+
+		self.assertEqual(
+			frappe.db.get_value("Work Permit", opened["Work Permit"][0], "work_permit_type"),
+			"Local Transfer",
+		)
+		self.assertEqual(
+			frappe.db.get_value(
+				"Medical Insurance", opened["Medical Insurance"][0], "insurance_status"
+			),
+			"Local Transfer",
+		)
+		# "Transfer" whichever door it came through - a Transfer Paper says "Transfer",
+		# a Preparation row says "Local Transfer".
+		self.assertEqual(
+			frappe.db.get_value("Residency", opened["Residency"][0], "category"), "Transfer"
+		)
+		self.assertEqual(
+			frappe.db.get_value("PACI", opened["PACI"][0], "category"), "Transfer"
+		)
+
+	def test_the_transfer_chain_does_not_open_a_second_set(self):
+		"""The downstream creators have to see the Preparation's documents and stand down.
+
+		A Local Transfer Work Permit reaching Completed asks for a Medical Insurance, and a
+		Transfer Residency asks for a PACI when it is submitted. Both now find the ones the
+		Preparation opened.
+		"""
+		preparation = self._preparation_with("Local Transfer")
+		create_documents_for_row(preparation.preparation_record[0], preparation.name)
+
+		# Counted as a delta, not an absolute: this employee is a real one off the site
+		# and may already carry transfer documents from previous work.
+		before = self._transfer_document_counts()
+		creat_medical_insurance_for_transfer(self.employee.name)
+		create_PACI_for_transfer(self.employee.name)
+
+		self.assertEqual(self._transfer_document_counts(), before, "the chain opened a second set")
+		self.assertEqual(len(self._opened_for(preparation.name)["Medical Insurance"]), 1)
+		self.assertEqual(len(self._opened_for(preparation.name)["PACI"]), 1)
+
+	def _transfer_document_counts(self):
+		"""How many live transfer documents this employee holds, per doctype."""
+		return {
+			doctype: frappe.db.count(
+				doctype,
+				{
+					"employee": self.employee.name,
+					"docstatus": ["<", 2],
+					"workflow_state": ["!=", "Cancelled"],
+					**classification,
+				},
+			)
+			for doctype, classification in (
+				("Medical Insurance", {"insurance_status": "Local Transfer"}),
+				("PACI", {"category": "Transfer"}),
+			)
+		}
+
+	def test_completion_does_not_need_a_transfer_paper(self):
+		"""A Preparation-sourced transfer has none, and completing it must not look for one."""
+		preparation = self._preparation_with("Local Transfer")
+		work_permit = create_documents_for_row(preparation.preparation_record[0], preparation.name)
+
+		self.assertFalse(work_permit.transfer_paper)
+		# Raised DoesNotExistError on `Transfer Paper None` before the guard.
+		work_permit.update_wp_child_table_in_transfer_paper()
 
 	def test_the_extend_and_renewal_categories_still_date_off_the_residency(self):
 		"""Guards the mapping the Overseas category was added to.

--- a/one_fm/grd/doctype/preparation/test_preparation_new_actions.py
+++ b/one_fm/grd/doctype/preparation/test_preparation_new_actions.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-001824: what the New Kuwaiti and Overseas Actions generate on submit."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, getdate, nowdate
+
+from one_fm.grd.doctype.preparation.preparation import (
+	NEW_ACTION_DOCUMENTS,
+	create_documents_for_row,
+)
+from one_fm.grd.doctype.residency.residency import create_moi_record
+
+SUB_DOCUMENTS = ("Work Permit", "Medical Insurance", "Residency", "PACI")
+
+
+def _an_active_employee():
+	"""An employee the GRD documents can be opened for.
+
+	Work Permit refuses anyone inactive or with a relieving date, so the filter is not
+	incidental. Taken from the site rather than created: Employee sits at MariaDB's
+	row-size limit here and a fixture would need a Company, a Fiscal Year and a
+	Designation before it inserted.
+	"""
+	name = frappe.db.get_value(
+		"Employee",
+		{"status": "Active", "relieving_date": ["is", "not set"]},
+		"name",
+		order_by="creation asc",
+	)
+	if not name:
+		raise frappe.DoesNotExistError("No active employee on this site to test against")
+	return frappe.get_doc("Employee", name)
+
+
+class TestNewActionDocuments(FrappeTestCase):
+	def setUp(self):
+		self.employee = _an_active_employee()
+
+	def _preparation_with(self, action):
+		"""A draft Preparation carrying one row with the given Action."""
+		preparation = frappe.get_doc(
+			{
+				"doctype": "Preparation",
+				"posting_date": nowdate(),
+				"preparation_record": [
+					{"employee": self.employee.name, "renewal_or_extend": action}
+				],
+			}
+		).insert(ignore_permissions=True)
+
+		return preparation
+
+	def _opened_for(self, preparation_name):
+		"""{doctype: [names]} of everything opened against this Preparation."""
+		return {
+			doctype: frappe.get_all(
+				doctype, filters={"preparation": preparation_name}, pluck="name"
+			)
+			for doctype in SUB_DOCUMENTS
+		}
+
+	def test_the_action_field_offers_both_new_actions(self):
+		options = frappe.get_meta("Preparation Record").get_field("renewal_or_extend").options
+		for action in NEW_ACTION_DOCUMENTS:
+			self.assertIn(action, options.split("\n"))
+
+	def test_new_kuwaiti_opens_only_a_work_permit(self):
+		preparation = self._preparation_with("New Kuwaiti")
+
+		create_documents_for_row(preparation.preparation_record[0], preparation.name)
+
+		opened = self._opened_for(preparation.name)
+		self.assertEqual(len(opened["Work Permit"]), 1)
+		# A Kuwaiti has no residency, no civil ID application and no medical insurance
+		# process, so the other three must not be opened.
+		for doctype in ("Medical Insurance", "Residency", "PACI"):
+			self.assertEqual(opened[doctype], [], f"{doctype} should not be opened")
+
+		work_permit = frappe.get_doc("Work Permit", opened["Work Permit"][0])
+		self.assertEqual(work_permit.work_permit_type, "New Kuwaiti")
+
+	def test_overseas_opens_all_four_with_their_categories(self):
+		preparation = self._preparation_with("Overseas")
+
+		create_documents_for_row(preparation.preparation_record[0], preparation.name)
+
+		opened = self._opened_for(preparation.name)
+		for doctype in SUB_DOCUMENTS:
+			self.assertEqual(len(opened[doctype]), 1, f"{doctype} was not opened exactly once")
+
+		# The government classification each document is opened under (WI-001881).
+		self.assertEqual(
+			frappe.db.get_value("Work Permit", opened["Work Permit"][0], "work_permit_type"),
+			"Overseas",
+		)
+		self.assertEqual(
+			frappe.db.get_value(
+				"Medical Insurance", opened["Medical Insurance"][0], "insurance_status"
+			),
+			"New",
+		)
+		self.assertEqual(
+			frappe.db.get_value("Residency", opened["Residency"][0], "category"),
+			"First Time",
+		)
+		self.assertEqual(
+			frappe.db.get_value("PACI", opened["PACI"][0], "category"),
+			"New Application",
+		)
+
+	def test_a_first_application_is_dated_the_day_it_is_opened(self):
+		"""No residency to count back from, unlike a renewal or an extension."""
+		preparation = self._preparation_with("Overseas")
+
+		create_documents_for_row(preparation.preparation_record[0], preparation.name)
+
+		opened = self._opened_for(preparation.name)
+		for doctype in ("Work Permit", "Residency", "PACI"):
+			self.assertEqual(
+				str(frappe.db.get_value(doctype, opened[doctype][0], "date_of_application")),
+				nowdate(),
+				f"{doctype} is not dated today",
+			)
+
+	def test_the_extend_and_renewal_categories_still_date_off_the_residency(self):
+		"""Guards the mapping the Overseas category was added to.
+
+		The three existing categories used to be an if/if/if chain ending in "anything
+		that is not a renewal or a transfer is an extension"; they now come from a dict,
+		and this pins that the dates they are applied for did not move.
+		"""
+		employee = frappe.get_doc(
+			"Employee",
+			frappe.db.get_value(
+				"Employee",
+				{"status": "Active", "relieving_date": ["is", "not set"], "residency_expiry_date": ["is", "set"]},
+				"name",
+			),
+		)
+		expiry = getdate(employee.residency_expiry_date)
+
+		for action, category, expected_date in (
+			("Renewal (Non-Kuwaiti)", "Renewal", add_days(expiry, -14)),
+			("Extend 2 months", "Extend", add_days(expiry, -7)),
+			("Transfer", "Transfer", getdate(nowdate())),
+		):
+			with self.subTest(action=action):
+				create_moi_record(employee, action)
+				residency = frappe.get_last_doc("Residency", filters={"employee": employee.name})
+				self.assertEqual(residency.category, category)
+				self.assertEqual(getdate(residency.date_of_application), getdate(expected_date))
+
+	def test_the_documents_carry_their_preparation(self):
+		"""The link WI-001973 put on the form has to be filled in by this path too."""
+		preparation = self._preparation_with("Overseas")
+
+		create_documents_for_row(preparation.preparation_record[0], preparation.name)
+
+		opened = self._opened_for(preparation.name)
+		for doctype in SUB_DOCUMENTS:
+			self.assertEqual(
+				frappe.db.get_value(doctype, opened[doctype][0], "preparation"),
+				preparation.name,
+			)

--- a/one_fm/grd/doctype/preparation_record/preparation_record.json
+++ b/one_fm/grd/doctype/preparation_record/preparation_record.json
@@ -65,7 +65,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Action",
-   "options": "\nRenewal (Kuwaiti)\nRenewal (Non-Kuwaiti)\nExtend 1 month\nExtend 2 months\nExtend 3 months\nLocal Transfer\nCancellation"
+   "options": "\nNew Kuwaiti\nOverseas\nRenewal (Kuwaiti)\nRenewal (Non-Kuwaiti)\nExtend 1 month\nExtend 2 months\nExtend 3 months\nLocal Transfer\nCancellation"
   },
   {
    "allow_on_submit": 1,
@@ -146,7 +146,7 @@
  "grid_page_length": 50,
  "istable": 1,
  "links": [],
- "modified": "2025-10-14 12:19:52.875090",
+ "modified": "2026-08-05 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Preparation Record",

--- a/one_fm/grd/doctype/residency/residency.py
+++ b/one_fm/grd/doctype/residency/residency.py
@@ -160,6 +160,23 @@ class Residency(Document):
         return {'Normal':'طبيعي','Diplomat':'دبلوماسي'}.get(passport)
     
 
+# The Actions whose Residency is opened by Preparation's own dispatcher rather than by
+# the "for extend" branch below (WI-001824). Without this the branch - which reads as
+# "anything that is not a renewal is an extension" - would open a second Residency for
+# them, categorised as Extend.
+ACTIONS_HANDLED_ON_SUBMIT = ('Renewal (Non-Kuwaiti)', 'New Kuwaiti', 'Overseas')
+
+# The Residency a category opens, and how many days before the residency expires it is
+# applied for. Anything not listed is an extension, applied for a week ahead.
+MOI_CATEGORY_BY_ACTION = {
+    'Renewal (Non-Kuwaiti)': ('Renewal', -14),
+    'Transfer': ('Transfer', None),
+    # First residency for an overseas hire (WI-001881): there is no expiry to count
+    # back from, so it is applied for the day the Preparation was submitted.
+    'Overseas': ('First Time', None),
+}
+
+
 #fetching the list of employee has Extend and renewal status from HR list.
 def set_employee_list_for_moi(preparation_name):
     # filter work permit records only take the non kuwaiti
@@ -172,7 +189,10 @@ def set_employee_list_for_moi(preparation_name):
                 except Exception as e:
                     frappe.log_error(message=frappe.get_traceback(), title=f"Error creating MOI for Employee {employee.employee} in Preparation {preparation_name}")
                     continue
-            if employee.renewal_or_extend != 'Renewal (Non-Kuwaiti)' and employee.nationality != 'Kuwaiti':# For extend
+            if (
+                employee.renewal_or_extend not in ACTIONS_HANDLED_ON_SUBMIT
+                and employee.nationality != 'Kuwaiti'
+            ):# For extend
                 try:
                     create_moi_record(frappe.get_doc('Employee',employee.employee),employee.renewal_or_extend,preparation_name)
                 except Exception as e:
@@ -189,15 +209,8 @@ def creat_moi_for_transfer(work_permit_name):
 
 def create_moi_record(employee,Renewal_or_Extend,preparation_name = None):
 
-    if Renewal_or_Extend == "Renewal (Non-Kuwaiti)":
-        category = "Renewal"
-        start_date = add_days(employee.residency_expiry_date, -14)
-    if Renewal_or_Extend == "Transfer":
-        category = "Transfer"
-        start_date = today()
-    if Renewal_or_Extend != "Renewal (Non-Kuwaiti)" and Renewal_or_Extend != "Transfer":
-        category = "Extend"
-        start_date = add_days(employee.residency_expiry_date, -7)
+    category, days_before_expiry = MOI_CATEGORY_BY_ACTION.get(Renewal_or_Extend, ("Extend", -7))
+    start_date = add_days(employee.residency_expiry_date, days_before_expiry) if days_before_expiry else today()
 
 
     # start_day_for_renewal = add_days(employee.residency_expiry_date, -14)# MIGHT CHANGE IN TRANSFER

--- a/one_fm/grd/doctype/residency/residency.py
+++ b/one_fm/grd/doctype/residency/residency.py
@@ -164,13 +164,16 @@ class Residency(Document):
 # the "for extend" branch below (WI-001824). Without this the branch - which reads as
 # "anything that is not a renewal is an extension" - would open a second Residency for
 # them, categorised as Extend.
-ACTIONS_HANDLED_ON_SUBMIT = ('Renewal (Non-Kuwaiti)', 'New Kuwaiti', 'Overseas')
+ACTIONS_HANDLED_ON_SUBMIT = ('Renewal (Non-Kuwaiti)', 'New Kuwaiti', 'Overseas', 'Local Transfer')
 
 # The Residency a category opens, and how many days before the residency expires it is
 # applied for. Anything not listed is an extension, applied for a week ahead.
 MOI_CATEGORY_BY_ACTION = {
     'Renewal (Non-Kuwaiti)': ('Renewal', -14),
     'Transfer': ('Transfer', None),
+    # Same category whether the transfer came from a Transfer Paper (which says
+    # "Transfer") or from a Preparation row (which says "Local Transfer").
+    'Local Transfer': ('Transfer', None),
     # First residency for an overseas hire (WI-001881): there is no expiry to count
     # back from, so it is applied for the day the Preparation was submitted.
     'Overseas': ('First Time', None),

--- a/one_fm/grd/doctype/work_permit/work_permit.py
+++ b/one_fm/grd/doctype/work_permit/work_permit.py
@@ -416,6 +416,28 @@ def create_work_permit_transfer(tp_name,employee):
             create_wp_transfer(frappe.get_doc('Employee',employee_in_tp.employee),"Local Transfer",tp_name)#check if you need to do it this way create_wp_transfer(employee_in_tp,"Local Transfer",tp_name)
 
 
+def create_wp_from_preparation(employee, work_permit_type, preparation_name):
+    """Open a Work Permit for a Preparation row whose Action is not a renewal (WI-001824).
+
+    A renewal dates its application off the residency it is renewing, which is what
+    create_wp_renewal does. A New Kuwaiti or Overseas application has no residency yet,
+    so it is applied for on the day the Preparation is submitted.
+
+    No copy of a previous Work Permit either: these are first applications, so there is
+    nothing to carry forward, and copying one would bring the old PAM references with it.
+    """
+    work_permit = frappe.new_doc('Work Permit')
+    work_permit.employee = employee.name
+    work_permit.work_permit_type = work_permit_type
+    work_permit.date_of_application = today()
+    work_permit.preparation = preparation_name
+    work_permit.ref_doctype = 'Preparation'
+    work_permit.ref_name = preparation_name
+    work_permit.insert()
+
+    return work_permit
+
+
 # Create Work Permit record once a month for renewals list
 def create_work_permit_renewal(preparation_name):
 #Get employees of the choosen preparation record

--- a/one_fm/grd/doctype/work_permit/work_permit.py
+++ b/one_fm/grd/doctype/work_permit/work_permit.py
@@ -269,6 +269,12 @@ class WorkPermit(Document):
         param: work_permit object
         This method to update work permit status if completed in transfer paper, close the transfer paper, and submit it.
         """
+        if not self.transfer_paper:
+            # A Local Transfer opened from a Preparation row has no Transfer Paper
+            # (WI-001824), and there is nothing to update or close in that case. Without
+            # this the completion raises DoesNotExistError on a Transfer Paper of None.
+            return
+
         tp = frappe.get_doc('Transfer Paper',self.transfer_paper)
         if tp:
             for wp in tp.work_permit_records:


### PR DESCRIPTION
[WI-001824](https://one-fm.com/app/work-item/WI-001824) — the Action on a Preparation row decides how many linked documents its submit generates.

> **Stacked on #6632 (WI-001973).** Base is that branch, not `staging`, so this diff shows only this work. GitHub will retarget to `staging` when #6632 merges.

## What lands

`Preparation Record.renewal_or_extend` gains **New Kuwaiti** and **Overseas**, matching the BA site's option list exactly. Submitting a Preparation then opens what the process map specifies:

| Action | Work Permit | Medical Insurance | Residency | PACI |
|---|---|---|---|---|
| New Kuwaiti | ✅ `New Kuwaiti` | — | — | — |
| Overseas | ✅ `Overseas` | ✅ `New` | ✅ `First Time` | ✅ `New Application` |
| Local Transfer | ✅ `Local Transfer` | ✅ `Local Transfer` | ✅ `Transfer` | ✅ `Transfer` |
| Renewal (Kuwaiti) | unchanged | — | — | — |
| Renewal (Non-Kuwaiti) / Extend / Cancellation | unchanged | unchanged | unchanged | unchanged |

A Kuwaiti has no residency, no civil ID application and no medical insurance process, which is why New Kuwaiti is one document and not four. The classifications are the mapping **WI-001881** specifies — they could not be deferred, since `work_permit_type` is mandatory and a Residency with no category is not a draft anyone can act on. WI-001881 carries the rest of its own ACs (the Ref DocType / Ref Name traceability, which Medical Insurance, Residency and PACI do not set today).

## Six traps on the way there

This is why the diff touches five controllers rather than one. Every one of these would have shipped as a duplicate record or a hard error:

1. **`create_moi_record` decided the category by elimination** — `if action != "Renewal (Non-Kuwaiti)" and action != "Transfer": category = "Extend"`. Overseas and Local Transfer would both have opened an *Extend* Residency, dated a week before an expiry they do not have. Now a mapping (`MOI_CATEGORY_BY_ACTION`), which is also what keeps Extend and Cancellation behaving exactly as before — a test pins that.
2. **`set_employee_list_for_moi` had the same shape**, so it would have opened a *second* Residency for these rows on top of the dispatcher's. It now skips the Actions the dispatcher owns.
3. **`create_mi_record` and `create_PACI` left a local unbound** for an unrecognised type — `UnboundLocalError` on `Insurance_status` / `start_day`. Both handle the new categories now, and Medical Insurance names the Work Permit type it cannot insure instead of dying on a missing local.
4. **A Local Transfer Work Permit reaching `Completed` opens a Medical Insurance**, and **a Transfer Residency opens a PACI on submit** — both on top of what the Preparation already opened. Each now stands down if one is already open for that employee this year (year-scoped to match `cancel_existing`, so a genuine second transfer in a later year is still its own record).
5. **Completing that permit called `frappe.get_doc("Transfer Paper", None)`** and raised `DoesNotExistError`, because a Preparation-sourced transfer has no Transfer Paper. There is nothing to close in that case, so it returns.
6. **`creat_medical_insurance_for_transfer` looked up the Work Permit with no type filter** — `frappe.get_doc("Work Permit", {"employee": …})` — so it could hand a years-old renewal to `create_mi_record`. Found by the mutation check below, which failed with *"Medical Insurance cannot be opened for a Renewal Kuwaiti Work Permit (WP-2023-00139)"*. It now takes the employee's latest Local Transfer permit.

A row added to an already-submitted Preparation routes through the same dispatcher, or the new Actions would have silently created nothing there — the old path calls `create_wp_renewal`, whose renewal guard fails and is swallowed by the surrounding `except`.

## Verification

`bench run-tests --module one_fm.grd.doctype.preparation.test_preparation_new_actions --skip-before-tests` — **9 passed**

- New Kuwaiti opens exactly one Work Permit and none of the other three
- Overseas and Local Transfer each open all four, with the categories in the table above
- first applications are dated the day they are opened (no residency to count back from)
- all four carry their `preparation` link
- the Action field offers both new options
- **the transfer chain does not open a second set** — asserted as a before/after delta, because the employee is a real one off the site and may already hold transfer documents
- **completing a Preparation-sourced transfer does not look for a Transfer Paper**
- **regression guard on the mapping refactor**: Renewal still applies at expiry−14, Extend at expiry−7, Transfer today

**Mutation-checked.** Disabling the two duplicate guards makes the delta test fail with `{'Medical Insurance': 14, 'PACI': 14} != {'Medical Insurance': 13, 'PACI': 13}` — exactly the duplicate pair it exists to catch. Restored and green.

Also `bench run-tests --module one_fm.grd.doctype.preparation.test_preparation --skip-before-tests` — **OK** (WI-001973's test, unaffected).

## Two notes for you

- **No cost rows for the new Actions.** `GRD Renewal Extension Cost` in HR Settings has no row for New Kuwaiti / Overseas / Local Transfer, so the four amount fields stay blank when one is selected. The client script guards on `if(r.message)`, so nothing breaks — but if these actions have fees, the process owner needs to add the rows.
- **Pre-existing SQL injection, not fixed here.** `get_grd_renewal_extension_cost` is `@frappe.whitelist()` and builds its query with `.format()` on `renewal_or_extend`, straight from the client. Unrelated to this WI so I left it alone; it is a ~6-line Query Builder swap whenever you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)