### PR TITLE
Preparation: queue the costing mail instead of failing the submit on it

### DIFF
--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -192,18 +192,18 @@ class Preparation(Document):
             subject = 'Records are created for WP, MI, MOI, PACI, and FP'
             create_notification_log(subject, message, [self.grd_operator], self)
 
-        inform_the_costing_to = frappe.db.get_single_value('HR Settings', 'inform_the_costing_to')
-        if inform_the_costing_to:
-            page_link = get_url(self.get_url())
-            message = "<p>Records are created<a href='{0}'>{1}</a>.</p>".format(page_link, self.name)
-            subject = 'Details of the Preparation Cost for WP, MI, MOI, PACI, and FP'
-            print_format = frappe.db.get_single_value('HR Settings', 'costing_print_format')
-            if not print_format:
-                print_format = 'Standard'
-            attachments = [frappe.attach_print(self.doctype, self.name, file_name=self.name, print_format=print_format)]
-            send_email(self, [inform_the_costing_to], message, subject, attachments)
-
-   
+        # The costing mail renders a PDF and hands it to the mail server, and neither belongs
+        # inside the submit transaction. wkhtmltopdf died with SIGSEGV on staging and took the
+        # whole submit down with it - but the Work Permit, Medical Insurance, MOI and PACI
+        # records created above each commit as they go, so they survived while the Preparation
+        # rolled back to draft, and re-submitting created them a second time. Queued after the
+        # commit so a broken PDF is an Error Log entry, not a failed submit.
+        frappe.enqueue(
+            'one_fm.grd.doctype.preparation.preparation.send_costing_notification',
+            queue='short',
+            enqueue_after_commit=True,
+            preparation=self.name
+        )
 
     @frappe.whitelist()
     def set_renewal_for_all_preparation_record(self, renew_all):
@@ -290,6 +290,22 @@ def notify_request_for_renewal_or_extend():# Notify finance
     subject = '{0} Renewal and Extend list approved'.format("Prepare Payments")
     send_email(preparation_list, [preparation_list.notify_finance_user], message, subject)
     create_notification_log(subject, message, [preparation_list.notify_finance_user], preparation_list)
