### PR TITLE
fix: bypass permissions when syncing user role profile on employee save

### DIFF
--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -180,7 +180,7 @@ class EmployeeOverride(EmployeeMaster):
             if role_profile:
                 user = frappe.get_doc("User", self.user_id)
                 user.role_profile_name = role_profile
-                user.save()
+                user.save(ignore_permissions=True)
             else:
                 frappe.msgprint("Role profile not set in Designation, please set default.")
 


### PR DESCRIPTION
assign_role_profile_based_on_designation() saved the linked User doc with a permission-checked user.save(), causing "No permission for User" for HR users (e.g. HR User role) who lack write access to the User doctype. This blocked Employee Promotion submits and any Employee edit that changed designation for an employee with a linked user_id.

- pass ignore_permissions=True to user.save(), matching the other User writes in this file (update_user_doc, update_employee_phone_number)
