### PR TITLE
fix(ccp): backfill orphaned reference_type left by VisaRequest.update_tracker_status()

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -528,6 +528,7 @@ one_fm.patches.v15_0.add_bonus_request_line_manager_assignment_rule #2026-07-23
 one_fm.patches.v15_0.add_leave_application_compensatory_leave_request_field #2026-07-25
 
 one_fm.patches.v15_0.add_roster_double_shift_ot_checker_assignment_rules #2026-07-24
+one_fm.patches.v15_0.backfill_visa_processing_reference_type #2026-08-09
 one_fm.patches.v15_0.configure_agency_process_completion_values #2026-07-24
 one_fm.patches.v15_0.set_arrival_deployment_workflow_state_permlevel #2026-07-24
 one_fm.patches.v15_0.add_transportation_manager_arrival_deployment_transitions #2026-07-24

--- a/one_fm/patches/v15_0/backfill_visa_processing_reference_type.py
+++ b/one_fm/patches/v15_0/backfill_visa_processing_reference_type.py
@@ -1,0 +1,29 @@
+import frappe
+
+
+def execute():
+	"""Backfill reference_type = "Visa Request" on Candidate Country Process
+	Details rows that already carry a reference_name but were left without it.
+
+	Visa Request.update_tracker_status() writes reference_name onto the
+	"Visa Processing" tracker row via a raw frappe.db.set_value call, which
+	bypasses Document validation and never set reference_type alongside it.
+	Since reference_name is a Dynamic Link keyed off reference_type, any row
+	with one and not the other fails get_invalid_links() ("Reference Type
+	must be set first") the next time anything calls a full doc.save() on the
+	parent Candidate Country Process -- exactly what broke
+	configure_agency_process_completion_values on 2026-08-09.
+	"""
+	if not frappe.db.exists("DocType", "Candidate Country Process Details"):
+		return
+
+	ccpd = frappe.qb.DocType("Candidate Country Process Details")
+	frappe.qb.update(ccpd).set(
+		ccpd.reference_type, "Visa Request"
+	).where(
+		ccpd.process_name == "Visa Processing"
+	).where(
+		(ccpd.reference_name.isnotnull()) & (ccpd.reference_name != "")
+	).where(
+		(ccpd.reference_type.isnull()) | (ccpd.reference_type == "")
+	).run()

--- a/one_fm/patches/v15_0/configure_agency_process_completion_values.py
+++ b/one_fm/patches/v15_0/configure_agency_process_completion_values.py
@@ -24,6 +24,7 @@ def execute():
 		"Arrival & Deployment": "Joined",
 	}
 
+	skipped = []
 	for doctype in ("Agency Country Process Template", "Agency Country Process", "Candidate Country Process"):
 		if not frappe.db.exists("DocType", doctype):
 			continue
@@ -40,5 +41,24 @@ def execute():
 				row.reference_complete_status_field = "status"
 				row.reference_complete_status_value = target_value
 				changed = True
-			if changed:
+			if not changed:
+				continue
+			try:
 				doc.save()
+			except Exception:
+				# doc.save() validates every row in agency_process_details, not just
+				# the ones this patch touched -- a single record with unrelated,
+				# pre-existing bad data (e.g. a Dynamic Link field set without its
+				# reference-type field) would otherwise abort the whole patch.
+				frappe.db.rollback()
+				skipped.append(f"{doctype} {parent}")
+				frappe.log_error(
+					title="configure_agency_process_completion_values: skipped a record",
+					message=frappe.get_traceback(),
+				)
+
+	if skipped:
+		frappe.log_error(
+			title="configure_agency_process_completion_values: records skipped",
+			message="\n".join(skipped),
+		)

--- a/one_fm/visa_management/doctype/visa_request/visa_request.py
+++ b/one_fm/visa_management/doctype/visa_request/visa_request.py
@@ -28,7 +28,7 @@ class VisaRequest(Document):
 		rows = frappe.get_all(
 			"Candidate Country Process Details",
 			filters={"parent": ccp_name, "process_name": "Visa Processing"},
-			fields=["name", "reference_name"],
+			fields=["name", "reference_name", "reference_type"],
 			limit=1,
 		)
 		if rows:
