### PR TITLE
fix: unblock Penalty And Investigation form for non-System-Manager users

### DIFF
--- a/one_fm/legal/doctype/penalty_and_investigation/penalty_and_investigation.js
+++ b/one_fm/legal/doctype/penalty_and_investigation/penalty_and_investigation.js
@@ -121,36 +121,22 @@ frappe.ui.form.on("Penalty And Investigation", {
 	fetch_employee_details: function (frm) {
 		if (!frm.doc.employee) return;
 
-		let set_details = (site, project) => {
-			if (site) frm.set_value("operations_site", site);
-			if (project) frm.set_value("project", project);
-		};
-
-		if (frm.doc.incident_date) {
-			frappe.db.get_list("Employee Schedule", {
-				filters: {
-					employee: frm.doc.employee,
-					date: frm.doc.incident_date,
-					employee_availability: "Working"
-				},
-				fields: ["site", "project"],
-				limit: 1
-			}).then(res => {
-				if (res && res.length > 0) {
-					set_details(res[0].site, res[0].project);
-				} else {
-					// Fallback to Employee Master
-					frappe.db.get_value("Employee", frm.doc.employee, ["site", "project"], (r) => {
-						if (r) set_details(r.site, r.project);
-					});
+		// The site/project lookup reads Employee Schedule (roster data). It is done
+		// server-side so raising a penalty does not require roster read permission -
+		// the method checks access and returns only the two fields it needs.
+		frappe.call({
+			method: "one_fm.legal.doctype.penalty_and_investigation.penalty_and_investigation.get_incident_site_project",
+			args: {
+				employee: frm.doc.employee,
+				incident_date: frm.doc.incident_date
+			},
+			callback: function (r) {
+				if (r && r.message) {
+					if (r.message.site) frm.set_value("operations_site", r.message.site);
+					if (r.message.project) frm.set_value("project", r.message.project);
 				}
-			});
-		} else {
-			// No incident date, fallback to master
-			frappe.db.get_value("Employee", frm.doc.employee, ["site", "project"], (r) => {
-				if (r) set_details(r.site, r.project);
-			});
-		}
+			}
+		});
 	},
 	fetch_penalty_details: function (frm) {
 		const clear = () => {

--- a/one_fm/legal/doctype/penalty_and_investigation/penalty_and_investigation.py
+++ b/one_fm/legal/doctype/penalty_and_investigation/penalty_and_investigation.py
@@ -185,6 +185,52 @@ class PenaltyAndInvestigation(Document):
 
 
 @frappe.whitelist()
+def get_incident_site_project(employee: str, incident_date: str | None = None) -> dict:
+	"""Return the operations site and project to pre-fill for a penalty's employee.
+
+	The form needs the site/project the employee was rostered to on the incident
+	date. Reading Employee Schedule (roster data) straight from the client would
+	force every penalty-raiser to hold read permission on the whole roster; this
+	method instead confirms the caller may raise a penalty, then returns only the
+	two fields - nothing else of the schedule is exposed.
+	"""
+	# Only someone allowed to create a Penalty And Investigation may look this up.
+	if not frappe.has_permission("Penalty And Investigation", "create"):
+		frappe.throw(_("Not permitted"), frappe.PermissionError)
+
+	if not employee:
+		return {}
+
+	site = project = None
+
+	# The working roster row for that day wins; get_all is used deliberately so the
+	# lookup does not depend on the caller having Employee Schedule read permission.
+	if incident_date:
+		schedule = frappe.get_all(
+			"Employee Schedule",
+			filters={
+				"employee": employee,
+				"date": incident_date,
+				"employee_availability": "Working",
+			},
+			fields=["site", "project"],
+			limit=1,
+		)
+		if schedule:
+			site = schedule[0].site
+			project = schedule[0].project
+
+	# Fall back to the Employee master when there is no working roster row.
+	if not site and not project:
+		emp = frappe.db.get_value("Employee", employee, ["site", "project"], as_dict=True)
+		if emp:
+			site = emp.site
+			project = emp.project
+
+	return {"site": site, "project": project}
+
+
+@frappe.whitelist()
 def get_penalty_count():
 	user = frappe.session.user
 	count = frappe.db.count("Penalty And Investigation", {


### PR DESCRIPTION
Raising a Penalty And Investigation required the raiser to hold read permission on the whole Employee Schedule (roster) doctype, because the form fetched the incident-day site/project directly from the client. Users without roster access hit a "No permission for Employee Schedule" popup.

- add whitelisted get_incident_site_project that checks create access on Penalty And Investigation, reads the roster server-side, and returns only site/project (with the existing Employee-master fallback)
- replace the client-side Employee Schedule get_list with a call to the new method

<h3 style="unicode-bidi: plaintext; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">What was wrong</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">User <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">m.alsheaibi</code> (roles: Employee, HR User, Penalty Recipient, …) could open the <strong>Penalty And Investigation</strong> form but hit two <strong>"Not permitted"</strong> popups when entering data:</p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="unicode-bidi: plaintext;"><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">No permission for Employee Schedule</code></li><li style="unicode-bidi: plaintext;"><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">No permission for Penalty Code</code></li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Root cause:</strong> the form grants <em>create</em> to Employee / HR Supervisor / HR Manager / General Manager, but its client script reads two linked doctypes that only granted read to <strong>System Manager</strong> (Employee Schedule also to Projects Manager). So anyone raising a penalty was blocked:</p>
Doctype | Where it's read | Purpose
-- | -- | --
Employee Schedule | frappe.db.get_list(...) in fetch_employee_details | auto-fill site/project from the incident-day roster
Penalty Code | applied_penalty_code Link field + fetch_penalty_details | pick/read the penalty code

<h3 style="unicode-bidi: plaintext; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">What I changed (server-method approach)</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Instead of granting every penalty-raiser read access to the entire roster, the Employee Schedule lookup is now done <strong>server-side</strong> and returns only the two fields it needs:</p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="unicode-bidi: plaintext;"><strong><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">penalty_and_investigation.py</code></strong><span> </span>— new whitelisted<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">get_incident_site_project(employee, incident_date)</code>. It checks<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">frappe.has_permission("Penalty And Investigation", "create")</code>, reads the roster via<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">get_all</code>, and returns<span> </span><strong>only</strong><span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">site</code>/<code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">project</code><span> </span>(keeping the existing fallback to the Employee master when there's no "Working" roster row). No other roster data is exposed to the client.</li><li style="unicode-bidi: plaintext;"><strong><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">penalty_and_investigation.js</code></strong><span> </span>—<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">fetch_employee_details</code><span> </span>now calls that method via<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">frappe.call</code><span> </span>instead of<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">frappe.db.get_list("Employee Schedule", ...)</code>.</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This removes the Employee Schedule permission requirement entirely for the form, without opening up roster data to all employees.</p><h3 style="unicode-bidi: plaintext; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">What is handled outside this PR</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The <strong>Penalty Code</strong> read permission is being granted via <strong>Role Permission Manager</strong> (the <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">applied_penalty_code</code> Link field genuinely needs read on that doctype). This is a permission/config change, not code, so it is intentionally not part of this PR.</p>
