### PR TITLE
Residency: record the attachment without re-validating the whole Employee

### DIFF
--- a/one_fm/grd/doctype/residency/residency.py
+++ b/one_fm/grd/doctype/residency/residency.py
@@ -12,6 +12,7 @@ from frappe.core.doctype.communication.email import make
 from frappe.utils import get_datetime, add_to_date, getdate, get_link_to_form, now_datetime, nowdate, cstr
 from one_fm.grd.doctype.paci import paci
 from one_fm.utils import is_scheduler_emails_enabled
+from one_fm.grd.utils import attach_employee_document
 
 class Residency(Document):
     company = frappe.db.get_value("Company", frappe.defaults.get_global_default('company'), 
@@ -118,43 +119,27 @@ class Residency(Document):
     def set_residency_expiry_new_date_in_employee_doctype(self):
         """
         runs: `on_submit`
-        This method to sort records of employee documents upon document name;
-        First, get the employee document child table.
-        second, find index of the document.
-        Third, set the new document.
-        After that, clear the child table and append the new order
-        """
-        today = date.today()
-        Find = False
-        employee = frappe.get_doc('Employee', self.employee)
-        document_dic = frappe.get_list('Employee Document',
-            fields={'attach','document_name','issued_on','valid_till'},
-            filters={'parent':self.employee}, ignore_permissions=True
-        )
-        for index,document in enumerate(document_dic):
-            if document.document_name == "Residency Expiry Attachment":
-                Find = True
-                break
-        if Find:
-            document_dic.insert(index,{
-                "attach": self.residency_attachment,
-                "document_name": "Residency Expiry Attachment",
-                "issued_on":today,
-                "valid_till": self.new_residency_expiry_date
-            })
-            employee.set('one_fm_employee_documents',[]) #clear the child table
-            for document in document_dic:                # append new arrangements
-                employee.append('one_fm_employee_documents',document)
+        Record the new residency attachment and expiry date on the Employee.
 
-        if not Find:
-            employee.append("one_fm_employee_documents", {
-            "attach": self.residency_attachment,
-            "document_name": "Residency Expiry Attachment",
-            "issued_on":today,
-            "valid_till":self.new_residency_expiry_date
-            })
-        employee.residency_expiry_date = self.new_residency_expiry_date
-        employee.save()
+        The two facts are written directly rather than through a full save of the
+        Employee, which re-validates every field on it - so completing a Residency
+        failed on data that has nothing to do with it: 1,124 employees hold a Marital
+        Status the field's options no longer accept ("Single", "Divorced", "Widowed").
+
+        The old version rebuilt the whole child table to keep it ordered, and inserted
+        the new row beside the existing one rather than over it, so every renewal left
+        another Residency Expiry Attachment behind. The helper updates the row in place.
+        """
+        attach_employee_document(
+            self.employee,
+            document_name="Residency Expiry Attachment",
+            attach=self.residency_attachment,
+            valid_till=self.new_residency_expiry_date,
+            issued_on=date.today(),
+        )
+        frappe.db.set_value(
+            "Employee", self.employee, "residency_expiry_date", self.new_residency_expiry_date
+        )
 
     def get_passport_arabic(self, passport):
         return {'Normal':'طبيعي','Diplomat':'دبلوماسي'}.get(passport)

--- a/one_fm/grd/utils.py
+++ b/one_fm/grd/utils.py
@@ -94,3 +94,56 @@ def map_to_mgrp(source_name, target_doc=None):
     }, target_doc)
     return doc
 
+
+
+def next_employee_document_idx(employee):
+    """The idx a new Employee Document row should take.
+
+    A raw insert does not get the ordering a child table append would, so it is worked
+    out here rather than left at 0, where two rows would tie.
+    """
+    last = frappe.db.get_value(
+        "Employee Document",
+        {"parent": employee, "parenttype": "Employee"},
+        "idx",
+        order_by="idx desc",
+    )
+    return (last or 0) + 1
+
+
+def attach_employee_document(employee, document_name, attach, valid_till, issued_on=None):
+    """Record a government document on an Employee, without saving the whole Employee.
+
+    ``employee.append(...)`` followed by ``employee.save()`` drags the entire Employee
+    record through validation, so a GRD document could not be completed because of data
+    that has nothing to do with it - 1,124 employees hold a Marital Status the field's
+    options no longer accept ("Single", "Divorced", "Widowed"), and any full save of one
+    throws. This writes the one row it actually has and nothing else.
+
+    An existing row for the same ``document_name`` is updated rather than joined by a
+    second one, so a renewal replaces what it renews instead of stacking up.
+    """
+    values = {
+        "attach": attach,
+        "issued_on": issued_on or today(),
+        "valid_till": valid_till,
+    }
+
+    existing = frappe.db.exists(
+        "Employee Document", {"parent": employee, "document_name": document_name}
+    )
+    if existing:
+        frappe.db.set_value("Employee Document", existing, values)
+        return existing
+
+    row = frappe.get_doc({
+        "doctype": "Employee Document",
+        "parent": employee,
+        "parenttype": "Employee",
+        "parentfield": "one_fm_employee_documents",
+        "idx": next_employee_document_idx(employee),
+        "document_name": document_name,
+        **values,
+    })
+    row.db_insert()
+    return row.name

--- a/one_fm/tests/test_grd_employee_documents.py
+++ b/one_fm/tests/test_grd_employee_documents.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""Recording a government document on an Employee without saving the whole Employee.
+
+Reported from testing on MOI-2026-00369: completing a Residency threw
+
+    Marital Status cannot be "Single". It should be one of "Unmarried", "Married",
+    "Widow", "Divorce", "Unknown"
+
+The Residency has nothing to do with marital status. It failed because it wrote its
+attachment through ``employee.save()``, which re-validates every field on the Employee -
+and most of the fleet holds a Marital Status the field's current options reject.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.grd.utils import attach_employee_document, next_employee_document_idx
+
+DOCUMENT = "Residency Expiry Attachment"
+
+
+class TestAttachingAnEmployeeDocument(FrappeTestCase):
+	def setUp(self):
+		self.employee = frappe.db.get_value("Employee", {"status": "Active"}, "name")
+		if not self.employee:
+			self.skipTest("no Active Employee on this instance")
+
+	def rows(self, document_name=DOCUMENT):
+		return frappe.get_all(
+			"Employee Document",
+			filters={"parent": self.employee, "document_name": document_name},
+			fields=["name", "attach", "valid_till", "idx"],
+			order_by="idx",
+		)
+
+	def test_a_document_the_employee_does_not_have_is_added(self):
+		name = f"Test Doc {frappe.generate_hash(length=6)}"
+		self.addCleanup(
+			frappe.db.delete, "Employee Document", {"parent": self.employee, "document_name": name}
+		)
+
+		attach_employee_document(
+			self.employee, document_name=name, attach="/private/files/x.pdf",
+			valid_till="2027-01-01",
+		)
+
+		rows = self.rows(name)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0].attach, "/private/files/x.pdf")
+
+	def test_it_takes_the_next_row_number(self):
+		"""A raw insert gets no idx of its own; two rows at 0 would tie."""
+		name = f"Test Doc {frappe.generate_hash(length=6)}"
+		self.addCleanup(
+			frappe.db.delete, "Employee Document", {"parent": self.employee, "document_name": name}
+		)
+		expected = next_employee_document_idx(self.employee)
+
+		attach_employee_document(
+			self.employee, document_name=name, attach="/private/files/x.pdf",
+			valid_till="2027-01-01",
+		)
+
+		self.assertEqual(self.rows(name)[0].idx, expected)
+
+	def test_a_renewal_replaces_the_row_it_renews(self):
+		"""The old code inserted the new row beside the existing one and kept both, so
+		every renewal left another copy behind."""
+		name = f"Test Doc {frappe.generate_hash(length=6)}"
+		self.addCleanup(
+			frappe.db.delete, "Employee Document", {"parent": self.employee, "document_name": name}
+		)
+		attach_employee_document(
+			self.employee, document_name=name, attach="/private/files/old.pdf",
+			valid_till="2026-01-01",
+		)
+
+		attach_employee_document(
+			self.employee, document_name=name, attach="/private/files/new.pdf",
+			valid_till="2027-01-01",
+		)
+
+		rows = self.rows(name)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0].attach, "/private/files/new.pdf")
+		self.assertEqual(str(rows[0].valid_till), "2027-01-01")
+
+	def test_it_does_not_drag_the_employee_through_validation(self):
+		"""The whole point. An Employee holding a Marital Status the options no longer
+		accept can still be given a document - which is what a GRD clerk needs."""
+		name = f"Test Doc {frappe.generate_hash(length=6)}"
+		self.addCleanup(
+			frappe.db.delete, "Employee Document", {"parent": self.employee, "document_name": name}
+		)
+		was = frappe.db.get_value("Employee", self.employee, "marital_status")
+		self.addCleanup(
+			frappe.db.set_value, "Employee", self.employee, "marital_status", was,
+			update_modified=False,
+		)
+		frappe.db.set_value(
+			"Employee", self.employee, "marital_status", "Not A Valid Option",
+			update_modified=False,
+		)
+
+		attach_employee_document(
+			self.employee, document_name=name, attach="/private/files/x.pdf",
+			valid_till="2027-01-01",
+		)
+
+		self.assertEqual(len(self.rows(name)), 1)
+
+	def test_a_full_employee_save_would_have_failed_there(self):
+		"""What makes the test above meaningful rather than a tautology."""
+		was = frappe.db.get_value("Employee", self.employee, "marital_status")
+		self.addCleanup(
+			frappe.db.set_value, "Employee", self.employee, "marital_status", was,
+			update_modified=False,
+		)
+		frappe.db.set_value(
+			"Employee", self.employee, "marital_status", "Not A Valid Option",
+			update_modified=False,
+		)
+
+		doc = frappe.get_doc("Employee", self.employee)
+		with self.assertRaises(frappe.ValidationError):
+			doc.save(ignore_permissions=True)
+
+
+class TestTheResidencyUsesIt(FrappeTestCase):
+	def test_completing_a_residency_no_longer_saves_the_whole_employee(self):
+		"""Pinned on the source: a full save is what broke this."""
+		import inspect
+
+		from one_fm.grd.doctype.residency.residency import Residency
+
+		method = Residency.set_residency_expiry_new_date_in_employee_doctype
+		# The docstring explains the save it replaced, so only the body is inspected.
+		body = inspect.getsource(method).replace(method.__doc__ or "", "")
+
+		self.assertIn("attach_employee_document", body)
+		self.assertNotIn("employee.save()", body)


### PR DESCRIPTION
Reported from testing on **MOI-2026-00369** — transitioning a Residency to Completed threw:

```
Marital Status cannot be "Single". It should be one of "Unmarried", "Married",
"Widow", "Divorce", "Unknown"
```

## Cause

A Residency has nothing to do with marital status. It failed because it recorded its attachment through `employee.save()`, which re-validates **every** field on the Employee.

A Property Setter added on **2026-08-12 00:57** narrowed the Marital Status options to the PAM vocabulary without migrating the data, so **1,124 of the 2,030** employees who have a value now hold one the field rejects. Any full save of one of them throws, whatever the caller was actually trying to write.

## Fix

The two facts it has — the document row and the expiry date — are written directly, the way the PACI completion already does since WI-001830. Extracted as `grd.utils.attach_employee_document` so there is one of it rather than a third copy.

**Also fixes a duplicate.** The old version inserted the new row *beside* the existing Residency Expiry Attachment and kept both, so every renewal left another copy behind — the employee on the reported record already carries two. The helper updates the row in place.

## Verified

On `MOI-2026-00369` (`HR-EMP-02434`, marital status "Single"): it submits, the attachment row is **updated rather than added** (2 rows stay 2), and `residency_expiry_date` lands on the Employee. Rolled back after checking.

6 tests, mutation-checked — restoring the full save fails by name. One of them asserts a full `employee.save()` *would* still fail there, so the test above is not a tautology.

## Deliberately not in this PR

**The Marital Status vocabulary itself**, because it is a decision rather than a bug fix. The app's own registered patch `standardize_employee_marital_status_options` maps `Unmarried -> Single` and is what the data follows (1,121 Single vs 97 Unmarried); the new Property Setter — which is *not* in `custom/property_setter/employee.py` — points the other way. Whichever wins, it wants doing on purpose.

The same full-save trap is still live at `work_permit.py:375` and `:397`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)