### PR TITLE
WI-002022 [Iman] Residency Doctype Update

### DIFF
--- a/one_fm/grd/doctype/residency/residency.js
+++ b/one_fm/grd/doctype/residency/residency.js
@@ -95,8 +95,25 @@ frappe.ui.form.on('Residency', {
 	},
 	new_residency_expiry_date: function(frm){
 		set_new_residency_expiry_date_update_time(frm);
+	},
+	upload_damj_letter: function(frm){
+		set_attachment_timestamp(frm, 'upload_damj_letter', 'upload_damj_letter_on');
+	},
+	upload_residency_fine_payment_receipt: function(frm){
+		set_attachment_timestamp(frm, 'upload_residency_fine_payment_receipt', 'upload_residency_fine_payment_receipt_on');
 	}
 });
+// WI-002022: stamp when an exception document went up, and clear the stamp if the file is
+// removed. One helper for both pairs - the three older stamps below each carry their own
+// copy of this same logic.
+var set_attachment_timestamp = function(frm, attach_field, timestamp_field){
+	if(frm.doc[attach_field] && !frm.doc[timestamp_field]){
+		frm.set_value(timestamp_field, frappe.datetime.now_datetime());
+	}
+	if(!frm.doc[attach_field] && frm.doc[timestamp_field]){
+		frm.set_value(timestamp_field, null);
+	}
+};
 var set_employee_details = function(frm){
     if(frm.doc.employee){
         frappe.call({

--- a/one_fm/grd/doctype/residency/residency.json
+++ b/one_fm/grd/doctype/residency/residency.json
@@ -34,6 +34,8 @@
   "last_name_english",
   "section_break_20",
   "one_fm_civil_id",
+  "damj_is_applicable",
+  "original_civil_id",
   "designation",
   "place_of_birth",
   "gender",
@@ -59,13 +61,21 @@
   "company_street_name",
   "company_building_name",
   "company_contact_number",
+  "section_break_vrai",
+  "residency_fine_to_be_added",
+  "column_break_zpot",
+  "residency_fine_amount_kwd",
   "section_break_42",
   "invoice_attachment",
   "residency_attachment",
+  "upload_residency_fine_payment_receipt",
+  "upload_damj_letter",
   "new_residency_expiry_date",
   "column_break_34",
   "invoice_attachment_date",
   "residency_attachment_date",
+  "upload_residency_fine_payment_receipt_on",
+  "upload_damj_letter_on",
   "new_residency_expiry_date_update_time",
   "section_break_40",
   "grd_operator",
@@ -182,6 +192,18 @@
    "in_list_view": 1,
    "label": "Civil ID",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "damj_is_applicable",
+   "fieldtype": "Check",
+   "label": "DAMJ is Applicable"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "original_civil_id",
+   "fieldtype": "Data",
+   "label": "Original Civil ID"
   },
   {
    "fetch_from": "employee.designation",
@@ -324,9 +346,53 @@
    "read_only": 1
   },
   {
+   "fieldname": "section_break_vrai",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "residency_fine_to_be_added",
+   "fieldtype": "Check",
+   "label": "Residency Fine to be Added"
+  },
+  {
+   "fieldname": "column_break_zpot",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "residency_fine_amount_kwd",
+   "fieldtype": "Currency",
+   "label": "Residency Fine Amount (KWD)"
+  },
+  {
    "fieldname": "section_break_42",
    "fieldtype": "Section Break",
    "print_hide": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "upload_residency_fine_payment_receipt",
+   "fieldtype": "Attach",
+   "label": "Upload Residency Fine Payment Receipt"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "upload_damj_letter",
+   "fieldtype": "Attach",
+   "label": "Upload DAMJ Letter"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "upload_residency_fine_payment_receipt_on",
+   "fieldtype": "Data",
+   "label": "Upload Residency Fine Payment Receipt On",
+   "read_only": 1
+  },
+  {
+   "fieldname": "upload_damj_letter_on",
+   "fieldtype": "Data",
+   "label": "Upload DAMJ Letter On",
+   "read_only": 1
   },
   {
    "allow_on_submit": 1,
@@ -520,7 +586,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-05 12:00:00.000000",
+ "modified": "2026-08-12 10:10:00.000000",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Residency",

--- a/one_fm/grd/doctype/residency/residency.py
+++ b/one_fm/grd/doctype/residency/residency.py
@@ -38,6 +38,37 @@ class Residency(Document):
         self.set_company_address()
         self.set_company_unified_number()
         self.set_paci_number()
+        self.validate_exception_details()
+
+    def validate_exception_details(self):
+        """Hold the save until a ticked exception carries its evidence (WI-002022).
+
+        On `validate` rather than `on_submit` because the story blocks the save, not
+        only the completion: a Damj or a fine recorded without the government letter or
+        the payment receipt is not a record of anything, and letting one sit in Draft
+        that way means the operator finds out at the end of the process instead of the
+        moment they tick the box.
+
+        A fine amount of 0 counts as missing. Ticking "Residency Fine to be Added" and
+        then entering nothing is the mistake the check exists to catch, and a zero-value
+        fine has nothing for finance to reference.
+        """
+        field_list = []
+
+        if self.damj_is_applicable:
+            field_list += [
+                {'Original Civil ID': 'original_civil_id'},
+                {'Upload DAMJ Letter': 'upload_damj_letter'},
+            ]
+
+        if self.residency_fine_to_be_added:
+            field_list += [
+                {'Residency Fine Amount (KWD)': 'residency_fine_amount_kwd'},
+                {'Upload Residency Fine Payment Receipt': 'upload_residency_fine_payment_receipt'},
+            ]
+
+        if field_list:
+            self.set_mendatory_fields(field_list)
 
     def set_grd_values(self):
         if not self.grd_supervisor:
@@ -91,9 +122,34 @@ class Residency(Document):
     def on_submit(self):
         self.validate_mandatory_fields_on_submit()
         self.set_residency_expiry_new_date_in_employee_doctype()
+        self.apply_damj_civil_id()
         self.db_set('completed_on', now_datetime())
         if self.category == "Transfer":
             self.recall_create_paci()
+
+    def apply_damj_civil_id(self):
+        """Put the corrected Civil ID on the Employee once the Damj is completed (WI-002022).
+
+        A Damj merges two civil ID numbers the government issued the same person, and the
+        surviving one is the original. Until it is written back, every record that reads
+        the Civil ID off the Employee - and every one already holding the superseded
+        number - is wrong.
+
+        Written with `db_set`/`set_value` rather than a full Employee save for the same
+        reason `set_residency_expiry_new_date_in_employee_doctype` does: a full save
+        re-validates the whole Employee, and 1,124 of them hold a Marital Status the
+        field's options no longer accept, so any such save throws on data that has
+        nothing to do with the civil ID.
+
+        This record's own mirror of the number is updated too. It is fetched from the
+        Employee and would otherwise keep showing the number the merge just retired, on
+        the very document that recorded the merge.
+        """
+        if not (self.damj_is_applicable and self.original_civil_id):
+            return
+
+        frappe.db.set_value('Employee', self.employee, 'one_fm_civil_id', self.original_civil_id)
+        self.db_set('one_fm_civil_id', self.original_civil_id)
 
     def recall_create_paci(self):
         paci.create_PACI_for_transfer(self.employee)

--- a/one_fm/grd/doctype/residency/test_residency_damj.py
+++ b/one_fm/grd/doctype/residency/test_residency_damj.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002022: the Damj and Residency Fine exception paths on Residency."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import today
+
+A_LETTER = "/files/damj-letter.pdf"
+A_RECEIPT = "/files/fine-receipt.pdf"
+
+
+def _an_active_employee():
+	"""An employee a Residency can be opened for.
+
+	Taken from the site rather than created: Employee sits at MariaDB's row-size limit
+	here, so a fixture would need a Company, a Fiscal Year and a Designation before it
+	inserted. Same reason test_preparation_new_actions.py does it this way.
+	"""
+	name = frappe.db.get_value("Employee", {"status": "Active"}, "name", order_by="creation asc")
+	if not name:
+		raise frappe.DoesNotExistError("No active employee on this site to test against")
+	return name
+
+
+class TestResidencyDamj(FrappeTestCase):
+	def setUp(self):
+		self.employee = _an_active_employee()
+		self.original_civil_id = frappe.db.get_value("Employee", self.employee, "one_fm_civil_id")
+
+	def _residency(self, **kwargs):
+		residency = frappe.get_doc(
+			{
+				"doctype": "Residency",
+				"employee": self.employee,
+				"category": "Renewal",
+				"date_of_application": today(),
+				**kwargs,
+			}
+		)
+		residency.flags.ignore_permissions = True
+		return residency
+
+	def test_damj_without_original_civil_id_or_letter_blocks_the_save(self):
+		with self.assertRaises(frappe.ValidationError):
+			self._residency(damj_is_applicable=1).insert()
+
+	def test_damj_without_the_letter_alone_blocks_the_save(self):
+		with self.assertRaises(frappe.ValidationError):
+			self._residency(damj_is_applicable=1, original_civil_id="299010112345").insert()
+
+	def test_damj_with_both_saves(self):
+		residency = self._residency(
+			damj_is_applicable=1,
+			original_civil_id="299010112345",
+			upload_damj_letter=A_LETTER,
+		)
+		residency.insert()
+		self.assertEqual(residency.original_civil_id, "299010112345")
+
+	def test_fine_without_amount_or_receipt_blocks_the_save(self):
+		with self.assertRaises(frappe.ValidationError):
+			self._residency(residency_fine_to_be_added=1).insert()
+
+	def test_a_zero_fine_amount_counts_as_missing(self):
+		# Ticking the box and entering nothing is the mistake the check exists to catch.
+		with self.assertRaises(frappe.ValidationError):
+			self._residency(
+				residency_fine_to_be_added=1,
+				residency_fine_amount_kwd=0,
+				upload_residency_fine_payment_receipt=A_RECEIPT,
+			).insert()
+
+	def test_fine_with_amount_and_receipt_saves(self):
+		residency = self._residency(
+			residency_fine_to_be_added=1,
+			residency_fine_amount_kwd=15.5,
+			upload_residency_fine_payment_receipt=A_RECEIPT,
+		)
+		residency.insert()
+		self.assertEqual(residency.residency_fine_amount_kwd, 15.5)
+
+	def test_neither_box_ticked_needs_nothing(self):
+		self._residency().insert()
+
+	def test_completing_a_damj_writes_the_original_civil_id_to_the_employee(self):
+		merged = "299010199999"
+		residency = self._residency(
+			damj_is_applicable=1,
+			original_civil_id=merged,
+			upload_damj_letter=A_LETTER,
+			invoice_attachment="/files/invoice.pdf",
+			new_residency_expiry_date=today(),
+		)
+		residency.insert()
+		residency.submit()
+
+		self.assertEqual(frappe.db.get_value("Employee", self.employee, "one_fm_civil_id"), merged)
+		# The record that carries the merge must not still show the retired number.
+		self.assertEqual(frappe.db.get_value("Residency", residency.name, "one_fm_civil_id"), merged)
+
+	def test_completing_without_damj_leaves_the_employee_civil_id_alone(self):
+		residency = self._residency(
+			original_civil_id="299010188888",  # populated but the box is not ticked
+			invoice_attachment="/files/invoice.pdf",
+			new_residency_expiry_date=today(),
+		)
+		residency.insert()
+		residency.submit()
+
+		self.assertEqual(
+			frappe.db.get_value("Employee", self.employee, "one_fm_civil_id"),
+			self.original_civil_id,
+		)


### PR DESCRIPTION
Two government exception paths had nowhere to live, so they were tracked off
the system: a Damj (the merge of two Civil ID numbers the government issued the
same person) and a residency fine the employee has to settle before the stamp.

Each is a checkbox that makes its own pair of fields mandatory. The check runs
on validate, not on submit, because the story blocks the save: a Damj recorded
without its government letter, or a fine without its payment receipt, is not a
record of anything, and catching it only at completion means the operator finds
out at the end of the process instead of when they tick the box.

A fine amount of 0 counts as missing. Ticking "Residency Fine to be Added" and
entering nothing is the mistake the check exists to catch, and finance has
nothing to reference in a zero-value fine.

On completion the original Civil ID is written back to the Employee, and to this
record's own mirror of the field - it is fetched from the Employee, so the very
document that recorded the merge would otherwise keep showing the number the
merge retired. Written with set_value rather than a full Employee save, the same
way the residency expiry date beside it is: a full save re-validates the whole
Employee, and 1,124 of them hold a Marital Status the field's options no longer
accept, so it throws on data unrelated to the civil ID.

Field names and labels are the BA site's configuration verbatim.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Chain: WI-002022 → WI-002027. Merge this first.

Tests: 9 passing (`bench run-tests --module one_fm.grd.doctype.residency.test_residency_damj`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)