+
+def send_costing_notification(preparation):
+    """Email the costing print of a submitted Preparation to the user set in HR Settings.
+
+    Runs in the background - see Preparation.send_notifications for why.
+    """
+    inform_the_costing_to = frappe.db.get_single_value('HR Settings', 'inform_the_costing_to')
+    if not inform_the_costing_to:
+        return
+
+    doc = frappe.get_doc('Preparation', preparation)
+    message = "<p>Records are created<a href='{0}'>{1}</a>.</p>".format(get_url(doc.get_url()), doc.name)
+    subject = 'Details of the Preparation Cost for WP, MI, MOI, PACI, and FP'
+    print_format = frappe.db.get_single_value('HR Settings', 'costing_print_format') or 'Standard'
+    attachments = [frappe.attach_print(doc.doctype, doc.name, file_name=doc.name, print_format=print_format)]
+    send_email(doc, [inform_the_costing_to], message, subject, attachments)
 
 def send_email(doc, recipients, message, subject, attachments=None):
     sendemail(

--- a/one_fm/grd/doctype/preparation/test_preparation.py
+++ b/one_fm/grd/doctype/preparation/test_preparation.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2021, ONE FM and Contributors
 # See license.txt
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from one_fm.grd.doctype.preparation.preparation import send_costing_notification
 
 # The sub-documents a submitted Preparation generates. Each one stores the parent's
 # name in `preparation`, set by the create_* functions in their own controllers.
@@ -28,3 +32,44 @@ class TestPreparationLinkOnSubDocuments(FrappeTestCase):
 				# document, so it is history and must not be re-pointed by hand.
 				self.assertTrue(field.read_only, f"{doctype}: Preparation is editable")
 				self.assertEqual(field.options, "Preparation")
+
+
+def _wkhtmltopdf_segfault(*args, **kwargs):
+	"""What staging did: the wkhtmltopdf child was killed by SIGSEGV, so pdfkit
+	reported exit code -11 and frappe re-raised it as an OSError."""
+	raise OSError("wkhtmltopdf exited with non-zero code -11. error:\nUnknown Error")
+
+
+class TestCostingNotificationIsQueued(FrappeTestCase):
+	"""The costing mail must not be able to fail a submit.
+
+	It used to render its PDF inline in on_submit. When wkhtmltopdf died on staging the
+	submit died with it - but the Work Permit, Medical Insurance, MOI and PACI records
+	created earlier in on_submit each commit as they go, so they outlived the Preparation
+	rolling back to draft, and re-submitting opened them a second time.
+	"""
+
+	def test_send_notifications_queues_the_pdf_instead_of_rendering_it(self):
+		preparation = frappe.new_doc("Preparation")
+		preparation.name = "PRE-TEST-QUEUED"
+		# The operator's Notification Log is not what is under test, and it needs the
+		# Preparation to exist for its Dynamic Link.
+		preparation.grd_operator = None
+
+		with patch.object(frappe, "attach_print", _wkhtmltopdf_segfault):
+			with patch.object(frappe, "enqueue") as enqueue:
+				# Fails loudly if anything renders a PDF in this call stack.
+				preparation.send_notifications()
+
+		enqueue.assert_called_once()
+		self.assertEqual(
+			enqueue.call_args.args[0],
+			"one_fm.grd.doctype.preparation.preparation.send_costing_notification",
+		)
+		# After commit, so a submit that fails later never mails a costing that was undone.
+		self.assertTrue(enqueue.call_args.kwargs["enqueue_after_commit"])
+
+	def test_nothing_is_rendered_when_no_costing_recipient_is_set(self):
+		with patch.object(frappe.db, "get_single_value", return_value=None):
+			with patch.object(frappe, "attach_print", _wkhtmltopdf_segfault):
+				send_costing_notification("PRE-TEST-QUEUED")


### PR DESCRIPTION
## The bug

Submitting a Preparation on staging died with:

```
OSError: wkhtmltopdf exited with non-zero code -11. error:
Unknown Error
```

`-11` is a signal, not an exit status: the wkhtmltopdf child was killed by **SIGSEGV**. Nothing about the document caused it — `HR Settings.costing_print_format` is unset, so it falls back to `Standard`, and that print renders to 11 KB with one image (the letterhead logo) and one stylesheet. The crash is environmental. With an empty stderr the message is `"Unknown Error"`, which isn't in `PDF_CONTENT_ERRORS`, so `frappe.utils.pdf.get_pdf` re-raises and the submit dies.

## Why it mattered more than a missing email

`send_notifications` was the **last** step of `on_submit`, but the creators that run before it commit as they go — `work_permit.py:43,398,413`, `residency.py:32`, `medical_insurance.py:30`, `paci.py:34`, `preparation.py:405`. So when the PDF blew up:

- the Preparation rolled back to **draft**,
- the Work Permit / Medical Insurance / MOI / PACI records it had opened stayed **committed**,
- and `create_PACI_renewal` has no same-year guard (`cancel_existing` only cancels *previous* years), so **re-submitting opened them again**.

## The change

The costing mail renders a PDF and talks to the mail server. Both are the textbook case for a background job, so it moves to one, `enqueue_after_commit=True` so a submit that fails later never mails a costing that was undone. A broken PDF is now an Error Log entry instead of a failed submit. The operator's Notification Log is a plain insert and stays inline.

## Tests

`bench run-tests --module one_fm.grd.doctype.preparation.test_preparation` — 3 passed. The two new ones patch `frappe.attach_print` to raise the exact staging `OSError`, so they fail loudly if anything renders a PDF inside the submit call stack again.

## Not in this PR

The staging wkhtmltopdf crash itself. Worth checking on the box: gunicorn worker count (a self-request for `/files/onefmlogo.png` from inside a request that holds the only worker starves), whether the site URL resolves internally, and `dmesg -T | grep -i segfault`. Also worth auditing HR-EMP-02834 for GRD records duplicated by a retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)