@@ -42,6 +42,12 @@ class VisaRequest(Document):
 			}
 			if not row.reference_name:
 				update_fields["reference_name"] = self.name
+			# reference_name is a Dynamic Link keyed off reference_type -- writing
+			# one without the other leaves the row unsaveable ("Reference Type must
+			# be set first") the next time anything calls a full doc.save() on the
+			# parent CCP, since this update bypasses Document validation.
+			if not row.reference_type:
+				update_fields["reference_type"] = "Visa Request"
 
 			is_completed = (self.workflow_state == "Completed")
 			# "Work Permit Cancelled" is what WI-001773 renamed the terminal cancelled


### PR DESCRIPTION
## Summary

`configure_agency_process_completion_values` failed in production today with `ValidationError: Reference Type must be set first` while calling `doc.save()` on a Candidate Country Process. Root cause: `Candidate Country Process Details.reference_name` became a Dynamic Link field (keyed off `reference_type`) in #6189, but `VisaRequest.update_tracker_status()` writes `reference_name` onto the "Visa Processing" tracker row via a raw `frappe.db.set_value()` call that never set `reference_type` alongside it. That raw write bypasses Document validation, so the inconsistency sat undetected until this patch's `doc.save()` ran full link validation across every row in the child table — not just the ones it touched.

This isn't environment-specific: any site whose DB carries a row with `reference_name` set and `reference_type` blank will hit the same error the moment something calls a full `doc.save()` on that Candidate Country Process.

- `one_fm/patches/v15_0/backfill_visa_processing_reference_type.py` (new) — backfills `reference_type = "Visa Request"` on existing "Visa Processing" rows that have `reference_name` set but `reference_type` blank. Registered in `patches.txt` **before** `configure_agency_process_completion_values` so the bad data is fixed before that patch retries.
- `visa_management/doctype/visa_request/visa_request.py` — `update_tracker_status()` now also sets `reference_type` whenever it's blank, so it can't recreate this gap.
- `patches/v15_0/configure_agency_process_completion_values.py` — now skips and `frappe.log_error`s an individual record instead of aborting the whole patch if `doc.save()` hits unrelated bad data, as insurance against any other pre-existing rows we haven't seen yet.

## 🛡️ Protected Area Report

- `one_fm/patches.txt` is touched: a new patch entry is inserted *before* the already-failing `configure_agency_process_completion_values #2026-07-24` entry. This reordering is intentional and necessary — the backfill must run first so the completion-values patch encounters clean data on retry. No other entries were reordered or removed.
- No other protected files/patterns (`hooks.py`, `setup.py`, `modules.txt`, Workflow/Assignment Rule fixtures, `ignore_permissions=True`, raw string-formatted SQL, `frappe.get_all()` in whitelisted methods, `db_set("workflow_state", ...)`) are touched.
- The backfill patch uses `frappe.qb` (Query Builder), not raw SQL, and does not call `frappe.db.commit()` itself — the patch runner already commits on success / rolls back on failure.
- `configure_agency_process_completion_values.py`'s new `except Exception` + `frappe.db.rollback()` is a deliberate skip-and-log for *pre-existing, unrelated* bad data so other records in the same migrate still get processed — it does not swallow or weaken any validation this patch itself performs.

## Test plan

- [ ] `python3 -m py_compile` passes on all three changed/added `.py` files (done locally)
- [ ] On a staging/copy site: run `bench migrate` and confirm `backfill_visa_processing_reference_type` and `configure_agency_process_completion_values` both complete without error
- [ ] Spot-check a previously-failing record (e.g. `Saad Swaleh - HR-OFF-2026-00511-1`) — confirm its "Visa Processing" row now has `reference_type = "Visa Request"` and the parent CCP saves cleanly
- [ ] Save a Visa Request against a CCP whose "Visa Processing" row has no `reference_name` yet — confirm both `reference_name` and `reference_type` get set together