### PR TITLE
Fix assurance level bulk check timing out on large batches

### DIFF
--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -3928,12 +3928,12 @@ def call_to_get_assurance_level(employees):
         else:
             url = f"{api_wrapper_base_url}/api/DigitalSigning/BulkCheckMobileIdentity"
             headers = {'Content-Type': 'application/json','ApiKey': f'{api_key}'}
-            batch_size=200
+            batch_size=100
             all_results = []
             for i in range(0, len(employees), batch_size):
                 batch = employees[i:i + batch_size]
                 try:
-                    response = requests.post(url, headers=headers, json=batch, timeout=60)
+                    response = requests.post(url, headers=headers, json=batch, timeout=180)
                     if response.status_code == 200:
                         data = response.json()
                         batch_result = data.get("data", [])


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
The bulk PACI verification-level check (`call_to_get_assurance_level`, used by the daily `update_active_employees_assurance_level` scheduled job) was failing with `requests.exceptions.ReadTimeout` on production when processing large batches of employees against the on-prem API wrapper's `BulkCheckMobileIdentity` endpoint.

## Analysis and design (optional)
Reproduced by manually triggering the scheduled job on production via `bench console`/browser call and observing the actual traceback: the request to `apiwrapper.one-fm.com` succeeded at the connection level (TLS handshake completed fine — this is not a network/firewall issue), but the server didn't finish responding within the hardcoded 60-second timeout. Batches of up to 200 employees each require the API wrapper to make a real, sequential round-trip to PACI's government service per employee, which can plausibly exceed 60 seconds combined for a full batch.

## Solution description
In `call_to_get_assurance_level()` (`apps/one_fm/one_fm/utils.py`):
- Increased the per-batch `requests.post(...)` timeout from `60` to `180` seconds, giving more headroom for PACI's per-employee response latency.
- Reduced `batch_size` from `200` to `100`, so each individual request has less work to do and is less likely to approach the timeout ceiling at all.
- No other logic changed — batching, error handling, and result aggregation behavior are unchanged; this is purely a timing/sizing adjustment.

(Note for reviewers: the overall scheduled job already has a 30-minute timeout at the `frappe.enqueue` level, so smaller, more numerous batches with a longer per-batch timeout still comfortably fit within that ceiling.)

## Is there a business logic within a doctype?
- [x] No

(This is a utility function change only — no doctype controller logic was added or modified. The function does eventually call `frappe.db.set_value` on Employee's `custom_civil_id_assurance_level`, but that logic is unchanged by this PR.)

## Output screenshots (optional)
N/A — backend-only change, no UI affected.

## Areas affected and ensured
- `call_to_get_assurance_level()` in `one_fm/utils.py` — the only function changed.
- Affects the daily `update_active_employees_assurance_level` scheduled job, and any other future callers of the bulk verification check.
- No effect on the single-civil-ID code path (`isinstance(employees, str)` branch), which already uses its own separate 30-second timeout and was not touched.

## Is there any existing behavior change of other features due to this code change?
No. This only adjusts timing/batch-size parameters for an existing HTTP call — the data processed, the fields updated, and the overall logic flow are unchanged.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

(Reproduced the original failure against real production data by manually triggering the job. ⚠️ **The fix itself has not yet been re-tested against production** — recommend re-running the scheduled job after this is deployed to confirm the timeout no longer occurs before merging/closing this out.)

## Was child table created?
- [ ] No child table — N/A for attachment sub-questions.

## Did you delete custom field?
- [ ] No

## Is patch required?
- [ ] No

(Plain code/logic change — no schema or data migration involved.)

## Which browser(s) did you use for testing?
N/A — this is a server-side/backend fix with no browser-facing UI component. The original failure was reproduced by triggering the job via `bench console`, not through browser-based testing.