### PR TITLE
fix(hooks): restore Roster Day Off Checker cron dropped by a duplicate key

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -695,6 +695,7 @@ scheduler_events = {
 		"15 12 * * *": [ #"At 12:15 pm - preponed from 01:30 pm (WI-001704); run after attendance is marked"
 			'one_fm.operations.doctype.roster_day_off_checker.roster_day_off_checker.generate_checker',
 			'one_fm.operations.doctype.roster_double_shift_ot_checker.roster_double_shift_ot_checker.check_roster_double_shift_ot',
+			'one_fm.api.tasks.assign_pm_shift', # create shift assignment
 		],
 		"30 4 * * *": [
 			'one_fm.operations.doctype.roster_client_day_off_checker.roster_client_day_off_checker.check_roster_client_day_off'
@@ -750,9 +751,6 @@ scheduler_events = {
 		],
         "0 6 * * *": [ # update currency exchange rates daily at 6 am
 			"one_fm.tasks.one_fm.currency_exchange.update_currency_exchange_rates"
-		],
-		"15 12 * * *": [ # create shift assignment
-			'one_fm.api.tasks.assign_pm_shift'
 		],
 		"45 13 * * *": [ # validate shift assignmet
 			'one_fm.api.tasks.validate_pm_shift_assignment'


### PR DESCRIPTION
Restores two scheduled jobs that have not run since **2026-07-24**.

### Cause
`scheduler_events["cron"]` defined `"15 12 * * *"` **twice**. Python keeps the last value for a repeated dict key, so the entry added by WI-001704 (`7687d85dc`) was discarded at import:

| Line | Entry | Fate |
|---|---|---|
| 695 | `generate_checker` + `check_roster_double_shift_ot` (WI-001704) | **discarded** |
| 754 | `assign_pm_shift` (present since 2024) | kept |

`ast.literal_eval` on the file confirms the key resolved to `['one_fm.api.tasks.assign_pm_shift']` alone. WI-001704 moved the job from 13:30 to 12:15, landing it on a slot that had been occupied for two years. No error is raised — a duplicate key is invisible in review.

### Evidence from production (read-only)
```
roster_day_off_checker      NO Scheduled Job Type record exists
roster_double_shift_ot      NO Scheduled Job Type record exists
assign_pm_shift             cron=15 12 * * *  stopped=0  last_execution=2026-08-08 12:15:24
```
The jobs were not stopped or failing — they had **no job record at all**. `sync_jobs` only creates records for methods present in the parsed hooks, so the old 13:30 record was deleted and no replacement created. The scheduler itself is healthy; other cron jobs ran minutes ago.

### Fix
Merge both entries under one key. Verified after the change: 37 cron keys, **no duplicates**, and `"15 12 * * *"` resolves to all three methods. `hooks.py` compiles.

### ⚠️ This will regress unless `staging` is fixed too
The duplicate is still present on `staging`, `test-production` and `sprint_29th-4th`. A release from `staging` will reintroduce it and silence these jobs again. This PR targets `version-15` directly to restore the jobs now; the same change needs to reach `staging`, or be included in the next cleanup branch.

### Note on ordering
The three methods are enqueued independently, so list position gives no execution-ordering guarantee. If `generate_checker` must run strictly after attendance marking, that has to be enforced inside the job.
