### PR TITLE
Guard amp_html column read in send_amp_verification_email

### DIFF
--- a/one_fm/api/amp_verification.py
+++ b/one_fm/api/amp_verification.py
@@ -159,7 +159,10 @@ def send_amp_verification_email(
 
 	status = frappe.db.get_value("Email Queue", email_queue.name, "status") if email_queue else None
 	error = frappe.db.get_value("Email Queue", email_queue.name, "error") if email_queue else None
-	stored_amp_html = frappe.db.get_value("Email Queue", email_queue.name, "amp_html") if email_queue else None
+
+	stored_amp_html = None
+	if email_queue and frappe.get_meta("Email Queue").has_field("amp_html"):
+		stored_amp_html = frappe.db.get_value("Email Queue", email_queue.name, "amp_html")
 
 	result = {
 		"email_queue": email_queue.name if email_queue else None,


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
`send_amp_verification_email()` crashes with `OperationalError: Unknown column 'amp_html'` when run on production, because production's `Email Queue` doctype doesn't have the custom `amp_html` field that local dev sites have. The crash happens *after* the actual email has already been sent successfully — it's purely in the diagnostic step that reports back send status, but it produces a scary traceback and prevents the function from returning its result dict every time it's called.


## Analysis and design (optional)
N/A — small defensive fix, no design changes.


## Solution description
Guard the `amp_html` column read with a `frappe.get_meta("Email Queue").has_field("amp_html")` check before attempting to read it, so the function returns cleanly on sites (like production) where that custom field doesn't exist. Mirrors the same defensive pattern already used in `one_fm.events.email_queue._inject_amp_into_message`, which already handles this case correctly for the injection logic — this fix just brings the diagnostic read-back in `amp_verification.py` up to the same standard.


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots (optional)
N/A — backend-only fix, no UI affected.


## Areas affected and ensured
- `one_fm/api/amp_verification.py` (`send_amp_verification_email` function only)


## Is there any existing behavior change of other features due to this code change?
No. Purely additive defensive guard — the actual email-sending logic is completely unchanged.


## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

(Verified locally that `frappe.get_meta("Email Queue").has_field(...)` correctly returns `True`/`False` for existing vs. nonexistent fields; verified on production that the underlying send already works correctly regardless of this fix — confirmed via real Email Queue records with status "Sent" and correctly-structured AMP content.)


## Was child table created?
N/A
- [ ] is attachment required?


## Did you delete custom field?
- [ ] Yes
- [x] No


## Is patch required?
- [ ] Yes
- [x] No

(No patch needed — this only changes function behavior for future calls, no one-time data migration involved.)


## Which browser(s) did you use for testing?
N/A — backend-only fix, verified via `bench console` / production Email Queue records, not browser-tested.
