### PR TITLE
feat(project): add the "Show in Roadmap" custom field

### DIFF
--- a/one_fm/custom/custom_field/project.py
+++ b/one_fm/custom/custom_field/project.py
@@ -152,6 +152,20 @@ def get_project_custom_fields():
                 "mandatory_depends_on": "eval: doc.type==\"SCRUM\"",
             },
             {
+                # Opt-in flag for the frappe_agile Roadmap board: a SCRUM project
+                # only gets a lane once this is set to Yes, so the board is curated
+                # rather than showing every SCRUM project that exists. Left blank
+                # the project stays off the board, which is why this is Select
+                # rather than Check - blank is meaningfully "not decided yet".
+                "fieldname": "custom_show_in_roadmap",
+                "label": "Show in Roadmap",
+                "fieldtype": "Select",
+                "options": "\nYes\nNo",
+                "insert_after": "custom_sprint_prefix",
+                "depends_on": "eval: doc.type==\"SCRUM\"",
+                "mandatory_depends_on": "eval: doc.type==\"SCRUM\"",
+            },
+            {
                 "fieldname": "total_expense_claim",
                 "label": "Total Expense Claim (via Expense Claims)",
                 "fieldtype": "Currency",

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -577,3 +577,4 @@ one_fm.patches.v15_0.add_vehicle_max_passenger_capacity #2026-08-11 WI-002000
 one_fm.patches.v15_0.update_work_permit_previous_company_workflow #2026-08-07 WI-001974
 one_fm.patches.v15_0.update_work_permit_pam_rejection #2026-08-07 WI-001827
 one_fm.patches.v15_0.add_work_permit_assignment_rules #2026-08-10 WI-001827
+one_fm.patches.v15_0.add_project_show_in_roadmap_field #2026-08-12 WI-002045

--- a/one_fm/patches/v15_0/add_project_show_in_roadmap_field.py
+++ b/one_fm/patches/v15_0/add_project_show_in_roadmap_field.py
@@ -1,0 +1,24 @@
+"""Add the "Show in Roadmap" (custom_show_in_roadmap) custom field to Project.
+
+A Select (blank / Yes / No) shown and required only for SCRUM projects
+(depends_on / mandatory_depends_on eval:doc.type=="SCRUM"), inserted after the
+Sprint Prefix field.
+
+It is the opt-in flag for the frappe_agile Roadmap board (WI-002045): a SCRUM
+project only gets a lane once this is Yes. Blank therefore keeps a project off
+the board, which is deliberate - existing projects stay off until someone
+curates them in, rather than the board showing everything as it did before.
+
+The definition lives in one_fm.custom.custom_field.project (the source of
+truth); this patch re-applies the full Project custom-field set with
+update=True, so it is idempotent and also reconciles any drift in the other
+Project fields.
+"""
+
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+from one_fm.custom.custom_field.project import get_project_custom_fields
+
+
+def execute():
+    create_custom_fields(get_project_custom_fields(), update=True)


### PR DESCRIPTION
## WI-002045

Adds a **Show in Roadmap** field to Project — the opt-in flag that frappe_agile's
Roadmap board uses to decide which SCRUM projects earn a lane.

| | |
|---|---|
| Fieldname | `custom_show_in_roadmap` |
| Type | Select — `blank` / `Yes` / `No` |
| Position | after Sprint Prefix (`custom_sprint_prefix`) |
| Shown / required | SCRUM projects only — `eval: doc.type=="SCRUM"` |

### Why Select rather than Check

Blank has to mean something different from No. A Check is either ticked or not,
so every existing project would read as an explicit "keep it off the board",
with no way to tell a deliberate exclusion from one nobody has looked at yet.
With a Select, blank is "not decided", `No` is "deliberately off", and only `Yes`
puts a project on the board.

### How it's added

Same pattern as `custom_sprint_prefix`:

- The definition goes in `one_fm.custom.custom_field.project.get_project_custom_fields()`,
  which is the source of truth for Project's custom fields.
- `one_fm/patches/v15_0/add_project_show_in_roadmap_field.py` re-applies the whole
  Project set with `create_custom_fields(..., update=True)`, so it is idempotent
  and reconciles drift in the other Project fields at the same time.
- Registered in `patches.txt`.

### Verification

Patch executed on a dev site: the Custom Field record is created with the
intended fieldtype, options, `insert_after`, `depends_on` and
`mandatory_depends_on`, and the `custom_show_in_roadmap` column exists on
`tabProject`.

### Note before deploying

The field is named `custom_show_in_roadmap` (Frappe's `name` is always
`{dt}-{fieldname}`, and this matches the sibling `custom_sprint_prefix`). **If a
field called `show_in_roadmap` was already created by hand on production, this
patch will add a second field rather than adopt it** — worth checking, and
renaming or deleting the manual one first if so.

### Files

- `one_fm/custom/custom_field/project.py`
- `one_fm/patches/v15_0/add_project_show_in_roadmap_field.py`
- `one_fm/patches.txt`
