### PR TITLE
WI-002023 [Iman] PACI Doctype Update

### DIFF
--- a/one_fm/custom/custom_field/hr_settings.py
+++ b/one_fm/custom/custom_field/hr_settings.py
@@ -99,9 +99,16 @@ def get_hr_settings_custom_fields():
                 "description": "Specify the number of days in advance the supervisor should be notified before an employee's document expires. A notification will be triggered based on this value."
             },
             {
+                "fieldname": "paci_fine_amount_kwd",
+                "fieldtype": "Currency",
+                "insert_after": "days_before_expiry_to_notify_supervisor",
+                "label": "PACI Fine Amount (KWD)",
+                "description": "The fixed PACI late fine. Fetched onto a PACI record when the operator marks the fine applicable, so the rate is changed in one place when PACI changes it."
+            },
+            {
                 "fieldname": "renewal_extension_costing_section",
                 "fieldtype": "Section Break",
-                "insert_after": "days_before_expiry_to_notify_supervisor",
+                "insert_after": "paci_fine_amount_kwd",
                 "label": "Renewal Extension Costing"
             },
             {

--- a/one_fm/grd/doctype/paci/paci.js
+++ b/one_fm/grd/doctype/paci/paci.js
@@ -14,6 +14,17 @@ frappe.ui.form.on('PACI', {
 	upload_civil_id: function(frm){
 		set_upload_civil_id(frm);
 	},
+	// WI-002023: show the fine the moment the box is ticked instead of after a save. The
+	// controller derives the same value on validate and remains the authority on it.
+	is_paci_fine_applicable: function(frm){
+		if(!frm.doc.is_paci_fine_applicable){
+			frm.set_value('paci_fine_amount_kwd', 0);
+			return;
+		}
+		frappe.db.get_single_value('HR Settings', 'paci_fine_amount_kwd').then(amount => {
+			frm.set_value('paci_fine_amount_kwd', amount || 0);
+		});
+	},
 
 });
 var set_employee_details = function(frm){

--- a/one_fm/grd/doctype/paci/paci.json
+++ b/one_fm/grd/doctype/paci/paci.json
@@ -33,6 +33,10 @@
   "column_break_16",
   "pam_designation",
   "residency_expiry_date",
+  "section_break_flkg",
+  "is_paci_fine_applicable",
+  "column_break_xblr",
+  "paci_fine_amount_kwd",
   "section_break_19",
   "upload_civil_id_payment",
   "upload_hawiyati",
@@ -175,6 +179,27 @@
    "fieldname": "residency_expiry_date",
    "fieldtype": "Data",
    "label": "Residency Expiry Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_flkg",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_paci_fine_applicable",
+   "fieldtype": "Check",
+   "label": "Is PACI Fine Applicable?"
+  },
+  {
+   "fieldname": "column_break_xblr",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "is_paci_fine_applicable",
+   "fieldname": "paci_fine_amount_kwd",
+   "fieldtype": "Currency",
+   "label": "PACI Fine Amount (KWD)",
    "read_only": 1
   },
   {
@@ -349,7 +374,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-10 10:00:00.000000",
+ "modified": "2026-08-12 10:20:00.000000",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "PACI",

--- a/one_fm/grd/doctype/paci/paci.py
+++ b/one_fm/grd/doctype/paci/paci.py
@@ -7,7 +7,7 @@ from frappe import _
 from frappe.model.document import Document
 from datetime import date
 from one_fm.api.notification import create_notification_log
-from frappe.utils import today, add_days, get_url, date_diff, get_year_start
+from frappe.utils import today, add_days, get_url, date_diff, get_year_start, flt
 from frappe.utils import get_datetime, add_to_date, getdate, get_link_to_form, now_datetime, nowdate, cstr
 from frappe.core.doctype.communication.email import make
 from one_fm.processor import sendemail
@@ -37,6 +37,27 @@ class PACI(Document):
     def validate(self):
         self.set_grd_values()
         self.set_new_expiry_date()
+        self.set_paci_fine_amount()
+
+    def set_paci_fine_amount(self):
+        """Fetch the PACI late fine off HR Settings, or clear it (WI-002023).
+
+        The rate is fixed by PACI, not negotiated per record, so the operator states
+        whether the fine applies and the amount follows from the master rate. Derived on
+        every save rather than only when the box is ticked, so a record saved after PACI
+        changes the rate carries the rate that was current when it was saved, and the
+        field cannot be left holding a number the operator typed by hand.
+
+        Cleared to 0 when the box is unticked. The field is hidden then, so a stale amount
+        left behind would be invisible and still reach the costing.
+        """
+        if not self.is_paci_fine_applicable:
+            self.paci_fine_amount_kwd = 0
+            return
+
+        self.paci_fine_amount_kwd = flt(
+            frappe.db.get_single_value('HR Settings', 'paci_fine_amount_kwd')
+        )
 
 
     def set_grd_values(self):

--- a/one_fm/grd/doctype/paci/test_paci_fine.py
+++ b/one_fm/grd/doctype/paci/test_paci_fine.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002023: the PACI fine follows the master rate in HR Settings."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase, change_settings
+from frappe.utils import today
+
+MASTER_RATE = 20.0
+
+
+def _an_active_employee():
+	name = frappe.db.get_value("Employee", {"status": "Active"}, "name", order_by="creation asc")
+	if not name:
+		raise frappe.DoesNotExistError("No active employee on this site to test against")
+	return name
+
+
+class TestPaciFine(FrappeTestCase):
+	def setUp(self):
+		self.employee = _an_active_employee()
+
+	def _paci(self, **kwargs):
+		paci = frappe.get_doc(
+			{
+				"doctype": "PACI",
+				"employee": self.employee,
+				"category": "New Application",
+				"date_of_application": today(),
+				**kwargs,
+			}
+		)
+		paci.flags.ignore_permissions = True
+		paci.insert()
+		return paci
+
+	@change_settings("HR Settings", {"paci_fine_amount_kwd": MASTER_RATE})
+	def test_ticking_the_box_fetches_the_master_rate(self):
+		paci = self._paci(is_paci_fine_applicable=1)
+		self.assertEqual(paci.paci_fine_amount_kwd, MASTER_RATE)
+
+	@change_settings("HR Settings", {"paci_fine_amount_kwd": MASTER_RATE})
+	def test_an_unticked_record_carries_no_fine(self):
+		paci = self._paci()
+		self.assertEqual(paci.paci_fine_amount_kwd, 0)
+
+	@change_settings("HR Settings", {"paci_fine_amount_kwd": MASTER_RATE})
+	def test_unticking_clears_a_populated_amount(self):
+		paci = self._paci(is_paci_fine_applicable=1)
+		self.assertEqual(paci.paci_fine_amount_kwd, MASTER_RATE)
+
+		paci.is_paci_fine_applicable = 0
+		paci.save()
+
+		# The field is hidden once unticked, so a stale amount would be invisible and
+		# still reach the costing.
+		self.assertEqual(paci.paci_fine_amount_kwd, 0)
+
+	@change_settings("HR Settings", {"paci_fine_amount_kwd": MASTER_RATE})
+	def test_a_hand_typed_amount_is_replaced_by_the_master_rate(self):
+		paci = self._paci(is_paci_fine_applicable=1, paci_fine_amount_kwd=999)
+		self.assertEqual(paci.paci_fine_amount_kwd, MASTER_RATE)
+
+	@change_settings("HR Settings", {"paci_fine_amount_kwd": 0})
+	def test_an_unconfigured_master_rate_yields_zero_rather_than_none(self):
+		paci = self._paci(is_paci_fine_applicable=1)
+		self.assertEqual(paci.paci_fine_amount_kwd, 0)
+
+	@change_settings("HR Settings", {"paci_fine_amount_kwd": 25.5})
+	def test_a_changed_master_rate_is_picked_up_on_the_next_save(self):
+		paci = self._paci(is_paci_fine_applicable=1)
+		self.assertEqual(paci.paci_fine_amount_kwd, 25.5)

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -577,3 +577,4 @@ one_fm.patches.v15_0.add_vehicle_max_passenger_capacity #2026-08-11 WI-002000
 one_fm.patches.v15_0.update_work_permit_previous_company_workflow #2026-08-07 WI-001974
 one_fm.patches.v15_0.update_work_permit_pam_rejection #2026-08-07 WI-001827
 one_fm.patches.v15_0.add_work_permit_assignment_rules #2026-08-10 WI-001827
+one_fm.patches.v15_0.add_paci_fine_amount_to_hr_settings #2026-08-12 WI-002023

--- a/one_fm/patches/v15_0/add_paci_fine_amount_to_hr_settings.py
+++ b/one_fm/patches/v15_0/add_paci_fine_amount_to_hr_settings.py
@@ -1,0 +1,16 @@
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+from one_fm.custom.custom_field.hr_settings import get_hr_settings_custom_fields
+
+# WI-002023: the master PACI late fine, so the operator states whether the fine applies
+# and the amount follows from one place.
+#
+# The whole HR Settings set is re-run rather than the one new field alone.
+# create_custom_fields updates a field that already exists instead of duplicating it, so
+# re-running the set is idempotent, and it repairs the insert_after chain in the same
+# pass - the new field sits between "Days Before Expiry to Notify Supervisor" and the
+# Renewal Extension Costing section, so that section's anchor moved too.
+
+
+def execute():
+	create_custom_fields(get_hr_settings_custom_fields())


### PR DESCRIPTION
The PACI late fine is fixed by PACI, not negotiated per record, so it had no
business being typed into each civil ID application. The operator now states
whether the fine applies and the amount follows from HR Settings, which is the
one place to change when PACI changes the rate.

Derived on every save, not only when the box is ticked: a record saved after the
rate changes carries the rate current at that save, and the field cannot be left
holding a number someone typed by hand. Unticking clears it to 0 - the field is
hidden then, so a stale amount would be invisible and still reach the costing.

The client script fills the field the moment the box is ticked so the operator
sees the number without saving first; the controller derives the same value and
stays the authority on it.

depends_on on the amount field is not in the BA site's configuration - it is what
the story's third criterion asks for, that unticking hides the field.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Chain: standalone.

Needs `bench migrate` for the new HR Settings field (patch `add_paci_fine_amount_to_hr_settings`).

Tests: 6 passing (`--module one_fm.grd.doctype.paci.test_paci_fine`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)