### PR TITLE
Medical Insurance: open the transfer MOI instead of raising AttributeError

### DIFF
--- a/one_fm/grd/doctype/residency/residency.py
+++ b/one_fm/grd/doctype/residency/residency.py
@@ -202,13 +202,19 @@ def set_employee_list_for_moi(preparation_name):
                     frappe.log_error(message=frappe.get_traceback(), title=f"Error creating MOI for Employee {employee.employee} in Preparation {preparation_name}")
                     continue
 
-# Creat moi for transfer
-def creat_moi_for_transfer(work_permit_name):
+# Open the MOI for a transferred employee, called when their Medical Insurance is
+# marked Done. Named "creat_moi_for_transfer" until the module was renamed from
+# moi_residency_jawazat to residency: that refactor corrected the spelling at the call
+# site but not here, so every Local Transfer insurance raised AttributeError on submit
+# and the MOI was never opened.
+def create_moi_for_transfer(work_permit_name):
     work_permit = frappe.get_doc('Work Permit',work_permit_name)
     if work_permit:
         employee = frappe.get_doc('Employee',work_permit.employee)
         if employee:
-            create_moi_record(frappe.get_doc('Employee',employee.employee),"Transfer")
+            # The employee is already loaded; re-fetching it through its own mirror
+            # field only risked a second lookup failing.
+            create_moi_record(employee,"Transfer")
 
 def create_moi_record(employee,Renewal_or_Extend,preparation_name = None):
 

--- a/one_fm/tests/test_medical_insurance_transfer_moi.py
+++ b/one_fm/tests/test_medical_insurance_transfer_moi.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""Marking a Local Transfer's Medical Insurance Done opens the employee's MOI.
+
+Reported from testing on MI-2026-00343: submitting threw
+
+    AttributeError: module 'one_fm.grd.doctype.residency.residency' has no
+    attribute 'create_moi_for_transfer'. Did you mean: 'creat_moi_for_transfer'?
+
+The call site was corrected when the module was renamed from moi_residency_jawazat
+to residency; the function itself was not.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.grd.doctype.medical_insurance.medical_insurance import MedicalInsurance
+from one_fm.grd.doctype.residency.residency import create_moi_for_transfer
+
+
+class TestTheCallResolves(FrappeTestCase):
+	def test_the_name_the_caller_uses_exists(self):
+		"""The whole bug: two spellings, and nothing joined them up."""
+		from one_fm.grd.doctype.residency import residency
+
+		self.assertTrue(callable(getattr(residency, "create_moi_for_transfer", None)))
+
+	def test_the_caller_still_calls_it_by_that_name(self):
+		"""Pinned on the source: correcting one side and not the other is what broke
+		this in the first place."""
+		import inspect
+
+		source = inspect.getsource(MedicalInsurance.recall_create_moi_transfer)
+
+		self.assertIn("residency.create_moi_for_transfer", source)
+
+	def test_the_misspelling_is_gone_rather_than_aliased(self):
+		from one_fm.grd.doctype.residency import residency
+
+		self.assertFalse(hasattr(residency, "creat_moi_for_transfer"))
+
+
+class TestItOpensTheMoi(FrappeTestCase):
+	"""End to end from a real Local Transfer Work Permit, rolled back by the suite."""
+
+	def setUp(self):
+		self.work_permit = frappe.db.get_value(
+			"Work Permit", {"work_permit_type": "Local Transfer", "employee": ["is", "set"]},
+			"name", order_by="creation desc",
+		)
+		if not self.work_permit:
+			self.skipTest("no Local Transfer Work Permit on this instance")
+		self.employee = frappe.db.get_value("Work Permit", self.work_permit, "employee")
+
+	def moi_names(self):
+		return set(frappe.get_all("Residency", {"employee": self.employee}, pluck="name"))
+
+	def test_a_transfer_moi_is_raised_for_the_permits_employee(self):
+		before = self.moi_names()
+
+		create_moi_for_transfer(self.work_permit)
+
+		new = self.moi_names() - before
+		self.assertEqual(len(new), 1)
+
+		moi = frappe.get_doc("Residency", new.pop())
+		self.assertEqual(moi.employee, self.employee)
+		self.assertEqual(moi.category, "Transfer")
+		self.assertEqual(moi.renewal_or_extend, "Transfer")
+
+	def test_it_is_dated_today_rather_than_counted_back_from_an_expiry(self):
+		"""A transfer has no expiry to count back from - MOI_CATEGORY_BY_ACTION gives
+		"Transfer" no offset, so the application is dated the day it is raised."""
+		before = self.moi_names()
+
+		create_moi_for_transfer(self.work_permit)
+
+		moi = frappe.get_doc("Residency", (self.moi_names() - before).pop())
+		self.assertEqual(str(moi.date_of_application), frappe.utils.today())


### PR DESCRIPTION
Reported from testing on **MI-2026-00343** — marking a Local Transfer's Medical Insurance *Done* threw:

```
AttributeError: module 'one_fm.grd.doctype.residency.residency' has no attribute
'create_moi_for_transfer'. Did you mean: 'creat_moi_for_transfer'?
```

## Cause

Two spellings, and nothing joined them up:

| | |
|---|---|
| `medical_insurance.py:49` | `residency.create_moi_for_transfer(...)` |
| `residency.py:206` | `def creat_moi_for_transfer(...)` |

`git log -L` puts it on `b1b4b1b5e` *"refactor: moi_residency_jawazat to residency"* — that commit renamed the module and **corrected the spelling at the call site but not at the definition**. The call has been dead ever since, so every Local Transfer insurance failed on submit and the employee's MOI was never opened. Pre-existing on staging, not introduced by the WI-001828 work.

## Fix

The **function** is renamed rather than the caller reverted — one definition, one caller, and the typo goes with it instead of being preserved.

Also dropped a re-fetch of the employee through its own mirror field: the document was already loaded a line above, and `frappe.get_doc('Employee', employee.employee)` would have failed outright on any record where that field is blank.

## Verified

Reproduced on the reported record. `MI-2026-00343` now submits and raises the Transfer MOI for `HR-EMP-00036`, dated today (a transfer has no expiry to count back from, so `MOI_CATEGORY_BY_ACTION` gives "Transfer" no offset). Rolled back after checking.

5 tests: three pin the two spellings against drifting apart again, two go end to end from a real Local Transfer Work Permit. Mutation-checked — restoring the typo fails the module import by name.

> **Note on this branch:** its WI-001828 commits were squash-merged in #6647, so it was carrying nine stale commits and was behind staging. I reset it onto current staging first — the PR is this one fix alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)