### PR TITLE
WI-002021 [Iman] Centralized Number to be added in Medical Insurance

### DIFF
--- a/one_fm/grd/doctype/medical_insurance/medical_insurance.json
+++ b/one_fm/grd/doctype/medical_insurance/medical_insurance.json
@@ -21,6 +21,7 @@
   "gender",
   "civil_id",
   "passport_expiry_date",
+  "centralized_number",
   "column_break_11",
   "employee_id",
   "nationality",
@@ -236,6 +237,14 @@
    "read_only": 1
   },
   {
+   "allow_on_submit": 1,
+   "fetch_from": "employee.one_fm_centralized_number",
+   "fieldname": "centralized_number",
+   "fieldtype": "Data",
+   "label": "Centralized Number",
+   "read_only": 1
+  },
+  {
    "collapsible": 1,
    "fieldname": "finance_department_section",
    "fieldtype": "Section Break",
@@ -289,7 +298,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-05 12:00:00.000000",
+ "modified": "2026-08-12 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Medical Insurance",


### PR DESCRIPTION
The number the GRD operator has to quote when filing the policy lived only on
the Employee, so it was copied by hand off a second tab. Fetched from
`employee.one_fm_centralized_number`, the same source Residency and PCC
Attestation read it from, so the three records cannot disagree about it.

Read-only and allow_on_submit, matching how Residency carries the same field:
the value belongs to the Employee, and a submitted policy still has to show it.

Existing submitted policies stay blank - fetch_from only fires on save, and
there is nothing to re-file on a closed policy. Open drafts pick it up on their
next save.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Chain: standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)