### PR TITLE
fix: Standardize all api responses/errors for mobile app

### DIFF
--- a/one_fm/api/api.py
+++ b/one_fm/api/api.py
@@ -1,7 +1,7 @@
 import frappe, base64, requests, firebase_admin, json
 from frappe import _
 import pandas as pd
-from frappe.utils import cstr, cint
+from frappe.utils import cstr, cint, strip_html
 from frappe.model.rename_doc import rename_doc
 from firebase_admin import messaging, credentials
 from frappe.desk.page.user_profile.user_profile import get_energy_points_heatmap_data, get_user_rank
@@ -60,7 +60,12 @@ def get_user_details():
     try:
         user_id = frappe.session.user
         user= frappe.get_value("User",user_id,"*")
-        employee_ID = frappe.get_value("Employee", {"user_id": user_id}, ["name","designation","employee_name_in_arabic","one_fm_nationality"])
+        employee_ID = frappe.get_value("Employee", {"user_id": user_id}, ["name","designation","employee_name_in_arabic", "one_fm_nationality"])
+
+        if not employee_ID:
+            return v1_api.utils.response(_("Employee Not Found"), 404, None,
+                _("Your user account is not linked to an employee record. "
+                  "Please contact the IT Helpdesk."))
 
         Rank = get_user_rank(user_id)
         energy_Review_Point = get_user_energy_and_review_points(user_id)
@@ -80,7 +85,13 @@ def get_user_details():
         user_details["Review_Point"] = str(int(energy_Review_Point[user_id]["review_points"])) if len(energy_Review_Point)!=0 else "0"
         return user_details
     except Exception as e:
-        print(frappe.get_traceback())
+        frappe.log_error(
+            title=f"Mobile API: api.get_user_details | {frappe.session.user}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return v1_api.utils.response(_("Something Went Wrong"), 500, None,
+            strip_html(cstr(e)) or type(e).__name__)
 
 @frappe.whitelist()
 def upload_file(doc, fieldname, filename, file_url, content, is_private):
