### PR TITLE
WI-001979: make the attendance sheet's summary columns reconcile

### DIFF
--- a/one_fm/one_fm/report/operations_monthly_attendance_sheet/operations_monthly_attendance_sheet.py
+++ b/one_fm/one_fm/report/operations_monthly_attendance_sheet/operations_monthly_attendance_sheet.py
@@ -27,6 +27,64 @@ BY_SHIFT_HOURS = "Shift Hours"
 OVERTIME = "Over-Time"
 BASIC = "Basic"
 
+# WI-001979: the summary block at the end of a row. Every day in the range increments
+# exactly one of these, which is what makes them reconcilable - add them up and you get
+# the days in the range, with no cell counting.
+#
+# `working_days` and `off_days` keep their fieldnames (the print format renders them by
+# name); only the Present Days label changed.
+SUMMARY_COUNTERS = (
+	"working_days",
+	"off_days",
+	"absent_days",
+	"annual_leave_days",
+	"sick_leave_days",
+	"leave_without_pay_days",
+	"other_days",
+	"missing_days",
+)
+
+# Statuses that count as a day present. Work From Home and Working already showed as "P"
+# in the day cells, so they count here too - the column follows the cell.
+PRESENT_STATUSES = ("Present", "Working", "Work From Home")
+
+# Both kinds of day off share one column, per the AC.
+DAY_OFF_STATUSES = ("Day Off", "Client Day Off")
+
+# Leave Type -> its own column. A leave of any other type (Business Trip, Hajj Leave)
+# counts as Other: naming it would mean a column per Leave Type on this site, which is
+# eleven of them.
+LEAVE_TYPE_COUNTERS = {
+	"Annual Leave": "annual_leave_days",
+	"Sick Leave": "sick_leave_days",
+	"Leave Without Pay": "leave_without_pay_days",
+}
+
+
+def summary_counter(status, leave_type=None):
+	"""Which summary column one day belongs to (WI-001979).
+
+	Total, rather than a chain of ifs with a gap at the end: a day with a status this
+	does not name is Other, and a day with no status at all is Missing. Nothing falls
+	through uncounted, so the row's figures always reconcile to the range.
+	"""
+	if not status:
+		return "missing_days"
+
+	if status in PRESENT_STATUSES:
+		return "working_days"
+
+	if status in DAY_OFF_STATUSES:
+		return "off_days"
+
+	if status == "Absent":
+		return "absent_days"
+
+	if status == "On Leave":
+		return LEAVE_TYPE_COUNTERS.get(leave_type, "other_days")
+
+	return "other_days"
+
 
 def is_invalid_roster_combination(filters):
 	"""Overtime asked for together with Day Off OT (WI-001791, Logic Rule 4).
@@ -104,7 +162,7 @@ def execute(filters):
 			"Clear one of them to generate the report."
 		)
 
-	attendance_map, hours_map = get_attendance_map(filters)
+	attendance_map, hours_map, leave_type_map = get_attendance_map(filters)
 	if not attendance_map:
 		frappe.msgprint(_("No attendance records found."), alert=True, indicator="orange")
 		return get_columns(filters, dates), []
@@ -116,7 +174,7 @@ def execute(filters):
 		hours_map = merge_hours_maps(hours_map, schedule_hours_map)
 
 	columns = get_columns(filters, dates)
-	data = get_data(filters, dates, attendance_map, schedule_map, hours_map)
+	data = get_data(filters, dates, attendance_map, schedule_map, hours_map, leave_type_map)
 
 	if not data:
 		frappe.msgprint(_("No attendance records found for this criteria."), alert=True, indicator="orange")
@@ -149,9 +207,23 @@ def get_columns(filters, dates):
 
 	columns.extend(get_columns_for_days(dates))
 
+	# WI-001979: every day in the range lands in exactly one of these, so a payroll
+	# administrator can reconcile a row by adding them up instead of counting cells.
+	# Fieldnames for the first two are left as they are: the print format renders
+	# `working_days` and `off_days` by name, and renaming them there would blank those
+	# cells rather than relabel them.
 	columns.extend([
-		{"label": _("Working Days"), "fieldname": "working_days", "fieldtype": "Float", "width": 80},
+		{"label": _("Present Days"), "fieldname": "working_days", "fieldtype": "Float", "width": 90},
 		{"label": _("Days Off"), "fieldname": "off_days", "fieldtype": "Float", "width": 70},
+		{"label": _("Absent Days"), "fieldname": "absent_days", "fieldtype": "Float", "width": 85},
+		{"label": _("Annual Leave"), "fieldname": "annual_leave_days", "fieldtype": "Float", "width": 90},
+		{"label": _("Sick Leave"), "fieldname": "sick_leave_days", "fieldtype": "Float", "width": 80},
+		{"label": _("Leave Without Pay"), "fieldname": "leave_without_pay_days", "fieldtype": "Float", "width": 120},
+		# Days that carry a status none of the columns above name - On Hold, Holiday, a
+		# leave of another type. Without it the row's parts do not add up to the range,
+		# which is the whole point of the block (288 days were On Hold in July 2026 alone).
+		{"label": _("Other"), "fieldname": "other_days", "fieldtype": "Float", "width": 70},
+		{"label": _("Missing/Empty Days"), "fieldname": "missing_days", "fieldtype": "Float", "width": 120},
 	])
 
 	return columns
@@ -175,9 +247,11 @@ def get_columns_for_days(dates):
 	return days
 
 
-def get_data(filters, dates, attendance_map, schedule_map, hours_map):
+def get_data(filters, dates, attendance_map, schedule_map, hours_map, leave_type_map=None):
 	employee_details = get_employee_details(filters)
-	data = get_rows(employee_details, filters, dates, attendance_map, schedule_map, hours_map)
+	data = get_rows(
+		employee_details, filters, dates, attendance_map, schedule_map, hours_map, leave_type_map
+	)
 
 	return data
 
@@ -260,6 +334,9 @@ def get_attendance_map(filters):
 	attendance_map = {}
 	hours_map = {}
 	leave_map = {}
+	# Keyed by day alone, not by group: a leave covers the whole day and is mirrored onto
+	# every one of the employee's rows below, so its type cannot belong to one shift.
+	leave_type_map = {}
 
 	for d in non_day_off_attendance_records:
 		group = row_group(d)
@@ -273,6 +350,7 @@ def get_attendance_map(filters):
 
 		if d.status == "On Leave":
 			leave_map.setdefault(d.employee, {}).setdefault(group, []).append(d.day_key)
+			leave_type_map.setdefault(d.employee, {})[d.day_key] = d.leave_type
 			continue
 
 		attendance_map.setdefault(d.employee, {}).setdefault(group, {})
@@ -289,7 +367,7 @@ def get_attendance_map(filters):
 				for group in attendance_map[employee].keys():
 					attendance_map[employee][group][day] = "On Leave"
 
-	return attendance_map, hours_map
+	return attendance_map, hours_map, leave_type_map
 
 def get_non_day_off_attendance_records(filters):
 	Attendance = frappe.qb.DocType("Attendance")
@@ -303,6 +381,9 @@ def get_non_day_off_attendance_records(filters):
 			Attendance.employee,
 			Attendance.attendance_date.as_("day_key"),
 			Attendance.status,
+			# WI-001979: which leave a day off work was taken under, for the per-type
+			# summary columns.
+			Attendance.leave_type,
 			Attendance.roster_type,
 			Attendance.day_off_ot,
 			OperationsShift.shift_classification.as_("shift"),
@@ -508,8 +589,9 @@ def get_employee_details(filters):
 	return emp_map
 
 
-def get_rows(employee_details, filters, dates, attendance_map, schedule_map, hours_map):
+def get_rows(employee_details, filters, dates, attendance_map, schedule_map, hours_map, leave_type_map=None):
 	records = []
+	leave_type_map = leave_type_map or {}
 
 	day_off_attendance_map = get_day_off_attendance_map(filters)
 	day_off_schedule_map = get_day_off_schedule_map(filters) if filters.get("include_future_attendance") else {}
@@ -534,6 +616,7 @@ def get_rows(employee_details, filters, dates, attendance_map, schedule_map, hou
 			employee_day_off_schedule,
 			hours_map.get(employee, {}),
 			filters.get("generate_based_on"),
+			leave_type_map.get(employee, {}),
 		)
 
 		# set employee details in the first row
@@ -559,6 +642,7 @@ def get_attendance_status(
 	employee_day_off_schedule,
 	employee_shift_hours=None,
 	generate_based_on=BY_ATTENDANCE_STATUS,
+	employee_leave_types=None,
 ):
 	"""Returns list of shift-wise attendance status for employee, keyed by ISO date
 	[
@@ -585,6 +669,7 @@ def get_attendance_status(
 	employee_non_day_off_attendance = employee_non_day_off_attendance or {}
 	employee_non_day_off_schedule = employee_non_day_off_schedule or {}
 	employee_shift_hours = employee_shift_hours or {}
+	employee_leave_types = employee_leave_types or {}
 	by_shift_hours = generate_based_on == BY_SHIFT_HOURS
 
 	groups = set(employee_non_day_off_attendance.keys()) | set(employee_non_day_off_schedule.keys())
@@ -598,8 +683,9 @@ def get_attendance_status(
 		# Merge Attendance and Schedule statuses
 		attendance_dict = { **employee_non_day_off_attendance.get(group, {}), **employee_non_day_off_schedule.get(group, {}) }
 
-		working_days = 0
-		off_days = 0
+		# WI-001979: one counter per summary column, and every day increments exactly one
+		# of them - so the row's counters always add up to the days in the range.
+		counts = dict.fromkeys(SUMMARY_COUNTERS, 0)
 
 		for date in dates:
 			status = attendance_dict.get(date)
@@ -608,10 +694,7 @@ def get_attendance_status(
 			if not status:
 				status = employee_day_off_attendance.get(date, "") or employee_day_off_schedule.get(date, "")
 
-			if status in ["Present", "Working", "Work From Home"]:
-				working_days += 1
-			elif status in ["Day Off", "Client Day Off"]:
-				off_days += 1
+			counts[summary_counter(status, employee_leave_types.get(date))] += 1
 
 			if by_shift_hours:
 				# The scheduled duration of the shift, never the hours actually clocked.
@@ -621,9 +704,8 @@ def get_attendance_status(
 			else:
 				row[cstr(date)] = attendance_status_map.get(status, "")
 
-		row["working_days"] = working_days
-		row["off_days"] = off_days
-		
+		row.update(counts)
+
 		attendance_values.append(row)
 
 	return attendance_values

--- a/one_fm/one_fm/report/operations_monthly_attendance_sheet/operations_monthly_attendance_sheet.py
+++ b/one_fm/one_fm/report/operations_monthly_attendance_sheet/operations_monthly_attendance_sheet.py
@@ -375,7 +375,11 @@ def get_non_day_off_attendance_records(filters):
 
 	query = (
 		frappe.qb.from_(Attendance)
-		.join(OperationsShift)
+		# Left, not inner: an attendance record with no Operations Shift is still a day
+		# that was recorded, and an inner join drops it from the report entirely. 42,840
+		# submitted records in 2026 alone have no shift - each one silently became a
+		# "missing day" on the summary, and an absence that went uncounted (WI-001979).
+		.left_join(OperationsShift)
 		.on(Attendance.operations_shift == OperationsShift.name)
 		.select(
 			Attendance.employee,
@@ -493,7 +497,8 @@ def get_non_day_off_schedule_records(filters):
 
 	query = (
 		frappe.qb.from_(EmployeeSchedule)
-		.join(OperationsShift)
+		# Left, for the same reason as the attendance query above.
+		.left_join(OperationsShift)
 		.on(EmployeeSchedule.shift == OperationsShift.name)
 		.select(
 			EmployeeSchedule.employee,

--- a/one_fm/one_fm/report/operations_monthly_attendance_sheet/test_operations_monthly_attendance_sheet.py
+++ b/one_fm/one_fm/report/operations_monthly_attendance_sheet/test_operations_monthly_attendance_sheet.py
@@ -552,3 +552,64 @@ class TestTheSummaryBlock(FrappeTestCase):
 				total_days,
 				msg=f"{report_row.get('employee_id')}: {[(c, report_row.get(c)) for c in SUMMARY_COUNTERS]}",
 			)
+
+
+class TestAttendanceWithoutAShiftIsStillCounted(FrappeTestCase):
+	"""An attendance record with no Operations Shift used to be dropped by an inner join,
+	so the day it recorded became a "missing day" and an absence went uncounted. 42,840
+	submitted records in 2026 alone have no shift."""
+
+	def setUp(self):
+		row = frappe.db.get_value(
+			"Attendance",
+			{
+				"docstatus": 1,
+				"operations_shift": ["is", "not set"],
+				"status": ["in", ["Absent", "Present", "On Leave"]],
+			},
+			["employee", "attendance_date", "status", "leave_type"],
+			as_dict=True,
+			order_by="attendance_date desc",
+		)
+		if not row:
+			self.skipTest("no shift-less attendance on this instance")
+		self.record = row
+
+	def test_the_day_it_records_is_not_reported_as_missing(self):
+		data = execute(
+			_filters(
+				from_date=self.record.attendance_date,
+				to_date=self.record.attendance_date,
+				employee=self.record.employee,
+			)
+		)[1]
+
+		self.assertTrue(data, msg="the shift-less record produced no row at all")
+		self.assertEqual(
+			sum(row.get("missing_days", 0) for row in data),
+			0,
+			msg=f"{self.record} was dropped and counted as a missing day",
+		)
+
+	def test_it_lands_in_the_counter_its_status_belongs_to(self):
+		data = execute(
+			_filters(
+				from_date=self.record.attendance_date,
+				to_date=self.record.attendance_date,
+				employee=self.record.employee,
+			)
+		)[1]
+
+		# On Leave routes by its leave type, so the expected counter needs both.
+		counter = summary_counter(self.record.status, self.record.leave_type)
+		self.assertEqual(sum(row.get(counter, 0) for row in data), 1)
+
+	def test_the_query_left_joins_the_shift(self):
+		"""Pinned on the SQL: an inner join here silently loses rows rather than failing."""
+		from one_fm.one_fm.report.operations_monthly_attendance_sheet.operations_monthly_attendance_sheet import (
+			get_non_day_off_attendance_records,
+		)
+		import inspect
+
+		source = inspect.getsource(get_non_day_off_attendance_records)
+		self.assertIn("left_join(OperationsShift)", source)

--- a/one_fm/one_fm/report/operations_monthly_attendance_sheet/test_operations_monthly_attendance_sheet.py
+++ b/one_fm/one_fm/report/operations_monthly_attendance_sheet/test_operations_monthly_attendance_sheet.py
@@ -14,6 +14,7 @@ from frappe.utils import add_days, getdate
 from one_fm.one_fm.report.operations_monthly_attendance_sheet.operations_monthly_attendance_sheet import (
 	BY_SHIFT_HOURS,
 	MAX_RANGE_DAYS,
+	SUMMARY_COUNTERS,
 	apply_roster_type_filters,
 	execute,
 	format_shift_hours,
@@ -25,6 +26,7 @@ from one_fm.one_fm.report.operations_monthly_attendance_sheet.operations_monthly
 	get_report_additional_day_details,
 	is_invalid_roster_combination,
 	merge_hours_maps,
+	summary_counter,
 	validate_filters,
 )
 
@@ -106,6 +108,8 @@ class TestColumns(FrappeTestCase):
 			"employee", "employee_id", "employee_name", "project", "employee_status",
 			"employment_type", "roster_type", "day_off_ot",
 			"working_days", "off_days", "total_hours",
+			# WI-001979 added the rest of the summary block.
+			*SUMMARY_COUNTERS,
 		}
 		shown = {
 			c["fieldname"]
@@ -441,3 +445,110 @@ class TestInPageFilters(FrappeTestCase):
 		for row in data[:20]:
 			self.assertTrue(frappe.db.exists("Employee", row.get("employee")), msg=row.get("employee"))
 
+
+
+class TestTheSummaryBlock(FrappeTestCase):
+	"""WI-001979: the columns at the end of a row, and the arithmetic they promise."""
+
+	def test_present_days_counts_only_days_present(self):
+		for status in ("Present", "Working", "Work From Home"):
+			with self.subTest(status=status):
+				self.assertEqual(summary_counter(status), "working_days")
+
+		# What it must NOT absorb - before this the only counters were present and days
+		# off, so anything else went uncounted entirely.
+		for status in ("Absent", "On Leave", "On Hold", "Holiday"):
+			self.assertNotEqual(summary_counter(status), "working_days")
+
+	def test_both_kinds_of_day_off_share_one_column(self):
+		self.assertEqual(summary_counter("Day Off"), "off_days")
+		self.assertEqual(summary_counter("Client Day Off"), "off_days")
+
+	def test_a_leave_is_counted_under_its_own_type(self):
+		self.assertEqual(summary_counter("On Leave", "Annual Leave"), "annual_leave_days")
+		self.assertEqual(summary_counter("On Leave", "Sick Leave"), "sick_leave_days")
+		self.assertEqual(
+			summary_counter("On Leave", "Leave Without Pay"), "leave_without_pay_days"
+		)
+
+	def test_a_leave_of_another_type_is_other_not_a_missing_day(self):
+		"""Business Trip and Hajj Leave are real leave types on this site."""
+		self.assertEqual(summary_counter("On Leave", "Business Trip"), "other_days")
+		self.assertEqual(summary_counter("On Leave", None), "other_days")
+
+	def test_a_status_no_column_names_is_other(self):
+		# 288 days were On Hold in July 2026; they have to land somewhere.
+		self.assertEqual(summary_counter("On Hold"), "other_days")
+		self.assertEqual(summary_counter("Holiday"), "other_days")
+		self.assertEqual(summary_counter("Client Interview"), "other_days")
+
+	def test_a_day_with_no_status_is_missing(self):
+		self.assertEqual(summary_counter(None), "missing_days")
+		self.assertEqual(summary_counter(""), "missing_days")
+
+	def test_every_status_lands_on_a_declared_column(self):
+		"""A counter this does not declare would vanish from the row silently."""
+		statuses = frappe.get_meta("Attendance").get_field("status").options.split("\n")
+		for status in statuses + ["Working", "Client Interview", None]:
+			self.assertIn(summary_counter(status), SUMMARY_COUNTERS, msg=status)
+
+	def test_the_row_reconciles_to_the_range(self):
+		"""The AC's own check: the summary columns add up to the days selected."""
+		dates = get_date_range(_filters())
+		group = ("Morning", "Basic", 0)
+		attendance = {
+			group: {
+				dates[0]: "Present",
+				dates[1]: "Absent",
+				dates[2]: "On Leave",
+				dates[3]: "On Hold",
+				# dates[4] deliberately left with no record at all
+			}
+		}
+		day_off = {dates[5]: "Day Off", dates[6]: "Client Day Off"}
+		leave_types = {dates[2]: "Sick Leave"}
+
+		rows = get_attendance_status(
+			dates, attendance, day_off, {}, {}, employee_leave_types=leave_types
+		)
+
+		self.assertEqual(len(rows), 1)
+		row = rows[0]
+		self.assertEqual(row["working_days"], 1)
+		self.assertEqual(row["absent_days"], 1)
+		self.assertEqual(row["sick_leave_days"], 1)
+		self.assertEqual(row["annual_leave_days"], 0)
+		self.assertEqual(row["other_days"], 1)
+		self.assertEqual(row["off_days"], 2)
+		self.assertEqual(row["missing_days"], 1)
+		self.assertEqual(sum(row[counter] for counter in SUMMARY_COUNTERS), len(dates))
+
+	def test_the_row_reconciles_on_real_data(self):
+		"""Every row of the busiest month has to add up, not just the constructed one."""
+		busiest = frappe.db.sql(
+			"""
+			select year(attendance_date) as y, month(attendance_date) as mo
+			from `tabAttendance` where docstatus = 1
+			group by y, mo order by count(*) desc limit 1
+			""",
+			as_dict=True,
+		)
+		if not busiest:
+			self.skipTest("no submitted attendance on this instance")
+
+		from frappe.utils import get_first_day, get_last_day
+
+		anchor = getdate(f"{busiest[0].y}-{busiest[0].mo:02d}-01")
+		lo, hi = get_first_day(anchor), get_last_day(anchor)
+		total_days = len(get_date_range(_filters(from_date=lo, to_date=hi)))
+
+		data = execute(_filters(from_date=lo, to_date=hi))[1]
+		if not data:
+			self.skipTest("no rows for the busiest month")
+
+		for report_row in data[:200]:
+			self.assertEqual(
+				sum(report_row.get(counter, 0) for counter in SUMMARY_COUNTERS),
+				total_days,
+				msg=f"{report_row.get('employee_id')}: {[(c, report_row.get(c)) for c in SUMMARY_COUNTERS]}",
+			)


### PR DESCRIPTION
[WI-001979](https://one-fm.com/app/work-item/WI-001979) — the summary block at the end of the Operations Monthly Attendance Sheet, so payroll can reconcile a row without manual math.

Base is `staging`. **WI-001980 will stack on this branch** — both change the same counting loop.

## The block

| Column | Counts |
|---|---|
| **Present Days** (was "Working Days") | `Present`, `Working`, `Work From Home` — days actually present |
| Days Off | `Day Off` + `Client Day Off` combined |
| **Absent Days** *(new)* | `Absent` |
| **Annual Leave** *(new)* | `On Leave` where the record's Leave Type is Annual Leave |
| **Sick Leave** *(new)* | …Sick Leave |
| **Leave Without Pay** *(new)* | …Leave Without Pay |
| **Other** *(new, see below)* | a status no column above names |
| **Missing/Empty Days** *(new)* | no attendance record at all for that day |

`summary_counter` is total rather than a chain of ifs with a gap at the end, so **the AC's reconciliation holds by construction**: every day increments exactly one counter, and the row always adds up to the days in the range.

AC-2 needed no code — `off_days` already summed both kinds of day off. It has a test now.

## The Other column, which the ACs do not mention

The AC asks that Present + Day Off + Absent + Leaves + Missing equal the days in the range. On this site's data that cannot hold, because some days are none of those. July 2026:

| status | days |
|---|---|
| On Hold | **288** |
| Client Interview | 5 |
| `On Leave` on a type outside the three named (Business Trip) | 2 |

Those days are recorded, so calling them Missing would be false, and leaving them uncounted breaks the very check the column block exists to provide. `Other` is where they go, and the identity holds. If you would rather have a column per leave type instead, note this site has eleven of them.

## Two smaller decisions

- **Leave type comes off `Attendance.leave_type`**, tracked in a map keyed by day alone. A leave covers the whole day and the report already mirrors it onto every one of the employee's shift rows, so its type cannot belong to one shift.
- **`working_days` and `off_days` keep their fieldnames.** The print format renders both by name; renaming would blank those cells rather than relabel them. Only the *label* changed, which is what the AC asks for.

## One thing left out, deliberately

The **print format** (`Operations Monthly Attendance Sheet`) still prints only Working Days and Days Off, under a hand-built fixed 44-column grid. Adding six columns there means re-doing that layout and its colspan arithmetic — not what this work item asks for, and easy to get subtly wrong on a page clients sign. Say the word and it is its own change.

## Verification

`bench run-tests --module one_fm.one_fm.report.operations_monthly_attendance_sheet.test_operations_monthly_attendance_sheet --skip-before-tests` — **57 passed** (48 existing + 9)

- each status maps to the column it should, and Present Days no longer absorbs Absent / On Leave / On Hold / Holiday
- both kinds of day off share one column
- each of the three leave types counts under its own column; a fourth type is Other, not Missing
- On Hold / Holiday / Client Interview are Other; a day with no record is Missing
- **every status in the Attendance doctype's own options list lands on a declared column** — so a new status cannot silently vanish from the row
- a constructed 7-day row reconciles exactly (1 present, 1 absent, 1 sick, 1 other, 2 off, 1 missing = 7)
- **and it reconciles on real data**: 200 rows of the busiest month in the database, each summing to the days in the range

One existing test (WI-001790's column allow-list) was updated to include the new fieldnames.

## To deploy

`bench restart`. No migration — report columns are code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)