### PR TITLE
WI-001975: hold a Draft Visa Request to the passport and age rules

### DIFF
--- a/one_fm/visa_management/doctype/visa_request/test_visa_request.py
+++ b/one_fm/visa_management/doctype/visa_request/test_visa_request.py
@@ -1,9 +1,85 @@
 # Copyright (c) 2026, ONE FM and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, add_months, add_years, nowdate
+
+from one_fm.visa_management.doctype.visa_request.visa_request import (
+	MINIMUM_APPLICANT_AGE_YEARS,
+	MINIMUM_PASSPORT_VALIDITY_MONTHS,
+)
 
 
-class TestVisaRequest(FrappeTestCase):
-	pass
+class TestApplicantEligibility(FrappeTestCase):
+	"""WI-001975: a Draft Visa Request has to clear the passport and age rules.
+
+	Built with new_doc and validated in memory rather than inserted: the eligibility
+	check runs in validate(), and a Visa Request needs a Job Offer, a Job Applicant and a
+	passport copy before it would insert - none of which this rule looks at.
+	"""
+
+	def _draft(self, **overrides):
+		issued = "2020-01-01"
+		visa_request = frappe.new_doc("Visa Request")
+		visa_request.update(
+			{
+				"workflow_state": "Draft",
+				"passport_issued_on": issued,
+				"passport_expires_on": add_years(issued, 10),
+				"date_of_birth": add_years(nowdate(), -30),
+				**overrides,
+			}
+		)
+		return visa_request
+
+	def test_a_valid_applicant_passes(self):
+		self._draft().validate_applicant_eligibility()
+
+	def test_a_passport_short_of_the_minimum_validity_is_refused(self):
+		issued = "2020-01-01"
+		visa_request = self._draft(
+			passport_issued_on=issued,
+			passport_expires_on=add_days(add_months(issued, MINIMUM_PASSPORT_VALIDITY_MONTHS), -1),
+		)
+
+		with self.assertRaises(frappe.ValidationError) as caught:
+			visa_request.validate_applicant_eligibility()
+		self.assertIn("passport validity must be at least 18 months", str(caught.exception))
+
+	def test_a_passport_exactly_at_the_minimum_validity_passes(self):
+		""""At least" 18 months, so the boundary is allowed."""
+		issued = "2020-01-01"
+		self._draft(
+			passport_issued_on=issued,
+			passport_expires_on=add_months(issued, MINIMUM_PASSPORT_VALIDITY_MONTHS),
+		).validate_applicant_eligibility()
+
+	def test_an_applicant_below_the_minimum_age_is_refused(self):
+		visa_request = self._draft(
+			date_of_birth=add_days(add_years(nowdate(), -MINIMUM_APPLICANT_AGE_YEARS), 1)
+		)
+
+		with self.assertRaises(frappe.ValidationError) as caught:
+			visa_request.validate_applicant_eligibility()
+		self.assertIn("at least 21 years old", str(caught.exception))
+
+	def test_an_applicant_who_turns_of_age_today_passes(self):
+		self._draft(
+			date_of_birth=add_years(nowdate(), -MINIMUM_APPLICANT_AGE_YEARS)
+		).validate_applicant_eligibility()
+
+	def test_a_record_past_draft_is_left_alone(self):
+		"""A passport ages while the application is in progress; that must not strand it."""
+		issued = "2020-01-01"
+		self._draft(
+			workflow_state="Pending By PAM",
+			passport_issued_on=issued,
+			passport_expires_on=add_months(issued, 1),
+			date_of_birth=nowdate(),
+		).validate_applicant_eligibility()
+
+	def test_missing_dates_are_not_treated_as_failures(self):
+		"""Both passport dates are mandatory on the form; date of birth is not."""
+		self._draft(date_of_birth=None).validate_applicant_eligibility()
+		self._draft(passport_issued_on=None, passport_expires_on=None).validate_applicant_eligibility()

--- a/one_fm/visa_management/doctype/visa_request/visa_request.py
+++ b/one_fm/visa_management/doctype/visa_request/visa_request.py
@@ -2,14 +2,67 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
+from frappe.utils import add_months, add_years, getdate, nowdate
+
+# WI-001975: the eligibility a Draft has to clear before it can be saved. Both are
+# government requirements rather than internal policy, so they are checked at the door -
+# an applicant who fails them cannot be put through the visa process at all.
+MINIMUM_PASSPORT_VALIDITY_MONTHS = 18
+MINIMUM_APPLICANT_AGE_YEARS = 21
 
 
 class VisaRequest(Document):
 	def validate(self):
