### PR TITLE
fix: read assurance level API base URL from Bumblebee Settings

### DIFF
--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -3901,8 +3901,9 @@ def call_to_get_assurance_level(employees):
     response = None
     try:
         api_key = frappe.conf.bulbul_api_wrapper_key
+        api_wrapper_base_url = frappe.db.get_single_value("Bumblebee Settings", "end_user_api_base_url")
         if isinstance(employees, str):
-            url = f"https://staging-apiwrapper.one-fm.com/api/DigitalSigning/CheckMobileIdentity/{employees}"
+            url = f"{api_wrapper_base_url}/api/DigitalSigning/CheckMobileIdentity/{employees}"
             headers = {'accept': 'text/plain','ApiKey': f'{api_key}'}
             response = requests.get(url, headers=headers, timeout=30)
             if response.status_code == 200:
@@ -3915,7 +3916,7 @@ def call_to_get_assurance_level(employees):
                 )
                 return {"error": response.status_code, "title": response.text}
         else:
-            url = f"https://staging-apiwrapper.one-fm.com/api/DigitalSigning/BulkCheckMobileIdentity"
+            url = f"{api_wrapper_base_url}/api/DigitalSigning/BulkCheckMobileIdentity"
             headers = {'Content-Type': 'application/json','ApiKey': f'{api_key}'}
             batch_size=200
             all_results = []


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
The daily `update_active_employees_assurance_level` scheduled job (which refreshes each Employee's `custom_civil_id_assurance_level` via the Bulbul assurance API) has been completing "successfully" in every environment, including production, without ever actually updating any Employee record. The job's Scheduled Job Log shows `Complete` because API failures are caught and logged internally rather than raised, which is why this went unnoticed.

Root cause: `call_to_get_assurance_level()` in `one_fm/utils.py` had the Bulbul apiwrapper host hardcoded to `staging-apiwrapper.one-fm.com`. In production this results in `ConnectionRefusedError` (confirmed via a production Error Log traceback), since production infrastructure has no route to the staging host.


## Analysis and design (optional)
Traced from a production `Scheduled Job Log` entry (`status: Complete`) for `utils.update_active_employees_assurance_level` down to zero Employee records having `custom_civil_id_assurance_level` populated. Found that:
- `update_assurance_level_task()` swallows API failures (`isinstance(verification_level, list)` check fails → logs an `Error Log` → returns `False`) without raising, so the scheduler always records `Complete`.
- The actual API failure (33 occurrences in this repo's local Error Log history) traces to `call_to_get_assurance_level()` calling a hardcoded `https://staging-apiwrapper.one-fm.com` URL instead of the environment-appropriate host.
- The working DSS digital-signature flow (`bumblebee/api/v1/gcpnext/digital_signature.py`) already solves this correctly by reading the host from `Bumblebee Settings.end_user_api_base_url` — this PR brings `call_to_get_assurance_level()` in line with that existing pattern instead of inventing a new config mechanism.


## Solution description
In `one_fm/utils.py`, `call_to_get_assurance_level()`:
- Added `api_wrapper_base_url = frappe.db.get_single_value("Bumblebee Settings", "end_user_api_base_url")`.
- Replaced both hardcoded `https://staging-apiwrapper.one-fm.com` URLs (single-employee `CheckMobileIdentity` path and bulk `BulkCheckMobileIdentity` path) with `f"{api_wrapper_base_url}/..."`.
- Used `frappe.db.get_single_value` rather than `frappe.get_single`/`frappe.get_doc` deliberately — it reads straight from the Singles table and doesn't require the `Bumblebee Settings` document controller to import cleanly.

No changes to `update_assurance_level_task()` itself, error handling, or the scheduler registration in `hooks.py` — those were already correct; only the URL source was wrong.


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No

(Change is confined to a utility function in `one_fm/utils.py`; no doctype controller was modified.)


## Output screenshots (optional)
N/A — backend/API-only change, no UI affected.


## Areas affected and ensured
- `one_fm.utils.call_to_get_assurance_level()` — both call shapes (single employee / bulk list).
- `one_fm.utils.update_assurance_level_task()` — the daily scheduled job that is the only **active** caller (`hooks.py` → `scheduler_events.daily`).
- `one_fm.overrides.employee.get_assurance_level_of_employee()` — the other caller of `call_to_get_assurance_level()`; confirmed this is **dead code** today (its call site in `Employee.before_save` is commented out), so it's unaffected in practice but will pick up the same fix if ever re-enabled.
- Does **not** touch the DSS digital-signing flow in the `bumblebee` app, which already read the base URL from `Bumblebee Settings` correctly.


## Is there any existing behavior change of other features due to this code change?
Yes. The assurance-level API calls now target whatever host is configured in `Bumblebee Settings.end_user_api_base_url` instead of the hardcoded staging host.
- On environments where `bumblebee` is installed and `end_user_api_base_url` is set (e.g. production, where the DSS signing flow already depends on this same setting) — this fixes the job, no other behavior change.
- On environments where `bumblebee` is **not installed** (confirmed: local dev site `onefm.localhost`), `frappe.db.get_single_value("Bumblebee Settings", ...)` now raises `DocType Bumblebee Settings not found` instead of attempting (and failing) an HTTP call to the staging host. Net effect is the same — the job still fails gracefully and logs an Error Log either way — but the failure reason changes.


## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

Verified against real `Employee` records on `onefm.localhost` (1,609 active employees, 1,418 matching the job's selection filters) to confirm the query side of the job was never the issue. Did **not** get an end-to-end successful API round trip locally, since this dev site has neither `bumblebee` installed nor network access to any apiwrapper host — the fix targets the production failure mode specifically (confirmed via a production traceback showing `ConnectionRefusedError` against the old hardcoded host).


## Was child table created?
No.
- [ ] is attachment required?
      (N/A)

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No

Pure code-logic change; no schema/data migration needed.


## Which browser(s) did you use for testing?
N/A — backend/API-only change, no browser UI involved.
