### PR TITLE
WI-001873: rework the Resumption Confirmation Details block

### DIFF
--- a/one_fm/custom/custom_field/leave_application.py
+++ b/one_fm/custom/custom_field/leave_application.py
@@ -205,9 +205,11 @@ def get_leave_application_custom_fields():
                 "fieldtype": "Section Break",
                 "insert_after": "source",
                 "label": "Resumption Confirmation Details",
-                # Shown once the leave is Approved and it is an Annual Leave or
-                # Leave Without Pay (the leave types HelpDesk follows up on for resumption).
-                "depends_on": "eval:doc.workflow_state=='Approved' && (doc.leave_type=='Annual Leave' || doc.leave_type=='Leave Without Pay')",
+                # Shown once the leave is Approved, it is an Annual Leave or Leave Without
+                # Pay (the leave types HelpDesk follows up on for resumption), and the
+                # employee is shift working (WI-001873) - resumption is only chased for
+                # the people a duty roster depends on.
+                "depends_on": "eval:doc.workflow_state=='Approved' && doc.custom_shift_working && (doc.leave_type=='Annual Leave' || doc.leave_type=='Leave Without Pay')",
                 "allow_on_submit": 1
             },
             {
@@ -253,7 +255,9 @@ def get_leave_application_custom_fields():
             {
                 "fieldname": "outcome",
                 "fieldtype": "Select",
-                "insert_after": "resumption_confirmation_details",
+                # After the contact questions rather than at the top of the section: it is
+                # the conclusion drawn from them (WI-001873).
+                "insert_after": "custom_will_the_employee_return",
                 "label": "Outcome",
                 "options": "\nConfirmed\nTry again\nResignation\nExtension Request",
                 "allow_on_submit": 1
@@ -261,7 +265,7 @@ def get_leave_application_custom_fields():
             {
                 "fieldname": "return_ticket_submitted",
                 "fieldtype": "Select",
-                "insert_after": "outcome",
+                "insert_after": "custom_does_the_employee_need_additional_time_to_resume",
                 "label": "Return Ticket Submitted",
                 "options": "\nYes\nNo",
                 # Mandatory once HelpDesk confirms the employee will return, so
@@ -276,14 +280,21 @@ def get_leave_application_custom_fields():
                 "insert_after": "return_ticket_submitted",
                 "label": "Actual Return Date",
                 # Mandatory once HelpDesk confirms the employee will return, so
-                # Operations can schedule the duty roster against a real date.
-                "mandatory_depends_on": "eval:doc.custom_will_the_employee_return == 'Yes'",
+                # Operations can schedule the duty roster against a real date - unless the
+                # employee has asked for more time, when there is no date to give yet
+                # (WI-001873).
+                "mandatory_depends_on": (
+                    "eval:doc.custom_will_the_employee_return == 'Yes'"
+                    " && doc.custom_does_the_employee_need_additional_time_to_resume != 'Yes'"
+                ),
                 "allow_on_submit": 1
             },
             {
                 "fieldname": "custom_does_the_employee_need_additional_time_to_resume",
                 "fieldtype": "Select",
-                "insert_after": "actual_return_date",
+                # Ahead of the return ticket and the return date, because the answer
+                # decides whether a return date is expected at all (WI-001873).
+                "insert_after": "outcome",
                 "label": "Does the Employee Need Additional Time to Resume?",
                 "options": "\nYes\nNo",
                 "allow_on_submit": 1,

--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -1165,6 +1165,12 @@ def update_employee_status_after_leave():
     
     frappe.db.commit()
 
+# The leave types HelpDesk chases a resumption for (WI-001873). Leave Without Pay sits
+# beside Annual Leave because both are long enough that the employee has to be contacted
+# before the roster can count on them coming back.
+RESUMPTION_LEAVE_TYPES = ("Annual Leave", "Leave Without Pay")
+
+
 def remind_annual_leave_employees_to_helpdesk_user():
     """
         Send a reminder email to helpdesk user with the list of employees whose leave ends soon.
@@ -1173,20 +1179,20 @@ def remind_annual_leave_employees_to_helpdesk_user():
     if not helpdesk_email:
         return
 
-    employees_on_annual_leave = get_employees_whose_leave_ends_in(leave_ends_in=6)
+    employees_on_leave = get_employees_whose_leave_ends_in(leave_ends_in=6)
 
-    if not employees_on_annual_leave:
+    if not employees_on_leave:
         return
 
-    message = frappe.render_template("one_fm/templates/emails/reminder_employees_on_annual_leave.html", {"employees": employees_on_annual_leave})
+    message = frappe.render_template("one_fm/templates/emails/reminder_employees_on_annual_leave.html", {"employees": employees_on_leave})
     sendemail(
         recipients=[helpdesk_email],
-        subject="Reminder: Employees' Annual Leave Ending in 7 Days",
+        subject="Reminder: Employees' Leave Ending in 7 Days",
         message=message,
         is_external_mail=True
     )
 
-def get_employees_whose_leave_ends_in(leave_ends_in=0, leave_type="Annual Leave", shift_working=1):
+def get_employees_whose_leave_ends_in(leave_ends_in=0, leave_types=RESUMPTION_LEAVE_TYPES, shift_working=1):
     to_date = add_days(getdate(today()), leave_ends_in)
 
     LeaveApplication = DocType("Leave Application")
@@ -1207,8 +1213,11 @@ def get_employees_whose_leave_ends_in(leave_ends_in=0, leave_type="Annual Leave"
         )
         .where(
             (LeaveApplication.docstatus == 1) &
-            (LeaveApplication.status == "Approved") &
-            (LeaveApplication.leave_type == leave_type) &
+            # The AC names the workflow state, not the HRMS status field. The two agree on
+            # every submitted record on this site, and the workflow is what the rest of the
+            # resumption block keys off (WI-001873).
+            (LeaveApplication.workflow_state == "Approved") &
+            (LeaveApplication.leave_type.isin(list(leave_types))) &
             (LeaveApplication.to_date == to_date) &
             (Employee.shift_working == shift_working)
         )

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -458,7 +458,7 @@ one_fm.patches.v15_0.update_bonus_request_assignment_rules #3
 one_fm.patches.v15_0.add_attendance_correction_fields
 one_fm.patches.v15_0.add_leave_application_emergency_contact_field #1
 one_fm.patches.v15_0.add_attendance_check_action_user_to_hr_settings
-one_fm.patches.v15_0.add_leave_application_resumption_contact_fields #1
+one_fm.patches.v15_0.add_leave_application_resumption_contact_fields #2 2026-08-06 WI-001873
 
 one_fm.patches.v15_0.add_absence_investigation_hr_officer_to_hr_settings
 one_fm.patches.v15_0.update_leave_application_workflow_dss #2026-07-17-2

--- a/one_fm/templates/emails/reminder_employees_on_annual_leave.html
+++ b/one_fm/templates/emails/reminder_employees_on_annual_leave.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>Employees on Annual Leave Ending Soon</title>
+    <title>Employees on Leave Ending Soon</title>
     <style>
         table {
             border-collapse: collapse;
@@ -20,7 +20,7 @@
 </head>
 <body>
     <p>Dear Helpdesk User,</p>
-    <p>This is a reminder that the following employees' annual leave will end in 7 days:</p>
+    <p>This is a reminder that the following employees' leave will end in 7 days:</p>
     <table>
         <thead>
             <tr>

--- a/one_fm/tests/test_leave_resumption_details.py
+++ b/one_fm/tests/test_leave_resumption_details.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-001873: the Resumption Confirmation Details block, and who HelpDesk is reminded about."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, today
+
+from one_fm.overrides.leave_application import (
+	RESUMPTION_LEAVE_TYPES,
+	get_employees_whose_leave_ends_in,
+)
+
+# The order the BA site has, top to bottom.
+RESUMPTION_FIELD_ORDER = (
+	"resumption_confirmation_details",
+	"custom_could_the_employee_be_reached",
+	"custom_action",
+	"custom_reason_employee_not_reached",
+	"custom_will_the_employee_return",
+	"outcome",
+	"custom_does_the_employee_need_additional_time_to_resume",
+	"return_ticket_submitted",
+	"actual_return_date",
+	"column_break_resumption_details",
+	"attach_return_ticket",
+)
+
+
+class TestTheResumptionBlock(FrappeTestCase):
+	"""Asserted through get_meta, which is what the form renders from - so a Customize
+	Form override of any of these fails here too."""
+
+	def setUp(self):
+		self.meta = frappe.get_meta("Leave Application")
+
+	def test_the_fields_are_in_the_order_the_ba_site_has(self):
+		fieldnames = [f.fieldname for f in self.meta.fields]
+		positions = [fieldnames.index(name) for name in RESUMPTION_FIELD_ORDER]
+
+		self.assertEqual(positions, sorted(positions), msg=str(RESUMPTION_FIELD_ORDER))
+
+	def test_the_additional_time_question_comes_before_the_return_date_it_governs(self):
+		fieldnames = [f.fieldname for f in self.meta.fields]
+
+		self.assertLess(
+			fieldnames.index("custom_does_the_employee_need_additional_time_to_resume"),
+			fieldnames.index("actual_return_date"),
+		)
+
+	def test_the_section_is_only_for_shift_working_employees(self):
+		depends_on = self.meta.get_field("resumption_confirmation_details").depends_on
+
+		self.assertIn("doc.custom_shift_working", depends_on)
+		# And still only for an approved Annual Leave or Leave Without Pay.
+		self.assertIn("doc.workflow_state=='Approved'", depends_on)
+		for leave_type in RESUMPTION_LEAVE_TYPES:
+			self.assertIn(leave_type, depends_on)
+
+	def test_a_return_date_is_not_demanded_while_more_time_is_being_asked_for(self):
+		mandatory = self.meta.get_field("actual_return_date").mandatory_depends_on
+
+		self.assertIn("doc.custom_will_the_employee_return == 'Yes'", mandatory)
+		self.assertIn(
+			"doc.custom_does_the_employee_need_additional_time_to_resume != 'Yes'", mandatory
+		)
+
+	def test_the_condition_reads_as_python_and_as_javascript(self):
+		"""depends_on runs in the browser; the same string is also evaluated server-side
+		for a mandatory check, so it has to be valid in both."""
+		mandatory = self.meta.get_field("actual_return_date").mandatory_depends_on
+		expression = mandatory.replace("eval:", "").replace("&&", "and").replace("||", "or")
+
+		doc = frappe._dict(
+			custom_will_the_employee_return="Yes",
+			custom_does_the_employee_need_additional_time_to_resume="Yes",
+		)
+		self.assertFalse(frappe.safe_eval(expression, None, {"doc": doc}))
+
+		doc.custom_does_the_employee_need_additional_time_to_resume = "No"
+		self.assertTrue(frappe.safe_eval(expression, None, {"doc": doc}))
+
+
+class TestWhoHelpdeskIsRemindedAbout(FrappeTestCase):
+	"""WI-001873: Annual Leave *or* Leave Without Pay, Approved, and shift working."""
+
+	def _a_submitted_leave(self, leave_type):
+		"""An existing approved leave for a shift-working employee, off the site."""
+		rows = frappe.db.sql(
+			"""
+			select la.name from `tabLeave Application` la
+			join `tabEmployee` e on e.name = la.employee
+			where la.docstatus = 1 and la.workflow_state = 'Approved'
+			  and la.leave_type = %s and e.shift_working = 1
+			limit 1
+			""",
+			leave_type,
+		)
+		return rows[0][0] if rows else None
+
+	def test_both_leave_types_are_chased(self):
+		self.assertEqual(set(RESUMPTION_LEAVE_TYPES), {"Annual Leave", "Leave Without Pay"})
+
+	def test_a_leave_ending_in_the_window_is_reported_for_either_type(self):
+		ends_in = 6
+		# Named here rather than read off RESUMPTION_LEAVE_TYPES: iterating the constant
+		# under test would let a regression that drops a type pass unnoticed, because the
+		# loop would simply stop checking it.
+		for leave_type in ("Annual Leave", "Leave Without Pay"):
+			with self.subTest(leave_type=leave_type):
+				name = self._a_submitted_leave(leave_type)
+				if not name:
+					self.skipTest(f"no approved {leave_type} for a shift-working employee")
+
+				# Moved into the window inside the test transaction, then rolled back.
+				frappe.db.set_value(
+					"Leave Application", name, "to_date", add_days(today(), ends_in),
+					update_modified=False,
+				)
+				employee = frappe.db.get_value("Leave Application", name, "employee")
+
+				reported = get_employees_whose_leave_ends_in(leave_ends_in=ends_in)
+				self.assertIn(employee, [row.employee for row in reported])
+
+	def test_a_leave_outside_the_window_is_not_reported(self):
+		name = self._a_submitted_leave("Annual Leave")
+		if not name:
+			self.skipTest("no approved Annual Leave for a shift-working employee")
+
+		frappe.db.set_value(
+			"Leave Application", name, "to_date", add_days(today(), 6), update_modified=False
+		)
+		employee = frappe.db.get_value("Leave Application", name, "employee")
+
+		# The reminder is sent 7 days out, so a different offset must not pick it up.
+		reported = get_employees_whose_leave_ends_in(leave_ends_in=3)
+		self.assertNotIn(employee, [row.employee for row in reported])
+
+	def test_an_employee_who_is_not_shift_working_is_left_alone(self):
+		"""The whole block exists for people a duty roster depends on."""
+		name = self._a_submitted_leave("Annual Leave")
+		if not name:
+			self.skipTest("no approved Annual Leave for a shift-working employee")
+
+		employee = frappe.db.get_value("Leave Application", name, "employee")
+		frappe.db.set_value(
+			"Leave Application", name, "to_date", add_days(today(), 6), update_modified=False
+		)
+		frappe.db.set_value("Employee", employee, "shift_working", 0, update_modified=False)
+
+		reported = get_employees_whose_leave_ends_in(leave_ends_in=6)
+		self.assertNotIn(employee, [row.employee for row in reported])


### PR DESCRIPTION
[WI-001873](https://one-fm.com/app/work-item/WI-001873) — the block HelpDesk fills in when a shift worker's long leave is ending. Independent of the other Operations-017 branches; base is `staging`.

## The four ACs

**1. Actual Return Date is not mandatory when more time is being asked for.**
`mandatory_depends_on` becomes `custom_will_the_employee_return == 'Yes' && custom_does_the_employee_need_additional_time_to_resume != 'Yes'`. Demanding a return date in the same breath as recording that there isn't one yet is a form that cannot be saved.

**2. The section is gated on Shift Working.**
`depends_on` gains `doc.custom_shift_working`, beside the Approved state and the two leave types it already required — resumption is only chased for the people a duty roster depends on. The field was already on the form (fetched from `employee.shift_working`) for exactly this kind of condition.

**3. The HelpDesk reminder covers Leave Without Pay too.**
`get_employees_whose_leave_ends_in` took a single `leave_type` defaulting to Annual Leave; it now takes both, named in one constant. **31 submitted LWP records** for shift-working employees on this site were outside the reminder entirely. It also gates on `workflow_state == "Approved"` rather than the HRMS `status` field, which is what the AC names — I checked, and the two agree on every submitted record here (245 Annual + 31 LWP, all `status = workflow_state = Approved`), so nothing changes for Annual Leave.

**4. Field order, from the BA site's export.**

| before | after |
|---|---|
| Could the Employee be Reached? | Could the Employee be Reached? |
| Action | Action |
| Reason Employee Not Reached | Reason Employee Not Reached |
| Will the Employee Return? | Will the Employee Return? |
| *(Outcome, at the top of the section)* | **Outcome** |
| Return Ticket Submitted | **Does the Employee Need Additional Time to Resume?** |
| Actual Return Date | Return Ticket Submitted |
| Does the Employee Need Additional Time…| Actual Return Date |

The outcome moves down to sit after the contact questions it is the conclusion of; the additional-time question moves up ahead of the return ticket and return date it governs — which is what makes AC-1 read correctly on screen.

## Notes for review

- **The BA export does not carry AC-2's condition.** BA's `resumption_confirmation_details.depends_on` is still just Approved + the two leave types; what BA added was the fetched `shift_working` field. I implemented the AC (added the condition) since the field exists precisely so a condition can read it. If the intent was only to expose the field, dropping `&& doc.custom_shift_working` is a one-line revert.
- **Fieldname difference:** BA calls its fetched field `shift_working`; this site has had `custom_shift_working` (same `fetch_from`) since the emergency-contact work. I used the local one — it is the field that carries data here. Worth aligning the two sites at some point.
- The patch that creates these fields is **re-registered with a new tag** (`#2 2026-08-06 WI-001873`): `create_custom_fields` updates fields that already exist, but a patch only re-runs when its line in `patches.txt` changes.

## Verification

Patch run on the bench, then read back through `frappe.get_meta` — the applied order is exactly the table above, and both conditions are as intended.

`bench run-tests --module one_fm.tests.test_leave_resumption_details --skip-before-tests` — **9 passed**

- the eleven fields of the block are in the BA order, and the additional-time question precedes the return date
- the section requires shift working, Approved, and one of the two leave types
- the return date's mandatory condition names both clauses — **and evaluates correctly both ways** through `safe_eval`, since the same string is used client- and server-side
- against real records: an Annual Leave **and** a Leave Without Pay ending in the window are both reported; one outside the window is not; and an employee whose Shift Working is cleared drops out

**Mutation-checked.** Reverting the constant to Annual Leave only fails two tests. It first failed only one — the behavioural test was iterating the very constant it tested, so a dropped type just stopped being checked. Now it iterates the two names literally.

## To deploy

`bench migrate` (re-runs the custom field patch), then `bench restart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)