@@ -201,9 +212,15 @@ def push_notification_rest_api_for_checkin(employee_id, title, body, checkin, ar
         employee_data = frappe.db.get_value("Employee", {"employee_id": employee_id}, ["fcm_token", "device_os"],as_dict=1)
         if not employee_data:
             employee_data = frappe.db.get_value("Employee", employee_id, ["fcm_token", "device_os"],as_dict=1)
+
+        if not employee_data:
+            return v1_api.utils.response(_("Employee Not Found"), 404, None,
+                _("No employee record found for Employee ID {0}. "
+                  "Please contact the IT Helpdesk.").format(employee_id))
+
         deviceToken = employee_data.fcm_token
         device_os = employee_data.device_os
-        
+
         #Body in json form defining a message payload to send through API. 
         # The parameter defers based on OS. Hence Body is designed based on the OS of the device.
         if deviceToken:
@@ -216,8 +233,18 @@ def push_notification_rest_api_for_checkin(employee_id, title, body, checkin, ar
             )
             res = messaging.send(message)
             return v1_api.utils.response("success", 200, {'response': str(res)})
+
+        return v1_api.utils.response(_("Notifications Not Set Up"), 404, None,
+            _("This device is not registered for notifications. "
+              "Please reopen the app and allow notifications."))
     except Exception as e:
-        return v1_api.utils.response("error", 500, {}, str(e))
+        frappe.log_error(
+            title=f"Mobile API: api.push_notification_rest_api_for_checkin | {employee_id}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return v1_api.utils.response(_("Something Went Wrong"), 500, None,
+            strip_html(cstr(e)) or type(e).__name__)
 
 @frappe.whitelist()
 def push_notification_rest_api_for_leave_application(employee_id, title, body, leave_id):

--- a/one_fm/api/v1/authentication.py
+++ b/one_fm/api/v1/authentication.py
@@ -1,7 +1,7 @@
 import frappe
 import pyotp
-from frappe.utils import getdate
-from frappe.twofactor import get_otpsecret_for_, process_2fa_for_sms, confirm_otp_token, get_email_subject_for_2fa,get_email_body_for_2fa
+from frappe.utils import getdate, cstr, strip_html
+from frappe.twofactor import get_otpsecret_for_, process_2fa_for_sms, confirm_otp_token, get_email_subject_for_2fa,get_email_body_for_2fa, ExpiredLoginException
 from frappe.integrations.oauth2 import get_token
 from frappe.core.doctype.user.user import generate_keys
 from frappe.utils.background_jobs import enqueue
@@ -138,36 +138,44 @@ def forgot_password(employee_id: str = None, otp_source: str = None, is_new: int
 	"""
 
 	if not employee_id:
-		return response("Bad Request", 400, None, "Please enter your Employee ID.")
+		return response(_("Missing Employee ID"), 400, None,
+			_("Please enter your Employee ID."))
 
 	if not otp_source:
-		return response("Bad Request", 400, None, "Please select an OTP source (SMS, Email, or WhatsApp).")
+		return response(_("Missing Delivery Method"), 400, None,
+			_("Please select where you want the code sent: SMS, Email, or WhatsApp."))
 
 	if not isinstance(employee_id, str):
-		return response("Bad Request", 400, None, "Invalid Employee ID format. Please enter a valid value.")
+		return response(_("Invalid Employee ID"), 400, None,
+			_("Please enter a valid Employee ID."))
 
 	if not isinstance(otp_source, str):
-		return response("Bad Request", 400, None, "Invalid OTP source format. Please select a valid option.")
-	
+		return response(_("Invalid Delivery Method"), 400, None,
+			_("Please select a valid option: SMS, Email, or WhatsApp."))
+
 	formatted_otp_source = otp_source.lower()
 
 	if formatted_otp_source not in ["sms", "email", "whatsapp"]:
-		return response("Bad Request", 400, None, "Invalid OTP source. OTP source must be either 'sms', 'email' or 'whatsapp'.")
-	
+		return response(_("Invalid Delivery Method"), 400, None,
+			_("Please select a valid option: SMS, Email, or WhatsApp."))
+
 	try:
 		employee_user_id =  frappe.get_value("Employee", {'employee_id': employee_id}, 'user_id')
-		
+
 		if not employee_user_id:
-			return response("Bad Request", 404, None, "No account found for employee ID {employee_id}. Please check and try again.".format(employee_id=employee_id))
-		
+			return response(_("Account Not Found"), 404, None,
+				_("No account found for Employee ID {0}. Please check and try again.").format(employee_id))
+
 		# Check for phone number if otp source is 'sms' or 'whatsapp'
 		if formatted_otp_source in ("sms", "whatsapp"):
 			target_user = frappe.db.get_value('User', employee_user_id, ['phone', 'mobile_no'], as_dict=1)
 			phone = target_user.mobile_no or target_user.phone
 
 			if not phone:
-				return response("Bad Request", 400, None, "No phone number found for user {user}.".format(user=employee_user_id))
-		
+				return response(_("No Phone Number"), 400, None,
+					_("No phone number is registered on your account. Please choose Email "
+					  "instead, or contact the IT Helpdesk to add your number."))
+
 		otp_secret = get_otpsecret_for_(employee_user_id)
 		token = int(pyotp.TOTP(otp_secret).now())
 		tmp_id = frappe.generate_hash(length=8)
@@ -196,10 +204,15 @@ def forgot_password(employee_id: str = None, otp_source: str = None, is_new: int
 		}
 
 		return response("Success", 201, result)
-	
+
 	except Exception as error:
-		frappe.log_error(title="API Forgot password", message=frappe.get_traceback())
-		return response("Internal Server Error", 500, None, error)
+		frappe.log_error(
+			title=f"Mobile API: authentication.forgot_password | {employee_id}",
+			message=frappe.get_traceback(),
+		)
+		frappe.db.commit()
+		return response(_("Something Went Wrong"), 500, None,
+			strip_html(cstr(error)) or type(error).__name__)
 
 
 @frappe.whitelist(allow_guest=True)
@@ -216,24 +229,47 @@ def verify_otp(otp, temp_id):
 	status of the OTP entered 
 	"""
 	try:
-		login_manager = frappe.local.login_manager
-		check_otp = confirm_otp_token(login_manager, otp, temp_id)
+		if not otp:
+			return response(_("Missing Verification Code"), 400, None,
+				_("Please enter the verification code that was sent to you."))
+
+		if not temp_id:
+			return response(_("Session Expired"), 400, None,
+				_("Your verification session has expired. Please request a new code."))
+
 		#  get password reset
 		password_token = frappe.db.get_value(
 			"Password Reset Token",
-			{"temp_id":temp_id}, 
+			{"temp_id":temp_id},
 			['name', 'status', 'expiration_time'],
 			as_dict=1
 		)
+		if not password_token:
+			return response(_("Session Expired"), 400, None,
+				_("Your verification session has expired. Please request a new code."))
+
+		login_manager = frappe.local.login_manager
+		check_otp = confirm_otp_token(login_manager, otp, temp_id)
+
 		if check_otp:
 			frappe.db.set_value("Password Reset Token", {"temp_id":temp_id}, "status", "Active")
 			return response ("success", 200, {
 				"password_token":password_token.name,
 				"message":"OTP verified successfully!"})
 		frappe.db.set_value("Password Reset Token", {"temp_id":temp_id}, "status", "Revoked")
-		return response("Error", 400, {}, "Incorrect OTP. Please check and enter the correct code.")
+		return response(_("Incorrect Code"), 400, None,
+			_("Incorrect verification code. Please check and enter the correct code."))
+	except ExpiredLoginException:
+		return response(_("Code Expired"), 400, None,
+			_("Your verification code has expired. Please request a new code."))
 	except Exception as e:
-		response("Error", 500, {}, str(e) or "OTP verification failed!")
+		frappe.log_error(
+			title=f"Mobile API: authentication.verify_otp | {frappe.session.user}",
+			message=frappe.get_traceback(),
+		)
+		frappe.db.commit()
+		return response(_("Something Went Wrong"), 500, None,
+			strip_html(cstr(e)) or type(e).__name__)
 
 
 @frappe.whitelist(allow_guest=True)
@@ -245,17 +281,32 @@ def change_password(employee_id, new_password, password_token):
 	password_token: will be used to verify the password reset and user
 	"""
 	try:
+		if not new_password:
+			return response(_("Missing Password"), 400, None,
+				_("Please enter your new password."))
+
 		employee_user = frappe.get_value("Employee", {'employee_id':employee_id}, ["user_id"])
+		if not employee_user:
+			return response(_("Account Not Found"), 404, None,
+				_("No account found for Employee ID {0}. Please check and try again.").format(employee_id))
+
 		password_token_info = frappe.db.get_value(
 			"Password Reset Token",
-			{"name":password_token}, 
+			{"name":password_token},
 			['name', 'status', 'expiration_time', 'user', 'new_password'],
 			as_dict=1
 		)
+		if not password_token_info:
+			return response(_("Session Expired"), 400, None,
+				_("Your password reset session has expired. Please request a new code."))
+
 		if (employee_user!=password_token_info.user):
-			return response ("Error", 400, {}, "Password reset failed. The user details do not match.")
+			return response(_("Wrong Account"), 400, None,
+				_("This password reset code was issued for a different account. "
+				  "Please request a new code."))
 		elif password_token_info.status != "Active":
-			return response ("Error", 400, {}, "Your password reset token has expired. Please request a new one.")
+			return response(_("Session Expired"), 400, None,
+				_("Your password reset session has expired. Please request a new code."))
 
 		_update_password(employee_user, new_password)
 		frappe.db.set_value("Password Reset Token", password_token, "status", "Revoked")
@@ -265,8 +316,13 @@ def change_password(employee_id, new_password, password_token):
 			"message": "Password reset successful! Please login with your new password."
 		}, "")
 	except Exception as e:
-		frappe.log_error(title="API Change password", message=frappe.get_traceback())
-		return response ("Error", 500, {}, str(e))
+		frappe.log_error(
+			title=f"Mobile API: authentication.change_password | {employee_id}",
+			message=frappe.get_traceback(),
+		)
+		frappe.db.commit()
+		return response(_("Something Went Wrong"), 500, None,
+			strip_html(cstr(e)) or type(e).__name__)
 
 
 @frappe.whitelist(allow_guest=True)
@@ -551,24 +607,37 @@ def set_password(employee_user_id, new_password):
 @frappe.whitelist(allow_guest=True)
 def user_login(employee_id, password):
 	try:
+		if not employee_id:
+			return response(_("Missing Employee ID"), 400, None,
+				_("Please enter your Employee ID."))
+
+		if not password:
+			return response(_("Missing Password"), 400, None,
+				_("Please enter your password."))
+
 		username =  frappe.db.get_value("Employee", {'employee_id': employee_id}, 'user_id')
 		if not username:
-			return response("Bad Request", 400, None,  "No account found for Employee ID {employee_id}. Please check and try again.".format(employee_id=employee_id))
+			return response(_("Account Not Found"), 400, None,
+				_("No account found for Employee ID {0}. Please check and try again.").format(employee_id))
+
 		auth = frappe.auth.LoginManager()
 		auth.authenticate(user=username, pwd=password)
 		auth.post_login()
 		msg={'status':200, 'text':frappe.local.response.message, 'user': frappe.session.user}
-		
 		# Fetch OAuth2 Token (replacing the old API Key "OAuth1" method)
 		client_id = frappe.db.get_value("OAuth Client", {"app_name": "OneFM"}, "client_id")
 		if not client_id:
-			response("error", 500, None, "OAuth Client 'OneFM' not configured in the system.")
-			return
-		
+			frappe.log_error(
+				title=f"Mobile API: authentication.user_login | {employee_id}",
+				message="OAuth Client 'OneFM' is not configured. Mobile login cannot issue a token.",
+			)
+			frappe.db.commit()
+			return response(_("Sign-In Unavailable"), 500, None,
+				_("Sign-in is temporarily unavailable. Please contact the IT Helpdesk."))
+
 		site = frappe.utils.cstr(frappe.local.conf.app_url) if frappe.local.conf.app_url else "http://127.0.0.1:8000"
 		if site.endswith('/'):
 			site = site[:-1]
-			
 		args = {
 			'client_id': client_id,
 			'grant_type': 'password',
@@ -584,7 +653,13 @@ def user_login(employee_id, password):
 			msg['token'] = f"Bearer {token_data.get('access_token')}"
 			msg['refresh_token'] = token_data.get('refresh_token')
 		else:
-			frappe.throw(_("OAuth2 Authentication Failed"))
+			frappe.log_error(
+				title=f"Mobile API: authentication.user_login | {employee_id}",
+				message=f"OAuth2 token request failed with HTTP {auth_api_response.status_code}\n\n{auth_api_response.text}",
+			)
+			frappe.db.commit()
+			return response(_("Sign-In Failed"), 401, None,
+				_("We could not complete your sign-in. Please try again, or contact the IT Helpdesk."))
 		user, user_roles, user_employee =  get_current_user_details()
 		msg.update(user_employee)
 		msg.update({"roles": user_roles})
@@ -596,13 +671,19 @@ def user_login(employee_id, password):
 		msg['endpoint_state'] = endpoint_state
 		msg['employee_endpoint_state'] = user_employee.custom_enable_face_recognition
 		msg['shift_working'] = user_employee.shift_working
-		response("success", 200, msg)
+		return response("success", 200, msg)
 	except frappe.exceptions.AuthenticationError:
-		print('auth eror')
-		response("error", 401, None, frappe.local.response.message)
+		err = strip_html(cstr(frappe.local.response.get("message") or "")) \
+			or _("Incorrect Employee ID or password. Please try again.")
+		return response(_("Sign-In Failed"), 401, None, err)
 	except Exception as e:
-		print(frappe.get_traceback(), 'Email Login')
-		response("error", 500, None, str(e))
+		frappe.log_error(
+			title=f"Mobile API: authentication.user_login | {employee_id}",
+			message=frappe.get_traceback(),
+		)
+		frappe.db.commit()
+		return response(_("Something Went Wrong"), 500, None,
+			strip_html(cstr(e)) or type(e).__name__)
 
 
 @frappe.whitelist(allow_guest=True)
@@ -620,24 +701,37 @@ def enrollment_status(employee_id: str):
 	"""
 	try:
 		if not employee_id:
-			return response("error", 404, "Employee ID is required")
+			return response(_("Missing Employee ID"), 400, None,
+				_("Please enter your Employee ID."))
+
 		employee = frappe.db.get_value(
-			'Employee', 
-			{'employee_id':employee_id} 
+			'Employee',
+			{'employee_id':employee_id}
 			,['status', 'enrolled', 'registered', 'employee_name', 'user_id','employee_name_in_arabic'], as_dict=1)
 		if employee:
 			if (employee.status in ['Left', 'Court Case']):
-				return response("error", 404, {}, f"Employee is not active")
+				return response(_("Account Not Active"), 403, None,
+					_("Your employee record is marked as '{0}' and cannot sign in. "
+					  "Please contact the HR Department.").format(employee.status))
 			elif (not employee.user_id):
-				return response("error", 404, {}, f"No active user account or login email found for {employee_id}".format(employee_id=employee_id))
+				return response(_("No Login Account"), 404, None,
+					_("No login account is set up for Employee ID {0}. "
+					  "Please contact the IT Helpdesk.").format(employee_id))
 			else:
 				return response("success", 200, {
 					"enrolled": employee.enrolled,
-					"registered": employee.registered, 
+					"registered": employee.registered,
 					"employee_name":employee.employee_name,
 					"employee_name_ar":employee.employee_name_in_arabic},
 				)
 		else:
-			return response("error", 404, {}, f"Employee ID {employee_id} does not exist")
+			return response(_("Employee Not Found"), 404, None,
+				_("No employee record found for Employee ID {0}. Please check and try again.").format(employee_id))
 	except Exception as e:
-		return response("error", 500, {}, str(e))
+		frappe.log_error(
+			title=f"Mobile API: authentication.enrollment_status | {employee_id}",
+			message=frappe.get_traceback(),
+		)
+		frappe.db.commit()
+		return response(_("Something Went Wrong"), 500, None,
+			strip_html(cstr(e)) or type(e).__name__)

--- a/one_fm/api/v1/face_recognition.py
+++ b/one_fm/api/v1/face_recognition.py
@@ -7,7 +7,7 @@ from one_fm.utils import get_current_shift, is_holiday,get_holiday_today
 from one_fm.api.v1.utils import (
     response, verify_via_face_recogniton_service
 )
-from frappe.utils import add_days, cint, cstr, flt, getdate, now_datetime
+from frappe.utils import add_days, cint, cstr, flt, getdate, now_datetime, strip_html
 from one_fm.api.doc_events import haversine
 from one_fm.overrides.employee import (
     has_day_off, is_employee_on_leave, NOT_RETURNED_FROM_LEAVE
@@ -51,7 +51,8 @@ def enroll(employee_id: str = None, filename: str = None, video: str = None) -> 
     """
     try:
         if not employee_id:
-            return response("Bad Request", 400, None, "Employee ID required.")
+            return response(_("Missing Employee ID"), 400, None,
+                            _("Please enter your Employee ID."))
 
         if not filename:
             filename = frappe.session.user+'.mp4'
@@ -60,26 +61,33 @@ def enroll(employee_id: str = None, filename: str = None, video: str = None) -> 
         endpoint_state = frappe.db.get_single_value("ONEFM General Setting", 'enable_face_recognition_endpoint')
         if not video_file:
             if endpoint_state:
-                return response("Bad Request", 400, None, "Video File is required.")
+                return response(_("No Video Captured"), 400, None,
+                                _("No video was captured. Please record your face again and retry."))
+
+        employee_name = frappe.db.get_value("Employee", {"employee_id": employee_id}, "name")
+        if not employee_name:
+            return response(_("Employee Not Found"), 404, None,
+                            _("No employee record found for Employee ID {0}. Please contact the IT Helpdesk.").format(employee_id))
 
         # check Face Recognition Endpoint
 
         if endpoint_state:
             if not face_recog_base_url:
-                return response("Bad Request", 400, None, "Face Recognition Service configuration is not available.")
+                frappe.log_error(
+                    title=f"Mobile API: face_recognition.enroll | {employee_id}",
+                    message="face_recognition_service_base_url is not set in site config.",
+                )
+                frappe.db.commit()
+                return response(_("Enrollment Unavailable"), 503, None,
+                                _("Face enrollment is temporarily unavailable. Please contact your Site Supervisor."))
             status, message = verify_via_face_recogniton_service(url=face_recog_base_url + "enroll", data={"username": frappe.session.user, "filename": filename}, files={"video_file": video_file})
         else:
             status, message = True, 'Successful'
 
-
-        doc = frappe.get_doc("Employee", {"employee_id": employee_id})
-        if not doc:
-            return response("Resource Not Found", 404, None, "No employee found with {employee_id}".format(employee_id=employee_id))
-
-
-
         if not status:
-            return response("Bad Request", 400, None, message)
+            return response(_("Enrollment Failed"), 400, None, message)
+
+        doc = frappe.get_doc("Employee", employee_name)
 
         # Set a context flag to indicate an API update (It will affect in 'Employee' validate method)
         frappe.flags.allow_enrollment_update = True
@@ -90,10 +98,15 @@ def enroll(employee_id: str = None, filename: str = None, video: str = None) -> 
         frappe.db.commit()
 
         return response("Success", 201,
-                        "User enrolled successfully.<br>Please wait for 10sec, you will be redirected to checkin.")
+                        _("You are enrolled. You will be taken to check-in shortly."))
     except Exception as error:
-        frappe.log_error(message=frappe.get_traceback(), title="Enrollment")
-        return response("Internal Server Error", 500, None, error)
+        frappe.log_error(
+            title=f"Mobile API: face_recognition.enroll | {employee_id}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(cstr(error)) or type(error).__name__)
 
 
 @frappe.whitelist()
@@ -118,87 +131,90 @@ def verify_checkin_checkout(employee_id: str = None, log_type: str = None,shift:
         }
     """
     try:
-        # ensure skip attendance is correctly formated
-        try:
-            current_shift = shift
-            skip_attendance = int(skip_attendance) if skip_attendance else 0
-            latitude = float(latitude)
-            longitude = float(longitude)
-        except:
-            return response("Bad Request", 400, None,
-                            "skip_attendance must be an integer, latitude and longitude must be float.")
+        current_shift = shift
 
         if not employee_id:
-            return response("Bad Request", 400, None, "Employee ID is required")
+            return response(_("Missing Employee ID"), 400, None,
+                            _("Please enter your Employee ID."))
 
         if not log_type:
-            return response("Bad Request", 400, None, "Log type parameter required")
-
-        if not skip_attendance:
-            return response("Bad Request", 400, None, "Skip attendance parameter required.")
-
-        if not latitude:
-            return response("Bad Request", 400, None, "Latitude parameter required.")
-
-        if not longitude:
-            return response("Bad Request", 400, None, "Longitude parameter required.")
-
-        if not isinstance(log_type, str):
-            return response("Bad Request", 400, None, "Invalid log type format. Please enter a valid value.")
+            return response(_("Missing Log Type"), 400, None,
+                            _("Please select whether you are checking in or out."))
 
         if log_type not in {"IN", "OUT"}:
-            return response("Bad Request", 400, None, "Invalid log type. Log type must be IN/OUT.")
+            return response(_("Invalid Log Type"), 400, None,
+                            _("Please select whether you are checking in or out."))
 
-        if not isinstance(skip_attendance, int):
-            return response("Bad Request", 400, None, "Skip attendance parameter must be an integer.")
+        if latitude is None or cstr(latitude).strip() == "":
+            return response(_("Location Unavailable"), 400, None,
+                            _("Your location could not be read. Please enable GPS and try again."))
 
-        if skip_attendance not in {0, 1}:
-            return response("Bad Request", 400, "Invalid skip attendance parameter. It must be 0 or 1.")
+        if longitude is None or cstr(longitude).strip() == "":
+            return response(_("Location Unavailable"), 400, None,
+                            _("Your location could not be read. Please enable GPS and try again."))
 
-        if not isinstance(latitude, float):
-            return response("Bad Request", 400, None, "Latitude must be of type float.")
+        try:
+            latitude = float(latitude)
+            longitude = float(longitude)
+        except (TypeError, ValueError):
+            return response(_("Location Unavailable"), 400, None,
+                            _("Your location could not be read. Please enable GPS and try again."))
 
-        if not isinstance(longitude, float):
-            return response("Bad Request", 400, None, "Longitude must be of type float.")
+        skip_attendance = cint(skip_attendance)
 
         endpoint_state = frappe.db.get_single_value("ONEFM General Setting", 'enable_face_recognition_endpoint')
         employee = frappe.db.get_value("Employee", {"employee_id": employee_id}, ["name", "custom_enable_face_recognition"], as_dict=1)
 
+        if not employee or not employee.name:
+            return response(_("Employee Not Found"), 404, None,
+                            _("No employee record found for Employee ID {0}. Please contact the IT Helpdesk.").format(employee_id))
+
         video_file = frappe.request.files.get("video_file") or video or frappe.request.files.get("video")
         if not video_file:
             if endpoint_state and employee.custom_enable_face_recognition:
-                return response("Bad Request", 400, None, "Video File is required.")
+                return response(_("No Video Captured"), 400, None,
+                                _("No video was captured. Please record your face again and retry."))
 
-
-        if not employee.name:
-            return response("Resource Not Found", 404, None, "No employee record found with {employee_id}".format(employee_id=employee_id))
-        
         right_now = now_datetime()
         if log_type == "IN":
-            shift_info = frappe.db.sql(f"""
-                SELECT 
-                    sa.start_datetime, 
-                    st.begin_check_in_before_shift_start_time 
-                FROM 
-                    `tabShift Assignment` sa
-                JOIN 
-                    `tabShift Type` st ON sa.shift_type = st.name
-                WHERE 
-                    sa.employee = '{employee.name}' 
-                ORDER BY 
-                    sa.creation DESC 
-                LIMIT 1
-            """, as_dict=1)[0]
-            shift_actual_start = shift_info.start_datetime - timedelta(minutes=shift_info.begin_check_in_before_shift_start_time)
+            ShiftAssignment = frappe.qb.DocType("Shift Assignment")
+            ShiftType = frappe.qb.DocType("Shift Type")
+            shift_rows = (
+                frappe.qb.from_(ShiftAssignment)
+                .join(ShiftType)
+                .on(ShiftAssignment.shift_type == ShiftType.name)
+                .select(
+                    ShiftAssignment.start_datetime,
+                    ShiftType.begin_check_in_before_shift_start_time,
+                )
+                .where(ShiftAssignment.employee == employee.name)
+                .orderby(ShiftAssignment.creation, order=frappe.qb.desc)
+                .limit(1)
+            ).run(as_dict=True)
+
+            if not shift_rows:
+                return response(_("No Shift Assigned"), 400, None,
+                                _("You have no shift assigned. Please contact your Site Supervisor."))
+
+            shift_info = shift_rows[0]
+            shift_actual_start = shift_info.start_datetime - timedelta(minutes=cint(shift_info.begin_check_in_before_shift_start_time))
             if right_now < shift_actual_start:
-                return response("Bad Request", 400, None, f" Oops! You can't check in right now. Your check-in time is {shift_info.begin_check_in_before_shift_start_time} minutes before you start your shift." + "\U0001F612")
+                return response(_("Too Early to Check In"), 400, None,
+                                _("You cannot check in yet. Check-in opens {0} minutes before your shift starts, at {1}.").format(
+                                    cint(shift_info.begin_check_in_before_shift_start_time), _fmt_clock(shift_actual_start)))
         # check Face Recognition Endpoint
-        
+
         if not filename:
             filename = frappe.session.user+'.mp4'
         if endpoint_state and employee.custom_enable_face_recognition:
             if not face_recog_base_url:
-                return response("Bad Request", 400, None, "Face Recognition Service configuration is not available.")
+                frappe.log_error(
+                    title=f"Mobile API: face_recognition.verify_checkin_checkout | {employee_id}",
+                    message="face_recognition_service_base_url is not set in site config.",
+                )
+                frappe.db.commit()
+                return response(_("Verification Unavailable"), 503, None,
+                                _("Face verification is temporarily unavailable. Please contact your Site Supervisor."))
             status, message = verify_via_face_recogniton_service(url=face_recog_base_url + "verify", data={
                 "username": frappe.session.user, "filename": filename
                 }, files={"video_file": video_file})
@@ -206,13 +222,18 @@ def verify_checkin_checkout(employee_id: str = None, log_type: str = None,shift:
             status, message = True, 'Successful'
 
         if not status:
-            return response("Bad Request", 400, None, message)
+            return response(_("Face Verification Failed"), 400, None, message)
         doc = create_checkin_log(employee.name, log_type, skip_attendance, latitude, longitude,current_shift, "Mobile App")
         return response("Success", 201, doc, None)
 
     except Exception as error:
-        frappe.log_error(message=frappe.get_traceback(), title="Verify Checkin Error")
-        return response("Internal Server Error", 500, None, error)
+        frappe.log_error(
+            title=f"Mobile API: face_recognition.verify_checkin_checkout | {employee_id}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(cstr(error)) or type(error).__name__)
 
 
 def create_checkin_log(employee: str, log_type: str, skip_attendance: int, latitude: float, longitude: float,current_shift:str,
@@ -351,30 +372,38 @@ def has_day_off(employee,date):
 @frappe.whitelist()
 def get_site_location(employee_id: str = None, shift: str = None,latitude: float = None, longitude: float = None) -> dict:
     try:
+        print(employee_id, shift ,latitude , longitude)
         if not employee_id:
-            return response("Bad Request", 400, None, "Employee ID required.")
+            return response(_("Missing Employee ID"), 400, None,
+                            _("Please enter your Employee ID."))
 
-        if not latitude:
-            return response("Bad Request", 400, None, "Latitude required.")
+        if latitude is None or cstr(latitude).strip() == "":
+            return response(_("Location Unavailable"), 400, None,
+                            _("Your location could not be read. Please enable GPS and try again."))
 
-        if not longitude:
-            return response("Bad Request", 400, None, "Longitude required.")
+        if longitude is None or cstr(longitude).strip() == "":
+            return response(_("Location Unavailable"), 400, None,
+                            _("Your location could not be read. Please enable GPS and try again."))
 
-        if not isinstance(employee_id, str):
-            return response("Bad Request", 400, None, "Invalid Employee ID format. Please enter a valid value.")
+        try:
+            latitude = float(latitude)
+            longitude = float(longitude)
+        except (TypeError, ValueError):
+            return response(_("Location Unavailable"), 400, None,
+                            _("Your location could not be read. Please enable GPS and try again."))
 
         employee = frappe.db.get_value("Employee", {"employee_id": employee_id}, ["name", "holiday_list", "employee_name", "shift_working", "status"], as_dict=1)
         if not employee:
-            return response("Resource Not Found", 404, None,
-                            "No employee record found with {employee_id}".format(employee_id=employee_id))
+            return response(_("Employee Not Found"), 404, None,
+                            _("No employee record found for Employee ID {0}. Please contact the IT Helpdesk.").format(employee_id))
 
         # Block employees who have not returned from leave. This takes priority over
         # every shift check below, so the banner says what to do about the status
         # rather than talking about a check-in window the status makes irrelevant.
         if employee.status == NOT_RETURNED_FROM_LEAVE:
-            return response("Access Denied", 403, None,
-                            _("Action Required: You are currently marked as '{0}'. Please contact "
-                              "your Site Supervisor to complete your Duty Resumption process."
+            return response(_("Action Required"), 403, None,
+                            _("You are currently marked as '{0}'. Please contact your Site "
+                              "Supervisor to complete your Duty Resumption process."
                               ).format(NOT_RETURNED_FROM_LEAVE))
         
         today = getdate()
@@ -386,7 +415,9 @@ def get_site_location(employee_id: str = None, shift: str = None,latitude: float
             "employee_availability": "Fingerprint Appointment"
         })
         if fingerprint_appointment:
-            return response("Resource Not Found", 404, None, "You have a fingerprint appointment. See you soon!")
+            return response(_("Fingerprint Appointment"), 404, None,
+                            _("You have a fingerprint appointment scheduled today, so check-in is "
+                              "not required. See you soon!"))
 
         # check for medical appointment
         medical_appointment = frappe.db.exists("Employee Schedule", {
@@ -395,7 +426,9 @@ def get_site_location(employee_id: str = None, shift: str = None,latitude: float
             "employee_availability": "Medical Appointment"
         })
         if medical_appointment:
-            return response("Resource Not Found", 404, None, "You have a medical appointment. See you soon!")
+            return response(_("Medical Appointment"), 404, None,
+                            _("You have a medical appointment scheduled today, so check-in is "
+                              "not required. See you soon!"))
         shift = frappe.get_doc("Shift Assignment", shift) if shift and shift != 'undefined' else None
         upcoming_shifts = []
 
@@ -404,14 +437,15 @@ def get_site_location(employee_id: str = None, shift: str = None,latitude: float
             if shift_details:
                 if shift_details['type'] == "Early":
                     # check if user can checkin with the correct time
-                    return response("Resource Not Found", 404, None,
-                                    f"You are checking in too early. Check-in is allowed in {shift_details['time']} minutes.")
+                    return response(_("Too Early to Check In"), 404, None,
+                                    _("It is too early to check in. Check-in opens in {0} minutes.").format(shift_details['time']))
                 elif shift_details['type'] == "Late":
-                    return response("Resource Not Found", 404, None,
-                                    f"You are checking out too late. Check-out was allowed until {shift_details['time']} minutes ago.")
+                    return response(_("Check-Out Window Closed"), 404, None,
+                                    _("The check-out window for your shift closed {0} minutes ago. "
+                                      "Please contact your Site Supervisor.").format(shift_details['time']))
                 elif shift_details['type'] == "Upcoming":
-                    return response("Resource Not Found", 404, None,
-                                    f"Check-in for your shift starts in {shift_details['time']} minutes.")
+                    return response(_("Shift Not Started"), 404, None,
+                                    _("Check-in for your shift opens in {0} minutes.").format(shift_details['time']))
                 elif shift_details['type'] == "On Time":
                     shift = shift_details['data']  # Return the object of Shift Assignment
                     upcoming_shifts = shift_details['upcoming_shifts']
@@ -420,18 +454,22 @@ def get_site_location(employee_id: str = None, shift: str = None,latitude: float
 
         if shift:
             if shift.is_replaced == 1:
-                return response("Resource Not Found", 404, None, f"You have been replaced with another Employee.")
+                return response(_("Shift Reassigned"), 404, None,
+                                _("Another employee has been assigned to this shift, so you cannot "
+                                  "check in. Please contact your Site Supervisor."))
 
             if is_attendance_request_exists(employee.name, date):
-                return response("Resource Not Found", 404, None,
-                                f"You have an attendance request for today. Your attendance will be marked.")
+                return response(_("Attendance Request Approved"), 404, None,
+                                _("You have an approved attendance request for today. Your attendance "
+                                  "will be marked automatically, so no check-in is needed."))
 
             log_type = shift.get_next_checkin_log_type()
             if log_type == 'IN':
                 if shift.after_4hrs():
                     # check if hrs has passed since shift start. Here we can also allow those who checked out tp checkin by checkin if OUT exist for same shift
-                    return response("Resource Not Found", 404, None,
-                                    "You are 4 or more hours late, you cannot checkin at this time.")
+                    return response(_("Check-In Window Closed"), 404, None,
+                                    _("You are more than 4 hours late, so check-in is no longer allowed. "
+                                      "Please contact your Site Supervisor to record your attendance."))
 
             location = get_shift_site_location(shift, date, log_type, latitude, longitude)
             site = frappe.get_value("Operations Shift", shift.shift, "site")
@@ -472,26 +510,39 @@ def get_site_location(employee_id: str = None, shift: str = None,latitude: float
                 result['endpoint_status'] = facial_recognition_endpoint_state
                 return response("Success", 200, result)
 
-            elif site:
-                return response("Resource Not Found", 404, None, "No site location set for {site}".format(site=site))
+            frappe.log_error(
+                title=f"Mobile API: face_recognition.get_site_location | {employee_id}",
+                message=(
+                    f"No usable Location for shift {shift.name}.\n"
+                    f"site={site!r} site_location={shift.get('site_location')!r} "
+                    f"operations_shift={shift.get('shift')!r}\n"
+                    f"user_latitude={latitude} user_longitude={longitude}"
+                ),
+            )
+            frappe.db.commit()
+            return response(_("Site Location Missing"), 404, None,
+                            _("Your site location has not been set up yet, so check-in is "
+                              "unavailable. Please contact your Site Supervisor."))
 
         else:
             if employee.shift_working:
                 if has_day_off(employee.name, date):
-                    return response("Resource Not Found", 404, None,
-                                    f"Dear {employee.employee_name}, Today is your day off.  Happy Recharging!.")
+                    return response(_("Day Off"), 404, None,
+                                    _("Dear {0}, today is your day off. Happy recharging!").format(employee.employee_name))
             if employee.holiday_list:
                 holiday_today = get_holiday_today(str(getdate()))
                 if holiday_today.get(employee.holiday_list):
-                    return response("Resource Not Found", 404, None, "Today is your holiday, have fun.")
+                    return response(_("Holiday"), 404, None,
+                                    _("Today is a holiday, so no check-in is needed. Enjoy your day!"))
 
 
             if is_employee_on_leave(employee.name, date):
-                return response("Resource Not Found", 404, None, "You are currently on leave, see you soon!")
+                return response(_("On Leave"), 404, None,
+                                _("You are on approved leave today, so no check-in is needed. See you soon!"))
 
             status, message = is_holiday(employee=employee, date=date)
             if status:
-                return response("Resource Not Found", 404, None, message)
+                return response(_("Holiday"), 404, None, message)
 
             # WI-001777: the employee may well have a shift today whose check-in
             # window is simply not open - get_current_shift only returns a shift once
@@ -499,13 +550,20 @@ def get_site_location(employee_id: str = None, shift: str = None,latitude: float
             # unactionable, so quote the configured window instead.
             window_message = get_checkin_window_message(employee.name)
             if window_message:
-                return response("Resource Not Found", 404, None, window_message)
+                return response(_("Check-In Unavailable"), 404, None, window_message)
 
-            return response("Resource Not Found", 404, None, "You are not assigned to a shift.")
+            return response(_("No Shift Assigned"), 404, None,
+                            _("You have no shift assigned today. Please contact your Site "
+                              "Supervisor if you were expecting to work."))
 
     except Exception as error:
-        frappe.log_error(title="API Site location", message=frappe.get_traceback())
-        return response("Internal Server Error", 500, None, error)
+        frappe.log_error(
+            title=f"Mobile API: face_recognition.get_site_location | {employee_id}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(cstr(error)) or type(error).__name__)
 
 
 def is_attendance_request_exists(employee, date):
@@ -668,9 +726,26 @@ def checkin_list(employee_id, from_date, to_date):
     This method retrives employee checkin list
     """
     try:
+        if not employee_id:
+            return response(_("Missing Employee ID"), 400, None,
+                            _("Please enter your Employee ID."))
+
         employee = frappe.db.get_value("Employee", {"employee_id":employee_id}, "name")
         if not employee:
-            return response("Success", 404, None, "No employee record found for {employee_id}".format(employee_id=employee_id))
+            return response(_("Employee Not Found"), 404, None,
+                            _("No employee record found for Employee ID {0}. Please contact the IT Helpdesk.").format(employee_id))
+
+        try:
+            from_date = getdate(from_date)
+            to_date = getdate(to_date)
+        except Exception:
+            return response(_("Invalid Date Range"), 400, None,
+                            _("Please select a valid date range."))
+
+        if from_date > to_date:
+            return response(_("Invalid Date Range"), 400, None,
+                            _("The start date cannot be after the end date."))
+
         checkins = frappe.get_all("Employee Checkin", filters={
             "employee": employee,
             "time": ["BETWEEN", [f"{from_date} 00:00:00", f"{to_date} 23:59:59"]]
@@ -680,4 +755,10 @@ def checkin_list(employee_id, from_date, to_date):
         )
         return response("success", 200, checkins)
     except Exception as e:
-        return response("error", 500, None, str(e))
+        frappe.log_error(
+            title=f"Mobile API: face_recognition.checkin_list | {employee_id}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(cstr(e)) or type(e).__name__)

--- a/one_fm/api/v1/leave_application.py
+++ b/one_fm/api/v1/leave_application.py
@@ -6,7 +6,7 @@ from datetime import date
 import datetime
 import collections
 
-from frappe.utils import cint, cstr, getdate, add_months, add_days
+from frappe.utils import cint, cstr, getdate, add_months, add_days, strip_html
 from hrms.hr.doctype.leave_application.leave_application import get_leave_balance_on, get_leave_allocation_records, get_leave_details
 
 from one_fm.api.api import upload_file
@@ -33,18 +33,23 @@ def get_leave_detail(employee_id: str = None, leave_id: str = None) -> dict:
     """
     try:
         if not employee_id:
-            return response("Bad Request", 400, None, "Please enter your Employee ID.")
+            return response(_("Missing Employee ID"), 400, None,
+                            _("Please enter your Employee ID."))
 
         if not isinstance(employee_id, str):
-            return response("Bad Request", 400, None, "Invalid Employee ID format. Please enter a valid value.")
+            return response(_("Invalid Employee ID"), 400, None,
+                            _("Please enter a valid Employee ID."))
 
         if leave_id and not isinstance(leave_id, str):
-            return response("Bad Request", 400, None, "Invalid Leave ID format. Please enter a valid value.")
+            return response(_("Invalid Leave ID"), 400, None,
+                            _("Please select a valid leave application."))
 
         employee = frappe.db.get_value("Employee", {'employee_id':employee_id})
 
         if not employee:
-            return response("Resource Not Found", 404, None, "No employee record found for {employee_id}".format(employee_id=employee_id))
+            return response(_("Employee Not Found"), 404, None,
+                            _("No employee record found for Employee ID {0}. "
+                              "Please contact the IT Helpdesk.").format(employee_id))
 
         if not leave_id:
             leave_list = frappe.get_all("Leave Application", {'employee':employee},
@@ -52,9 +57,15 @@ def get_leave_detail(employee_id: str = None, leave_id: str = None) -> dict:
             if leave_list and len(leave_list) > 0:
                 return response("Success", 200, leave_list)
             else:
-                return response("Resource Not Found", 404, None, "No leaves found for {employee_id}".format(employee_id=employee_id))
+                return response(_("No Leave Applications"), 404, None,
+                                _("You have not applied for any leave yet."))
 
         elif leave_id:
+            if not frappe.db.exists("Leave Application", leave_id):
+                return response(_("Leave Not Found"), 404, None,
+                                _("This leave application no longer exists. "
+                                  "Please refresh and try again."))
+
             leave_details = frappe.get_doc("Leave Application", leave_id)
             if leave_details.leave_approver == frappe.session.user:
                 is_leave_approver = 1
@@ -67,14 +78,16 @@ def get_leave_detail(employee_id: str = None, leave_id: str = None) -> dict:
                 d.update({"file_name":filename})
             data.update({"is_leave_approver":is_leave_approver})
 
-            if leave_details:
-                return response("Success", 200, data)
-            else:
-                return response("Resource Not Found", 404, None, "No leave data found for {leave_id}".format(leave_id=leave_id))
+            return response("Success", 200, data)
 
     except Exception as error:
-        frappe.log_error(title="API Leave Detail", message=frappe.get_traceback())
-        return response("Internal Server Error", 500, None, error)
+        frappe.log_error(
+            title=f"Mobile API: leave_application.get_leave_detail | {employee_id}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(cstr(error)) or type(error).__name__)
 
 @frappe.whitelist()
 def approver_leave() -> dict:
@@ -118,16 +131,16 @@ def get_leave_balance(employee_id: str = None, leave_type: str = None) -> dict:
         }
     """
     if not employee_id:
-        return response("Bad Request", 400, None, "No employee record found for {employee_id}".format(employee_id=employee_id))
-
-    # if not leave_type:
-    #     return response("Bad Request", 400, None, "leave_type required.")
+        return response(_("Missing Employee ID"), 400, None,
+                        _("Please enter your Employee ID."))
 
     if not isinstance(employee_id, str):
-        return response("Bad Request", 400, None, "Invalid Employee ID format. Please enter a valid value.")
+        return response(_("Invalid Employee ID"), 400, None,
+                        _("Please enter a valid Employee ID."))
 
-    if not isinstance(leave_type, str):
-        return response("Bad Request", 400, None, "Invalid leave type. Please select a valid value.")
+    if leave_type is not None and not isinstance(leave_type, str):
+        return response(_("Invalid Leave Type"), 400, None,
+                        _("Please select a valid leave type."))
 
     today=date.today()
 
@@ -135,11 +148,15 @@ def get_leave_balance(employee_id: str = None, leave_type: str = None) -> dict:
         employee = frappe.db.get_value("Employee", {"employee_id": employee_id})
 
         if not employee:
-            return response("Resource Not Found", 404, None, "No employee record found for {employee_id}".format(employee_id=employee_id))
+            return response(_("Employee Not Found"), 404, None,
+                            _("No employee record found for Employee ID {0}. "
+                              "Please contact the IT Helpdesk.").format(employee_id))
 
         allocation_records = get_leave_details(employee, today)
-        
-        leave_type = leave_type.title()
+
+        if leave_type:
+            leave_type = leave_type.title()
+
         if allocation_records["leave_allocation"]:
             if leave_type:
                 if allocation_records["leave_allocation"].get(leave_type):
@@ -147,17 +164,23 @@ def get_leave_balance(employee_id: str = None, leave_type: str = None) -> dict:
                     leave_balance['leave_type'] = leave_type
                     return response("Success", 200, leave_balance)
                 else:
-                    response("Resource Not Found", 404, None, "No {leave_type} allocated to {employee}".format(
-                        employee=employee_id, leave_type=leave_type))
+                    return response(_("No Leave Balance"), 404, None,
+                                    _("You have no {0} allocated. Please contact HR.").format(leave_type))
             else:
                 leave_balance = allocation_records['leave_allocation']
                 return response("Success", 200, leave_balance)
         else:
-            return response("Resource Not Found", 404, None, "No leave allocation found for {employee}".format(
-                employee=employee_id))
+            return response(_("No Leave Allocation"), 404, None,
+                            _("You have no leave allocated for this period. Please contact HR."))
 
     except Exception as error:
-        return response("Internal Server Error", 500, None, error)
+        frappe.log_error(
+            title=f"Mobile API: leave_application.get_leave_balance | {employee_id}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(cstr(error)) or type(error).__name__)
 
 @frappe.whitelist()
 def get_leave_types(employee_id: str = None) -> dict:
@@ -176,22 +199,27 @@ def get_leave_types(employee_id: str = None) -> dict:
     """
 
     if not employee_id:
-        return response("Bad Request", 400, None, "Employee ID is required.")
+        return response(_("Missing Employee ID"), 400, None,
+                        _("Please enter your Employee ID."))
 
     if not isinstance(employee_id, str):
-        return response("Bad Request", 400, None, "Invalid Employee ID format. Please enter a valid value.")
+        return response(_("Invalid Employee ID"), 400, None,
+                        _("Please enter a valid Employee ID."))
 
     try:
         employee = frappe.db.get_value("Employee", {"employee_id": employee_id})
 
         if not employee:
-            return response("Resource Not Found", 404, None, "No employee record found for {employee_id}".format(employee_id=employee_id))
+            return response(_("Employee Not Found"), 404, None,
+                            _("No employee record found for Employee ID {0}. "
+                              "Please contact the IT Helpdesk.").format(employee_id))
 
         leave_types_set = set()
         leave_type_list = frappe.get_list("Leave Allocation", {"employee": employee}, 'leave_type')
 
         if not leave_type_list or len(leave_type_list) == 0:
-            return response("Resource Not Found", 404, None, "No leave allocated to {employee}".format(employee=employee_id))
+            return response(_("No Leave Allocation"), 404, None,
+                            _("You have no leave allocated for this period. Please contact HR."))
 
         leave_types = frappe.get_all("Leave Type", fields=["name", "is_proof_document_required"])
         leave_types_dict = {}
@@ -199,38 +227,65 @@ def get_leave_types(employee_id: str = None) -> dict:
             leave_types_dict[i.name] = i.is_proof_document_required
         leave_type_documents = {}
         for leave_type in leave_type_list:
-            leave_type_documents[leave_type.leave_type] = leave_types_dict[leave_type.leave_type]
+            if leave_type.leave_type in leave_types_dict:
+                leave_type_documents[leave_type.leave_type] = leave_types_dict[leave_type.leave_type]
         return response("Success", 200, leave_type_documents)
 
     except Exception as error:
-        return response("Internal Server Error", 500, None, error)
+        frappe.log_error(
+            title=f"Mobile API: leave_application.get_leave_types | {employee_id}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(cstr(error)) or type(error).__name__)
 
 
 @frappe.whitelist()
 def get_employees_role_to_display_reliever_field(employee_id: str = None)-> dict:
     try:
         employee = frappe.get_value("Employee", {"employee_id": employee_id}, ["name", "user_id", "reports_to"], as_dict=1)
+        if not employee:
+            return response(_("Employee Not Found"), 404, None,
+                            _("No employee record found for Employee ID {0}. "
+                              "Please contact the IT Helpdesk.").format(employee_id))
+
         super_user_role = frappe.db.get_single_value("ONEFM General Setting", "super_user_role")
         user_roles = frappe.get_roles(employee.user_id)
         if (employee.reports_to or (super_user_role in user_roles)):
             return response("Success", 200, True)
         return response("Success", 200, False)
     except Exception as error:
-        return response("Internal Server Error", 500, None, error)
+        frappe.log_error(
+            title=f"Mobile API: leave_application.get_employees_role_to_display_reliever_field | {employee_id}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(cstr(error)) or type(error).__name__)
 
 
 
 @frappe.whitelist()
 def get_employees_list():
-    super_user_role = frappe.db.get_single_value("ONEFM General Setting", "super_user_role")
-    users_with_role = frappe.get_all("Has Role",filters={"role": super_user_role, "parenttype": "User"},fields=["parent as user_name"])
-    user_names = [user["user_name"] for user in users_with_role]
-    employees_with_role = frappe.get_all("Employee",filters={"status": "Active", "user_id": ["in", user_names]},fields=["employee_id", "employee_name", "designation","employee"])
-    employees = frappe.get_all("Employee",filters={"status": "Active","reports_to": ["is", "set"]},fields=["employee_id", "employee_name", "designation","employee"])
-    for employee in employees_with_role:
-        if employee not in employees:
-            employees.append(employee)
-    return response("Success", 200, employees)
+    try:
+        super_user_role = frappe.db.get_single_value("ONEFM General Setting", "super_user_role")
+        users_with_role = frappe.get_all("Has Role",filters={"role": super_user_role, "parenttype": "User"},fields=["parent as user_name"])
+        user_names = [user["user_name"] for user in users_with_role]
+        employees_with_role = frappe.get_all("Employee",filters={"status": "Active", "user_id": ["in", user_names]},fields=["employee_id", "employee_name", "designation","employee"])
+        employees = frappe.get_all("Employee",filters={"status": "Active","reports_to": ["is", "set"]},fields=["employee_id", "employee_name", "designation","employee"])
+        for employee in employees_with_role:
+            if employee not in employees:
+                employees.append(employee)
+        return response("Success", 200, employees)
+    except Exception as error:
+        frappe.log_error(
+            title=f"Mobile API: leave_application.get_employees_list | {frappe.session.user}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(cstr(error)) or type(error).__name__)
 
 @frappe.whitelist()
 def create_new_leave_application(employee_id: str = None, from_date: str = None, 
@@ -252,69 +307,94 @@ def create_new_leave_application(employee_id: str = None, from_date: str = None,
     """
     try:
         if not employee_id:
-            return response("Bad Request", 400, None, "Employee ID is required.")
+            return response(_("Missing Employee ID"), 400, None,
+                            _("Please enter your Employee ID."))
 
         if not from_date:
-            return response("Bad Request", 400, None, "From date is required.")
+            return response(_("Missing Start Date"), 400, None,
+                            _("Please select the first day of your leave."))
 
         if not to_date:
-            return response("Bad Request", 400, None, "To date is required.")
+            return response(_("Missing End Date"), 400, None,
+                            _("Please select the last day of your leave."))
 
         if not leave_type:
-            return response("Bad Request", 400, None, "Leave type is required.")
+            return response(_("Missing Leave Type"), 400, None,
+                            _("Please select a leave type."))
 
         if not reason:
-            return response("Bad Request", 400, None, "Reason is required.")
+            return response(_("Missing Reason"), 400, None,
+                            _("Please enter a reason for your leave."))
 
         if not isinstance(employee_id, str):
-            return response("Bad Request", 400, None, "Invalid Employee ID format. Please enter a valid value.")
+            return response(_("Invalid Employee ID"), 400, None,
+                            _("Please enter a valid Employee ID."))
 
-        if not isinstance(from_date, str):
-            return response("Bad Request", 400, None, "Invalid From date. Please enter a valid value.")
+        if not isinstance(from_date, str) or not validate_date(from_date):
+            return response(_("Invalid Start Date"), 400, None,
+                            _("Please select a valid start date."))
 
-        if not validate_date(from_date):
-            return response("Bad Request", 400, None, "From date must be of the format yyyy-mm-dd.")
+        if not isinstance(to_date, str) or not validate_date(to_date):
+            return response(_("Invalid End Date"), 400, None,
+                            _("Please select a valid end date."))
 
-        if not validate_date(to_date):
-            return response("Bad Request", 400, None, "To date must be of the format yyyy-mm-dd.")
-
-        if not isinstance(to_date, str):
-            return response("Bad Request", 400, None, "Invalid To date. Please enter a valid value.")
+        if getdate(from_date) > getdate(to_date):
+            return response(_("Invalid Date Range"), 400, None,
+                            _("The start date cannot be after the end date."))
 
         if not resumption_date:
             resumption_date = cstr(add_days(getdate(to_date), 1))
         elif not isinstance(resumption_date, str):
-            return response("Bad Request", 400, None, "Invalid Resumption date. Please enter a valid value.")
+            return response(_("Invalid Resumption Date"), 400, None,
+                            _("Please select a valid resumption date."))
         if not validate_date(resumption_date):
-            return response("Bad Request", 400, None, "Resumption date must be of the format yyyy-mm-dd.")
+            return response(_("Invalid Resumption Date"), 400, None,
+                            _("Please select a valid resumption date."))
 
         if not isinstance(leave_type, str):
-            return response("Bad Request", 400, None, "Invalid leave type. Please enter a valid value.")
+            return response(_("Invalid Leave Type"), 400, None,
+                            _("Please select a valid leave type."))
 
         if not isinstance(reason, str):
-            return response("Bad Request", 400, None, "Invalid reason format. Please enter a valid value.")
+            return response(_("Invalid Reason"), 400, None,
+                            _("Please enter a valid reason for your leave."))
+
+        if not frappe.db.exists("Leave Type", leave_type):
+            return response(_("Invalid Leave Type"), 400, None,
+                            _("The leave type you selected is no longer available. "
+                              "Please choose another."))
 
         if proof_document_required_for_leave_type(leave_type) and not proof_document:
-            return response("Bad Request", 400, None, "Proof document required for {leave_type}".format(leave_type=leave_type))
+            return response(_("Proof Document Required"), 400, None,
+                            _("{0} requires a supporting document. "
+                              "Please attach one and try again.").format(leave_type))
 
         if not check_if_backdate_allowed(leave_type, from_date):
-            return response("Bad Request", 400, None, "You are not allowed to apply for a previous date.")
+            return response(_("Backdated Leave Not Allowed"), 400, None,
+                            _("{0} cannot be applied for a past date. "
+                              "Please contact HR if you need to record it.").format(leave_type))
         
 
         employee = frappe.db.get_value("Employee", {"employee_id": employee_id})
         if not employee:
-            return response("Resource Not Found", 404, None, "No employee record found for {employee_id}".format(employee_id=employee_id))
+            return response(_("Employee Not Found"), 404, None,
+                            _("No employee record found for Employee ID {0}. "
+                              "Please contact the IT Helpdesk.").format(employee_id))
 
         leave_approver = frappe.db.get_value("Employee", get_approver(employee), "user_id")
         if not leave_approver:
-            return response("Resource Not Found", 404, None, "No leave approver found for {employee}.".format(employee=employee_id))
+            return response(_("No Leave Approver"), 404, None,
+                            _("No leave approver is set up for your record. Please contact HR."))
 
         if frappe.db.exists("Leave Application", {'employee': employee,'from_date': ['BETWEEN', [from_date, to_date]],'to_date' : ['BETWEEN', [from_date, to_date]]}):
-            return response("Duplicate", 422, None, "Leave application already created for {employee}".format(employee=employee_id))
+            return response(_("Leave Already Applied"), 422, None,
+                            _("You have already applied for leave covering these dates."))
 
         if proof_document_required_for_leave_type(leave_type):
             if not proof_document:
-                return response("Missing", 400, None, "Proof document is required for {leave_type}".format(leave_type=leave_type))
+                return response(_("Proof Document Required"), 400, None,
+                                _("{0} requires a supporting document. "
+                                  "Please attach one and try again.").format(leave_type))
 
             if isinstance(proof_document, dict) :
                 attachment = proof_document.get('attachment')
@@ -329,7 +409,8 @@ def create_new_leave_application(employee_id: str = None, from_date: str = None,
                 attachment = proof_doc_json.get('attachment')
                 attachment_name = proof_doc_json.get('attachment_name')
             if not attachment or not attachment_name:
-                return response('Bad Request', 400, {}, "Proof document key requires attachment and attachment name.")
+                return response(_("Invalid Attachment"), 400, None,
+                                _("Your document could not be read. Please attach it again."))
 
             file_ext = "." + attachment_name.split(".")[-1]
             content = base64.b64decode(attachment)
@@ -343,8 +424,13 @@ def create_new_leave_application(employee_id: str = None, from_date: str = None,
             doc = new_leave_application(employee, from_date, to_date, leave_type, "Open", reason, leave_approver,reliever, resumption_date=resumption_date)
         return response("Success", 201, doc)
     except Exception as error:
-        frappe.log_error(message=frappe.get_traceback(), title='Leave API')
-        return response("Internal Server Error", 500, None, error)
+        frappe.log_error(
+            title=f"Mobile API: leave_application.create_new_leave_application | {employee_id}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(cstr(error)) or type(error).__name__)
     
 def new_leave_application(employee: str, from_date: str,to_date: str,leave_type: str,status:str, reason: str,leave_approver: str,reliever:str, attachments = {}, resumption_date: str = None) -> dict:
     leave = frappe.new_doc("Leave Application")
@@ -399,15 +485,22 @@ def proof_document_required_for_leave_type(leave_type):
 @frappe.whitelist()
 def leave_approver_action(leave_id: str,status: str) -> dict:
     try:
+        if not frappe.db.exists("Leave Application", leave_id):
+            return response(_("Leave Not Found"), 404, None,
+                            _("This leave application no longer exists. "
+                              "Please refresh and try again."))
+
         doc = frappe.get_doc("Leave Application",{"name":leave_id})
         has_leave_approver_role = "Leave Approver" in frappe.get_roles(frappe.session.user)
 
         if not has_leave_approver_role:
-            return response("error", 403, {}, "You are not allowed to approve leave applications")
+            return response(_("Not Allowed"), 403, None,
+                            _("You do not have permission to approve or reject leave applications."))
         
         if doc:
             if not doc.leave_approver in [frappe.session.user, 'administrator']:
-                return response("error", 401, {}, "Unauthorised.")
+                return response(_("Not Allowed"), 401, None,
+                                _("You are not the assigned approver for this leave application."))
             if status == "Approved":
                 doc.status = status
                 doc.save()
@@ -416,15 +509,23 @@ def leave_approver_action(leave_id: str,status: str) -> dict:
                 doc.db_set('workflow_state', 'Rejected')
                 doc.reload()
             else:
-                return response("error", 400, {}, "Expected Approved or Rejected")
+                return response(_("Invalid Action"), 400, None,
+                                _("Please choose either Approve or Reject."))
         else:
-            return response("error", 404, {}, f"Leave ID: {leave_id} not found")
+            return response(_("Leave Not Found"), 404, None,
+                            _("This leave application no longer exists. "
+                              "Please refresh and try again."))
         doc.submit()
         frappe.db.commit()
         return response("Success", 201, doc)
     except Exception as e:
-        frappe.log_error(message=frappe.get_traceback(), title="Leave Application Error")
-        return response("error", 500, {}, str(e))
+        frappe.log_error(
+            title=f"Mobile API: leave_application.leave_approver_action | {leave_id}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(cstr(e)) or type(e).__name__)
 
 @frappe.whitelist()
 def leave_application_list(
@@ -436,10 +537,13 @@ def leave_application_list(
     """
     try:
         if not employee_id:
-            return response("error", 400, {}, "Employee ID is required.")
+            return response(_("Missing Employee ID"), 400, None,
+                            _("Please enter your Employee ID."))
         employee = frappe.get_value("Employee", {"employee_id": employee_id}, ["name", "user_id"], as_dict=1)
         if not employee:
-            return response("error", 404, {}, "No employee record found for {employee_id}".format(employee_id=employee_id))
+            return response(_("Employee Not Found"), 404, None,
+                            _("No employee record found for Employee ID {0}. "
+                              "Please contact the IT Helpdesk.").format(employee_id))
         
         if not(from_date and to_date):
             posting_date = ["BETWEEN", [add_months(getdate(), -2), getdate()]]
@@ -485,7 +589,13 @@ def leave_application_list(
         ]
         return response("success", 200, {"my_leaves":my_leaves, "reports_to": reports_to})
     except Exception as e:
-        return response("error", 500, {}, str(frappe.get_traceback()))
+        frappe.log_error(
+            title=f"Mobile API: leave_application.leave_application_list | {employee_id}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(cstr(e)) or type(e).__name__)
 
 def clean_proof_documents(proof_documents):
     """
@@ -500,6 +610,10 @@ def clean_proof_documents(proof_documents):
 @frappe.whitelist()
 def fetch_proof_document(file_name: str, docname: str, doctype: str) -> dict:
     try:
+        if not frappe.db.exists("File", {"attached_to_name":docname, "attached_to_doctype":doctype, 'file_name':file_name}):
+            return response(_("Document Not Found"), 404, None,
+                            _("This document is no longer available. It may have been removed."))
+
         file_doc = frappe.get_doc("File",{"attached_to_name":docname, "attached_to_doctype":doctype, 'file_name':file_name})
         content = frappe.get_doc("File", file_doc.name).get_content()
         base64EncodedStr = base64.b64encode(content).decode('utf-8')
@@ -510,6 +624,10 @@ def fetch_proof_document(file_name: str, docname: str, doctype: str) -> dict:
         }
         return response("Success", 200, data)
     except Exception as e:
-        frappe.log_error(message=frappe.get_traceback(), title="Fetch Proof Document Error")
-        frappe.respond_as_web_page(_("Error"), e , http_status_code=417)
-        return response("Bad Request", 404, None, "Unable to fetch proof document")
+        frappe.log_error(
+            title=f"Mobile API: leave_application.fetch_proof_document | {docname}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(cstr(e)) or type(e).__name__)

--- a/one_fm/api/v1/notification.py
+++ b/one_fm/api/v1/notification.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe import _
+from frappe.utils import cstr, strip_html
 from one_fm.api.v1.utils import response
 
 @frappe.whitelist()
@@ -26,10 +27,12 @@ def get_notification_list(employee_id: str = None) -> dict:
     """
     try:
         if not employee_id:
-            return response("Bad Request", 400, None, "Employee ID is required")
+            return response(_("Missing Employee ID"), 400, None,
+                            _("Please enter your Employee ID."))
 
         if not isinstance(employee_id, str):
-            return response("Bad Request", 400, None, "Invalid Employee ID format. Please enter a valid value.")
+            return response(_("Invalid Employee ID"), 400, None,
+                            _("Please enter a valid Employee ID."))
 
         site = frappe.local.conf.app_url
 
@@ -37,7 +40,9 @@ def get_notification_list(employee_id: str = None) -> dict:
         employee_user_email = frappe.db.get_value("Employee", {"employee_id": employee_id}, ["user_id"])
 
         if not employee_user_email:
-            return response("Resource not found", 404, None, "No employee email found with {employee_id}".format(employee_id=employee_id))
+            return response(_("No Login Account"), 404, None,
+                            _("No login account is set up for Employee ID {0}. "
+                              "Please contact the IT Helpdesk.").format(employee_id))
         
         notification_list = frappe.get_all("Notification Log", filters={'for_user': employee_user_email, 'one_fm_mobile_app': 1}, fields=["name", "title", "subject", "category", "creation"])
 	
@@ -60,5 +65,10 @@ def get_notification_list(employee_id: str = None) -> dict:
         return response("Success", 200, result)
 
     except Exception as error:
-        frappe.log_error(title="API Notification", message=frappe.get_traceback())
-        return response("Internal Server Error", 500, None, error)
+        frappe.log_error(
+            title=f"Mobile API: notification.get_notification_list | {employee_id}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(cstr(error)) or type(error).__name__)

--- a/one_fm/api/v1/user.py
+++ b/one_fm/api/v1/user.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 import base64
 from datetime import date
 import datetime
@@ -7,7 +8,7 @@ from one_fm.api.api import upload_file
 from pathlib import Path
 import hashlib
 import base64, json
-from frappe.utils import cint, cstr, getdate
+from frappe.utils import cint, cstr, getdate, strip_html
 
 @frappe.whitelist()
 def get_user_details(employee_id: str = None):
@@ -44,47 +45,66 @@ def get_user_details(employee_id: str = None):
 def change_user_profile_image(employee_id: str = None, image: str = None):
 
     if not employee_id:
-        return response("Bad Request", 400, None, "Employee ID is required.")
+        return response(_("Missing Employee ID"), 400, None,
+                        _("Please enter your Employee ID."))
 
     if not isinstance(employee_id, str):
-        return response("Bad Request", 400, None, "Invalid Employee ID format. Please enter a valid value.")
+        return response(_("Invalid Employee ID"), 400, None,
+                        _("Please enter a valid Employee ID."))
 
     if not image:
-        return response("Bad Request", 400, None, "Image required.")
+        return response(_("No Photo Selected"), 400, None,
+                        _("Please choose a photo and try again."))
 
     if not isinstance(image, str):
-        return response("Bad Request", 400, None, "Invalid image format. Please enter a valid value.")
-    
-    content = base64.b64decode(image)
-    filename = hashlib.md5((employee_id + str(datetime.datetime.now())).encode('utf-8')).hexdigest() + ".png"
-    attachment_path = f"/files/profile_image/{employee_id}/{filename}"
-
-    Path(frappe.utils.cstr(frappe.local.site)+f"/public/files/profile_image/{employee_id}").mkdir(parents=True, exist_ok=True)
-    OUTPUT_FILE_PATH = frappe.utils.cstr(frappe.local.site)+f"/public/files/profile_image/{employee_id}/{filename}"
-    
-    with open(OUTPUT_FILE_PATH, "wb") as fh:
-        fh.write(content)
+        return response(_("Invalid Photo"), 400, None,
+                        _("Your photo could not be read. Please choose it again."))
 
     try:
+        try:
+            content = base64.b64decode(image)
+        except Exception:
+            return response(_("Invalid Photo"), 400, None,
+                            _("Your photo could not be read. Please retake it and try again."))
+
+        filename = hashlib.md5((employee_id + str(datetime.datetime.now())).encode('utf-8')).hexdigest() + ".png"
+        attachment_path = f"/files/profile_image/{employee_id}/{filename}"
+
+        Path(frappe.utils.cstr(frappe.local.site)+f"/public/files/profile_image/{employee_id}").mkdir(parents=True, exist_ok=True)
+        OUTPUT_FILE_PATH = frappe.utils.cstr(frappe.local.site)+f"/public/files/profile_image/{employee_id}/{filename}"
+
+        with open(OUTPUT_FILE_PATH, "wb") as fh:
+            fh.write(content)
+
         employee_user = frappe.db.get_value("Employee", {"employee_id": employee_id}, ["user_id"])
 
         if not employee_user:
-            return response("Resource Not Found", 404, None, "No employee record found for {employee_id}".format(employee_id=employee_id))
+            return response(_("Employee Not Found"), 404, None,
+                            _("No employee record found for Employee ID {0}. "
+                              "Please contact the IT Helpdesk.").format(employee_id))
 
         user = frappe.get_doc("User", employee_user)
 
         if not user:
-            return response("Resource Not Found", 404, None, "No user record found for {employee_id}".format(employee_id=employee_id))
+            return response(_("No Login Account"), 404, None,
+                            _("No login account is set up for Employee ID {0}. "
+                              "Please contact the IT Helpdesk.").format(employee_id))
 
         user_image = upload_file(user, "user_image", filename, attachment_path, content, is_private=False)
         user.user_image = user_image.file_url
         user.save()
         frappe.db.commit()
-        
+
         return response("Success", 201, user.as_dict())
-    
+
     except Exception as error:
-        return response("Internal Server Error", 500, None, error)
+        frappe.log_error(
+            title=f"Mobile API: user.change_user_profile_image | {employee_id}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(cstr(error)) or type(error).__name__)
 
 @frappe.whitelist()
 def get_user_roles(employee_id: str = None):
@@ -117,22 +137,29 @@ def get_user_roles(employee_id: str = None):
 def store_fcm_token(employee_id: str = None , fcm_token: str = None, device_os: str = None):
     try:
         if not employee_id:
-            return response("Bad Request", 400, None, "Employee ID is required.")
+            return response(_("Missing Employee ID"), 400, None,
+                            _("Please enter your Employee ID."))
 
         if not fcm_token:
-            return response("Bad Request", 400, None, "FCM token required.")
+            return response(_("Missing Device Token"), 400, None,
+                            _("Your device could not be registered for notifications. Please try again."))
 
         if not device_os:
-            return response("Bad Request", 400, None, "Device OS required.")
+            return response(_("Missing Device Type"), 400, None,
+                            _("Your device could not be registered for notifications. Please try again."))
 
         if not isinstance(employee_id, str):
-            return response("Bad Request", 400, None, "Invalid Employee ID format. Please enter a valid value.")
-        try:
-            employee = frappe.get_doc("Employee", {"employee_id": employee_id})
-        except frappe.exceptions.DoesNotExistError as error:
-            employee = frappe.get_doc("Employee", {"name": employee_id})
-        if not employee:
-            return response("Resource Not Found", 404, None, "No employee record found with {employee_id}".format(employee_id=employee_id))
+            return response(_("Invalid Employee ID"), 400, None,
+                            _("Please enter a valid Employee ID."))
+
+        employee_name = frappe.db.get_value("Employee", {"employee_id": employee_id}, "name") \
+            or frappe.db.get_value("Employee", {"name": employee_id}, "name")
+        if not employee_name:
+            return response(_("Employee Not Found"), 404, None,
+                            _("No employee record found for Employee ID {0}. "
+                              "Please contact the IT Helpdesk.").format(employee_id))
+
+        employee = frappe.get_doc("Employee", employee_name)
         
         
         employee.db_set('device_os',device_os)
@@ -142,6 +169,11 @@ def store_fcm_token(employee_id: str = None , fcm_token: str = None, device_os: 
         return response("Success", 201, employee.as_dict())
 
     except Exception as error:
-        frappe.log_error(title="API FCM Token", message=frappe.get_traceback())
-        return response("Internal Server Error", 500, None, error)
+        frappe.log_error(
+            title=f"Mobile API: user.store_fcm_token | {employee_id}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(cstr(error)) or type(error).__name__)
     

--- a/one_fm/api/v1/utils.py
+++ b/one_fm/api/v1/utils.py
@@ -1,5 +1,6 @@
 import frappe, datetime, requests
-from frappe.utils import getdate, cint, cstr, random_string, now_datetime
+from frappe import _
+from frappe.utils import getdate, cint, cstr, random_string, now_datetime, strip_html
 
 def response(message, status_code, data=None, error=None):
     """This method generates a response for an API call with appropriate data and status code.
@@ -147,16 +148,27 @@ def enrollment_status(employee_id: str = None) -> dict:
     :return: True or False
     """
     try:
+        if not employee_id:
+            return response(_("Missing Employee ID"), 400, None,
+                            _("Please enter your Employee ID."))
+
         get_employee = get_employee_by_id(employee_id)
         if get_employee.status:
             employee = frappe.get_doc("Employee", get_employee.message.name)
             if employee.enrolled:
-                return response(message="Employee is enrolled on the mobile app.", status_code=200, data={'enrolled':True}, error=None)
-            return response(message="Employee is not enrolled.", status_code=200, data={'enrolled':False}, error=None)
+                return response(message=_("Employee is enrolled on the mobile app."), status_code=200, data={'enrolled':True}, error=None)
+            return response(message=_("Employee is not enrolled."), status_code=200, data={'enrolled':False}, error=None)
         else:
-            return response(message=get_employee.message, status_code=get_employee.http_status_code, data={'status':False}, error=None)
+            return response(_("Employee Not Found"), get_employee.http_status_code,
+                            None, get_employee.message)
     except Exception as e:
-        return response(message=str(e), status_code=500, data={'status':False}, error=str(e))
+        frappe.log_error(
+            title=f"Mobile API: utils.enrollment_status | {employee_id}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(str(e)) or type(e).__name__)
 
 @frappe.whitelist()
 def update_employee(employee_id, field, value):
@@ -212,16 +224,35 @@ def log_error_via_api(traceback: str, message: str, medium: str):
 @frappe.whitelist()
 def google_map_api():
     try:
-        return response("success", 200, {
-            "google_map_api":frappe.db.get_single_value("Google Settings", "api_key")})
+        api_key = frappe.db.get_single_value("Google Settings", "api_key")
+        if not api_key:
+            return response(_("Map Unavailable"), 500, None,
+                            _("The map service is not configured. Please contact the IT Helpdesk."))
+        return response("success", 200, {"google_map_api": api_key})
     except Exception as e:
-        return response("error", 500, {}, str(e))
-    
+        frappe.log_error(
+            title=f"Mobile API: utils.google_map_api | {frappe.session.user}",
+            message=frappe.get_traceback(),
+        )
+        frappe.db.commit()
+        return response(_("Something Went Wrong"), 500, None,
+                        strip_html(str(e)) or type(e).__name__)
+
 
 def verify_via_face_recogniton_service(url: str, data: dict, files: dict) -> tuple:
     decrypt_video = 1 if type(files.get('video_file'))==str else 0
     data['decrypt_video'] = decrypt_video
-    res = requests.post(url=url, data=data, files=files)
+
+    try:
+        res = requests.post(url=url, data=data, files=files, timeout=60)
+    except requests.exceptions.RequestException:
+        frappe.log_error(
+            title=f"Mobile API: face recognition service unreachable | {frappe.session.user}",
+            message=frappe.get_traceback(),
+        )
+        return False, _("Face verification is temporarily unavailable. Please try again in a "
+                        "few minutes, or contact your Site Supervisor.")
+
     if res.status_code == 200:
         api_response = res.json()
         if api_response.get("error"):
@@ -230,7 +261,9 @@ def verify_via_face_recogniton_service(url: str, data: dict, files: dict) -> tup
             frappe.log_error(title=f"Error from face recognition system -- {frappe.session.user}", message=f"{traceback} -- {message}")# if traceback else None
             return False, message
         return True, ""
-    return False, "Facial Recogniton Service is currently available"
+
+    return False, _("Face verification is temporarily unavailable. Please try again in a "
+                    "few minutes, or contact your Site Supervisor.")
 
 def resolve_active_user(user_id, max_depth=5):
     """


### PR DESCRIPTION
## Why

Mobile users report that errors are generic and confusing. The cause is structural: almost
every failure path set the response `message` to an HTTP status word and put the real sentence
in `error`.

    return response("Bad Request", 400, None, "Please enter your Employee ID.")

The app renders `message` as the toast header and `error` as the body, so users saw
**"Bad Request"**, **"Resource Not Found"**, **"Internal Server Error"** or the bare word
**"error"**. Worse, 17 handlers passed the raw exception object as `error`, producing Python
reprs such as `'NoneType' object has no attribute 'name'`, and one returned the full
traceback to the phone.

Full findings: `docs/mobile-api-error-message-audit.md`.

## What changed

`one_fm.api.v1.utils.response(message, status_code, data, error)` is **unchanged** - this is
entirely a change to call sites. Every failure now follows one shape:

| Field | Contains |
|---|---|
| `message` | short title, 2-4 words - the toast header |
| `error` | the actionable sentence - the toast body |
| `data` | `None` on failures (`response()` writes `data` **or** `error`, never both) |

    return response(_("Missing Employee ID"), 400, None,
                    _("Please enter your Employee ID."))

Every `except` block now calls `frappe.log_error()` with a searchable title
(`Mobile API: <module>.<function> | <employee_id>`) followed by `frappe.db.commit()`, then
returns the exception message as the toast body. All user-facing strings are wrapped in `_()`.

**Why the commit is required:** `frappe.app.sync_database()` rolls back every request that is
not POST/PUT/DELETE/PATCH, and Error Log has no auto-commit. Without it the log row is
discarded before the response is sent, and 20 of the 50 mobile endpoints are GET.

## Endpoints covered - 25 of 50

| File | Rows | Endpoints |
|---|---|---|
| `api/v1/authentication.py` | 1, 2, 4, 5, 6 | `user_login`, `enrollment_status`, `forgot_password`, `verify_otp`, `change_password` |
| `api/v1/face_recognition.py` | 7, 8, 9, 14 | `get_site_location`, `checkin_list`, `verify_checkin_checkout`, `enroll` |
| `api/v1/leave_application.py` | 15-23 | all nine leave endpoints |
| `api/v1/user.py` | 26, 28 | `store_fcm_token`, `change_user_profile_image` |
| `api/v1/notification.py` | 25 | `get_notification_list` |
| `api/v1/utils.py` | 3, 50 | `enrollment_status`, `google_map_api` |
| `api/api.py` | 24, 27 | `get_user_details`, `push_notification_rest_api_for_checkin` |

