### PR TITLE
Work Permit: complete a Local Transfer that has no Transfer Paper

### DIFF
--- a/one_fm/grd/doctype/work_permit/work_permit.py
+++ b/one_fm/grd/doctype/work_permit/work_permit.py
@@ -269,6 +269,17 @@ class WorkPermit(Document):
         param: work_permit object
         This method to update work permit status if completed in transfer paper, close the transfer paper, and submit it.
         """
+        # A Local Transfer raised by hand has no Transfer Paper behind it - only the ones
+        # created from a Preparation record do. Asking for document None threw
+        # "Transfer Paper None not found" and stopped the permit being completed at all.
+        # update_work_permit_details_in_tp() already skips for the same reason.
+        # A Local Transfer raised by hand has no Transfer Paper behind it - only the ones
+        # created from a Preparation record do. Asking for document None threw
+        # "Transfer Paper None not found" and stopped the permit being completed at all.
+        # update_work_permit_details_in_tp() already skips for the same reason.
+        if not self.transfer_paper:
+            return
+
         tp = frappe.get_doc('Transfer Paper',self.transfer_paper)
         if tp:
             for wp in tp.work_permit_records:

--- a/one_fm/tests/test_work_permit_completion.py
+++ b/one_fm/tests/test_work_permit_completion.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""Completing a Local Transfer that was raised by hand, with no Transfer Paper behind it."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestCompletingATransferWithoutATransferPaper(FrappeTestCase):
+	def a_local_transfer(self):
+		name = frappe.db.get_value(
+			"Work Permit",
+			{"work_permit_type": "Local Transfer"},
+			"name",
+			order_by="creation desc",
+		)
+		if not name:
+			self.skipTest("no Local Transfer Work Permit on this instance")
+		return frappe.get_doc("Work Permit", name)
+
+	def test_it_does_not_look_for_transfer_paper_none(self):
+		"""Reported from testing: Pending By Operator -> Done threw "Transfer Paper None
+		not found". Only permits created from a Preparation record have one."""
+		doc = self.a_local_transfer()
+		doc.transfer_paper = None
+
+		doc.update_wp_child_table_in_transfer_paper()
+
+	def test_the_other_side_of_the_same_call_skips_too(self):
+		doc = self.a_local_transfer()
+		doc.transfer_paper = None
+
+		doc.update_work_permit_details_in_tp()


### PR DESCRIPTION
Found while testing the Work Permit stack on WP-2026-00381.

`Pending By Operator` → `Done` threw **Transfer Paper None not found** and the permit could not be completed at all.

`update_wp_child_table_in_transfer_paper` asks for `frappe.get_doc('Transfer Paper', self.transfer_paper)` unconditionally, but only permits created from a Preparation record carry a `transfer_paper` — one raised by hand from the Work Permit list has none. The sibling call in `update_work_permit_details_in_tp` already skips for exactly this reason; this is the other half of the same guard.

Pre-existing on `staging`, unrelated to the WI-001827/1828/1829/1974 stack, so it is on its own branch.

Two tests, mutation-checked (without the guard the first raises `DoesNotExistError: Transfer Paper None not found`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)