### PR TITLE
WI-002027 [Iman] Auto-Sync Merged Civil ID from Residency to PACI

### DIFF
--- a/one_fm/grd/doctype/residency/residency.py
+++ b/one_fm/grd/doctype/residency/residency.py
@@ -150,6 +150,40 @@ class Residency(Document):
 
         frappe.db.set_value('Employee', self.employee, 'one_fm_civil_id', self.original_civil_id)
         self.db_set('one_fm_civil_id', self.original_civil_id)
+        self.sync_damj_civil_id_to_paci()
+
+    def sync_damj_civil_id_to_paci(self):
+        """Carry the merged Civil ID over to the PACI opened alongside this Residency (WI-002027).
+
+        The PACI's Civil ID is fetched from the Employee, which means it is copied once at
+        insert and never looked at again. A Damj completed after the PACI was opened
+        therefore leaves the civil ID application quoting the number the government just
+        retired - the one thing it must not do.
+
+        Scoped to the same Preparation, which is what pairs the two documents: a
+        Preparation opens one Residency and one PACI per employee, so that pair is the
+        "linked record" the story means. A Residency with no Preparation - a transfer, say
+        - has no PACI to pair with and is left alone.
+
+        Cancelled records are skipped; there can be more than one live PACI for the same
+        employee (a rejected application and its replacement), and both need the
+        correction. Written with set_value because the field is read-only and the PACI may
+        already be submitted, and because a full save would re-run the PACI's own
+        validation over a document this change has no business re-validating.
+        """
+        if not self.preparation:
+            return
+
+        for paci_name in frappe.get_all(
+            'PACI',
+            filters={
+                'preparation': self.preparation,
+                'employee': self.employee,
+                'docstatus': ['!=', 2],
+            },
+            pluck='name',
+        ):
+            frappe.db.set_value('PACI', paci_name, 'civil_id', self.original_civil_id)
 
     def recall_create_paci(self):
         paci.create_PACI_for_transfer(self.employee)

--- a/one_fm/grd/doctype/residency/test_residency_damj_paci_sync.py
+++ b/one_fm/grd/doctype/residency/test_residency_damj_paci_sync.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002027: a completed Damj carries the merged Civil ID to the PACI beside it."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import today
+
+A_LETTER = "/files/damj-letter.pdf"
+MERGED_CIVIL_ID = "299010177777"
+
+
+def _an_active_employee():
+	name = frappe.db.get_value("Employee", {"status": "Active"}, "name", order_by="creation asc")
+	if not name:
+		raise frappe.DoesNotExistError("No active employee on this site to test against")
+	return name
+
+
+class TestDamjCivilIdSyncToPaci(FrappeTestCase):
+	def setUp(self):
+		self.employee = _an_active_employee()
+		self.original_civil_id = frappe.db.get_value("Employee", self.employee, "one_fm_civil_id")
+		self.preparation = self._preparation()
+
+	def _preparation(self):
+		preparation = frappe.get_doc(
+			{
+				"doctype": "Preparation",
+				"posting_date": today(),
+				"preparation_record": [{"employee": self.employee, "renewal_or_extend": "Renewal (Non-Kuwaiti)"}],
+			}
+		)
+		preparation.flags.ignore_permissions = True
+		preparation.insert()
+		return preparation.name
+
+	def _paci(self, preparation):
+		paci = frappe.get_doc(
+			{
+				"doctype": "PACI",
+				"employee": self.employee,
+				"category": "New Application",
+				"date_of_application": today(),
+				"preparation": preparation,
+			}
+		)
+		paci.flags.ignore_permissions = True
+		paci.insert()
+		return paci
+
+	def _completed_damj_residency(self, preparation, **kwargs):
+		residency = frappe.get_doc(
+			{
+				"doctype": "Residency",
+				"employee": self.employee,
+				"category": "Renewal",
+				"date_of_application": today(),
+				"preparation": preparation,
+				"damj_is_applicable": 1,
+				"original_civil_id": MERGED_CIVIL_ID,
+				"upload_damj_letter": A_LETTER,
+				"invoice_attachment": "/files/invoice.pdf",
+				"new_residency_expiry_date": today(),
+				**kwargs,
+			}
+		)
+		residency.flags.ignore_permissions = True
+		residency.insert()
+		residency.submit()
+		return residency
+
+	def test_the_paci_under_the_same_preparation_gets_the_merged_number(self):
+		paci = self._paci(self.preparation)
+		self.assertEqual(paci.civil_id, self.original_civil_id)
+
+		self._completed_damj_residency(self.preparation)
+
+		self.assertEqual(frappe.db.get_value("PACI", paci.name, "civil_id"), MERGED_CIVIL_ID)
+
+	def test_every_live_paci_under_the_preparation_is_corrected(self):
+		# A rejected application and its replacement both sit under the same Preparation.
+		first = self._paci(self.preparation)
+		second = self._paci(self.preparation)
+
+		self._completed_damj_residency(self.preparation)
+
+		for paci in (first, second):
+			self.assertEqual(frappe.db.get_value("PACI", paci.name, "civil_id"), MERGED_CIVIL_ID)
+
+	def test_a_paci_under_a_different_preparation_is_left_alone(self):
+		other = self._paci(self._preparation())
+
+		self._completed_damj_residency(self.preparation)
+
+		self.assertEqual(frappe.db.get_value("PACI", other.name, "civil_id"), self.original_civil_id)
+
+	def test_a_cancelled_paci_is_left_alone(self):
+		paci = self._paci(self.preparation)
+		paci.submit()
+		paci.cancel()
+
+		self._completed_damj_residency(self.preparation)
+
+		self.assertEqual(frappe.db.get_value("PACI", paci.name, "civil_id"), self.original_civil_id)
+
+	def test_a_residency_without_a_preparation_touches_no_paci(self):
+		paci = self._paci(self.preparation)
+
+		self._completed_damj_residency(None)
+
+		self.assertEqual(frappe.db.get_value("PACI", paci.name, "civil_id"), self.original_civil_id)
+		# The Employee is still corrected - that part does not depend on the pairing.
+		self.assertEqual(
+			frappe.db.get_value("Employee", self.employee, "one_fm_civil_id"), MERGED_CIVIL_ID
+		)


### PR DESCRIPTION
The PACI's Civil ID is fetched from the Employee, which copies it once at insert
and never looks again. A Damj completed after the PACI was opened therefore left
the civil ID application quoting the number the government had just retired -
the one number it must not carry.

Scoped to the same Preparation, which is what pairs the two documents: a
Preparation opens one Residency and one PACI per employee. A Residency with no
Preparation - a transfer - has no PACI to pair with and is left alone, while the
Employee correction from WI-002022 still applies.

Every live PACI under the Preparation is corrected, not just one: a rejected
application and its replacement both sit there, and both would otherwise go on
quoting the retired number. Cancelled records are skipped.

Written with set_value because the field is read-only and the PACI may already be
submitted, and because a full save would drag the PACI through its own validation
over a change that has no business re-validating it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Chain: WI-002022 → **WI-002027**. Based on #6680, retarget to staging once that merges.

Tests: 5 passing (`--module one_fm.grd.doctype.residency.test_residency_damj_paci_sync`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)