+		self.validate_applicant_eligibility()
 		self.validate_workflow_transitions()
 		self.validate_references()
 		self.update_tracker_status()
+
+	def validate_applicant_eligibility(self):
+		"""Hold a Draft to the passport and age rules (WI-001975).
+
+		Only in Draft. A record that has already moved into the workflow was accepted on
+		the day it was raised, and re-checking it here would strand it: the passport
+		carries on ageing while the application is in progress, so a visa halfway through
+		PAM would become unsaveable through no fault of the operator.
+		"""
+		if (self.workflow_state or "Draft") != "Draft":
+			return
+
+		self.validate_passport_validity()
+		self.validate_applicant_age()
+
+	def validate_passport_validity(self):
+		if not (self.passport_issued_on and self.passport_expires_on):
+			return
+
+		# Compared by adding the months to the issue date rather than counting days, so
+		# the answer does not drift with the length of the months in between.
+		if getdate(self.passport_expires_on) < getdate(
+			add_months(self.passport_issued_on, MINIMUM_PASSPORT_VALIDITY_MONTHS)
+		):
+			frappe.throw(
+				_(
+					"The applicant's passport validity must be at least {0} months from the "
+					"passport expiry date. The Visa Request cannot be saved."
+				).format(MINIMUM_PASSPORT_VALIDITY_MONTHS),
+				title=_("Passport Validity Too Short"),
+			)
+
+	def validate_applicant_age(self):
+		if not self.date_of_birth:
+			return
+
+		if getdate(add_years(self.date_of_birth, MINIMUM_APPLICANT_AGE_YEARS)) > getdate(nowdate()):
+			frappe.throw(
+				_(
+					"The applicant must be at least {0} years old to create a Visa Request. "
+					"The Visa Request cannot be saved."
+				).format(MINIMUM_APPLICANT_AGE_YEARS),
+				title=_("Applicant Below Minimum Age"),
+			)
 
 	def update_tracker_status(self):
 		if not self.job_offer:


### PR DESCRIPTION
[WI-001975](https://one-fm.com/app/work-item/WI-001975) — an applicant who cannot get a visa should not get a Visa Request.

A Draft refuses to save unless the passport carries at least **18 months** of validity and the applicant is at least **21**, with the exact messages from the work item's Notes.

Independent of the other Operations-017 branches — base is `staging`.

## Two decisions worth a look

**1. The check runs only in Draft.** The AC says "when the Recruiter clicks Save to save the Visa Request in the Draft workflow state", and that limit matters: a passport keeps ageing while PAM has the application, so re-checking on every later save would eventually make a visa halfway through the workflow unsaveable through no fault of the operator. A record past Draft was accepted on the day it was raised and is left alone.

**2. Validity is measured against the issue date, per the AC's wording.** The AC says to "calculate the passport validity using the Passport Issued On and Passport Expires On fields", so that is what this does — `expires_on >= issued_on + 18 months`. Compared by adding months rather than counting days, so the answer does not drift with the length of the months in between.

> ⚠️ **Worth confirming before this merges.** Read that way, the rule measures the passport's *total term*, which for an ordinary 5- or 10-year passport always passes — so in practice it catches short-term or emergency passports and data-entry errors (an expiry before the issue date), not much else. The alternative reading is **18 months remaining from today** (`expires_on >= today + 18 months`), which is the usual Kuwait work-visa requirement and would actually gate applicants. The validation message — "at least 18 months from the passport expiry date" — is ambiguous enough to support either.
>
> I implemented what the AC literally specifies rather than substitute my own reading. If the intent is remaining validity, it is a one-line change (`add_months(nowdate(), 18)` instead of `add_months(self.passport_issued_on, 18)`) plus one test date — say the word.

## Verification

`bench run-tests --module one_fm.visa_management.doctype.visa_request.test_visa_request --skip-before-tests` — **7 passed**

Both boundaries are pinned, in both directions:

| Case | Expected |
|---|---|
| passport valid exactly 18 months | saves |
| passport valid 18 months − 1 day | refused, "passport validity must be at least 18 months" |
| applicant turns 21 today | saves |
| applicant 21 one day short | refused, "at least 21 years old" |
| record in `Pending By PAM` with a 1-month passport and an infant's DOB | left alone |
| date of birth empty | no age check (the field is not mandatory on the form) |

Checked that nothing creates Visa Requests programmatically — no `new_doc("Visa Request")` anywhere in the app — so this only affects the recruiter's own save, with no automated flow to break behind it.

## To deploy

Nothing to migrate — controller change only. `bench restart` to pick up the Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)