### PR TITLE
WI-001975: count passport validity from today, not from the issue date

### DIFF
--- a/one_fm/visa_management/doctype/visa_request/test_visa_request.py
+++ b/one_fm/visa_management/doctype/visa_request/test_visa_request.py
@@ -156,13 +156,12 @@ class TestApplicantEligibility(FrappeTestCase):
 	"""
 
 	def _draft(self, **overrides):
-		issued = "2020-01-01"
 		visa_request = frappe.new_doc("Visa Request")
 		visa_request.update(
 			{
 				"workflow_state": "Draft",
-				"passport_issued_on": issued,
-				"passport_expires_on": add_years(issued, 10),
+				"passport_issued_on": add_years(nowdate(), -5),
+				"passport_expires_on": add_years(nowdate(), 5),
 				"date_of_birth": add_years(nowdate(), -30),
 				**overrides,
 			}
@@ -173,22 +172,29 @@ class TestApplicantEligibility(FrappeTestCase):
 		self._draft().validate_applicant_eligibility()
 
 	def test_a_passport_short_of_the_minimum_validity_is_refused(self):
-		issued = "2020-01-01"
+		"""Counted from today, not from the issue date."""
 		visa_request = self._draft(
-			passport_issued_on=issued,
-			passport_expires_on=add_days(add_months(issued, MINIMUM_PASSPORT_VALIDITY_MONTHS), -1),
+			passport_expires_on=add_days(add_months(nowdate(), MINIMUM_PASSPORT_VALIDITY_MONTHS), -1)
 		)
 
 		with self.assertRaises(frappe.ValidationError) as caught:
 			visa_request.validate_applicant_eligibility()
-		self.assertIn("passport validity must be at least 18 months", str(caught.exception))
+		self.assertIn("valid for at least 18 more months", str(caught.exception))
+
+	def test_a_long_lived_passport_near_its_expiry_is_refused(self):
+		"""Issued well over 18 months ago; only the remaining validity counts."""
+		visa_request = self._draft(
+			passport_issued_on=add_years(nowdate(), -9),
+			passport_expires_on=add_months(nowdate(), 1),
+		)
+
+		with self.assertRaises(frappe.ValidationError):
+			visa_request.validate_applicant_eligibility()
 
 	def test_a_passport_exactly_at_the_minimum_validity_passes(self):
 		""""At least" 18 months, so the boundary is allowed."""
-		issued = "2020-01-01"
 		self._draft(
-			passport_issued_on=issued,
-			passport_expires_on=add_months(issued, MINIMUM_PASSPORT_VALIDITY_MONTHS),
+			passport_expires_on=add_months(nowdate(), MINIMUM_PASSPORT_VALIDITY_MONTHS)
 		).validate_applicant_eligibility()
 
 	def test_an_applicant_below_the_minimum_age_is_refused(self):
@@ -207,11 +213,9 @@ class TestApplicantEligibility(FrappeTestCase):
 
 	def test_a_record_past_draft_is_left_alone(self):
 		"""A passport ages while the application is in progress; that must not strand it."""
-		issued = "2020-01-01"
 		self._draft(
 			workflow_state="Pending By PAM",
-			passport_issued_on=issued,
-			passport_expires_on=add_months(issued, 1),
+			passport_expires_on=add_months(nowdate(), 1),
 			date_of_birth=nowdate(),
 		).validate_applicant_eligibility()
 

--- a/one_fm/visa_management/doctype/visa_request/visa_request.py
+++ b/one_fm/visa_management/doctype/visa_request/visa_request.py
@@ -76,18 +76,19 @@ class VisaRequest(Document):
 		self.validate_applicant_age()
 
 	def validate_passport_validity(self):
-		if not (self.passport_issued_on and self.passport_expires_on):
+		if not self.passport_expires_on:
 			return
 
-		# Compared by adding the months to the issue date rather than counting days, so
-		# the answer does not drift with the length of the months in between.
+		# Measured from today, not from the issue date: what matters is how much validity
+		# the passport has left now. Compared by adding the months to today rather than
+		# counting days, so the answer does not drift with the length of the months.
 		if getdate(self.passport_expires_on) < getdate(
-			add_months(self.passport_issued_on, MINIMUM_PASSPORT_VALIDITY_MONTHS)
+			add_months(nowdate(), MINIMUM_PASSPORT_VALIDITY_MONTHS)
 		):
 			frappe.throw(
 				_(
-					"The applicant's passport validity must be at least {0} months from the "
-					"passport expiry date. The Visa Request cannot be saved."
+					"The applicant's passport must be valid for at least {0} more months "
+					"from today. The Visa Request cannot be saved."
 				).format(MINIMUM_PASSPORT_VALIDITY_MONTHS),
 				title=_("Passport Validity Too Short"),
 			)


### PR DESCRIPTION
## What

The 18-month passport validity rule on Visa Request was measured between `passport_issued_on` and `passport_expires_on`. That is the passport's total lifespan, not the validity the applicant still has:

- a 10-year passport one month from expiry **passed**
- a freshly issued 1-year passport **failed**

The window is now `today` → `passport_expires_on`. `passport_issued_on` is no longer read by the check, so the guard dropped it.

## Changes

- `visa_request.py` — `validate_passport_validity()` compares against `add_months(nowdate(), 18)`; message reworded to "must be valid for at least 18 more months from today".
- `test_visa_request.py` — eligibility fixtures rebased on today, plus `test_a_long_lived_passport_near_its_expiry_is_refused` for the case the old logic let through.

Unchanged: the rule still only applies in Draft, so a request already in the workflow is not stranded as its passport ages.

## Testing

```
bench run-tests --module one_fm.visa_management.doctype.visa_request.test_visa_request --skip-before-tests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)