### PR TITLE
WI-002024 [Iman] Action-Based PAM File Costing Split in Preparation Doctype

### DIFF
--- a/one_fm/grd/doctype/grd_renewal_extension_cost/grd_renewal_extension_cost.json
+++ b/one_fm/grd/doctype/grd_renewal_extension_cost/grd_renewal_extension_cost.json
@@ -21,7 +21,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Action",
-   "options": "\nRenewal (Kuwaiti)\nRenewal (Non-Kuwaiti)\nExtend 1 month\nExtend 2 months\nExtend 3 months\nLocal Transfer\nCancellation"
+   "options": "\nNew Kuwaiti\nOverseas\nOverseas (Government)\nRenewal (Kuwaiti)\nRenewal (Non-Kuwaiti)\nExtend 1 month\nExtend 2 months\nExtend 3 months\nLocal Transfer\nCancellation"
   },
   {
    "depends_on": "eval: doc.renewal_or_extend == \"Renewal (Kuwaiti)\" || doc.renewal_or_extend == \"Renewal (Non-Kuwaiti)\"",
@@ -65,7 +65,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-09-27 05:00:06.271161",
+ "modified": "2026-08-12 10:30:00.000000",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "GRD Renewal Extension Cost",

--- a/one_fm/grd/doctype/medical_insurance/medical_insurance.py
+++ b/one_fm/grd/doctype/medical_insurance/medical_insurance.py
@@ -103,10 +103,13 @@ def create_mi_record(WorkPermit):
     if(WorkPermit.work_permit_type == "Renewal Non Kuwaiti"):
         Insurance_status = "Renewal"
         new_medical_insurance.date_of_application = WorkPermit.date_of_application #setting the same date of application of wp
-    elif(WorkPermit.work_permit_type == "Overseas"):
+    elif(WorkPermit.work_permit_type in ("Overseas", "Overseas (Government)")):
         # An overseas hire has no insurance yet, so the policy is opened as New
         # (WI-001881). Applied for the day the Work Permit was, which for an Overseas
         # Work Permit is the day its Preparation was submitted.
+        #
+        # A government-contract hire is the same insurance (WI-002024): the file the work
+        # permit was raised against changes its fee, not whether the employee is insured.
         Insurance_status = "New"
         new_medical_insurance.date_of_application = WorkPermit.date_of_application
     elif (WorkPermit.work_permit_type == "Local Transfer"):#for non kuwaiti <if it is for kuwait called new or renew and they don't have MI process

--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -49,6 +49,19 @@ NEW_ACTION_DOCUMENTS = {
         "residency": None,
         "paci": "New Application",
     },
+    # WI-002024: the same overseas hire, but against a government contract file rather
+    # than a private one. Every document it opens is the one Overseas opens - what
+    # differs is the work permit fee, which PAM charges at the lower government project
+    # rate, so the Action has to be distinguishable at the point the fee is fetched and
+    # on the permit itself. Splitting it here rather than adding a flag beside Overseas
+    # keeps it a single choice in the operator's Action dropdown, which is where the
+    # distinction is actually made.
+    "Overseas (Government)": {
+        "work_permit": "Overseas (Government)",
+        "medical_insurance": None,
+        "residency": None,
+        "paci": "New Application",
+    },
     # The process map groups Local Transfer with Overseas and the non-Kuwaiti renewal:
     # all four documents, opened by the Preparation itself. There is no Transfer Paper in
     # that path, which is why the transfer side of the Work Permit lifecycle had to stop

--- a/one_fm/grd/doctype/preparation/test_overseas_government_action.py
+++ b/one_fm/grd/doctype/preparation/test_overseas_government_action.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002024: the Overseas (Government) Action and the documents it opens."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import nowdate
+
+from one_fm.grd.doctype.preparation.preparation import (
+	NEW_ACTION_DOCUMENTS,
+	create_documents_for_row,
+)
+from one_fm.grd.doctype.residency.residency import (
+	ACTIONS_HANDLED_ON_SUBMIT,
+	MOI_CATEGORY_BY_ACTION,
+)
+
+ACTION = "Overseas (Government)"
+SUB_DOCUMENTS = ("Work Permit", "Medical Insurance", "Residency", "PACI")
+
+
+def _an_active_employee():
+	"""An employee the GRD documents can be opened for.
+
+	Work Permit refuses anyone inactive or with a relieving date, so the filter is not
+	incidental. Taken from the site for the reason test_preparation_new_actions.py gives:
+	Employee sits at MariaDB's row-size limit here.
+	"""
+	name = frappe.db.get_value(
+		"Employee",
+		{"status": "Active", "relieving_date": ["is", "not set"]},
+		"name",
+		order_by="creation asc",
+	)
+	if not name:
+		raise frappe.DoesNotExistError("No active employee on this site to test against")
+	return frappe.get_doc("Employee", name)
+
+
+class TestOverseasGovernmentAction(FrappeTestCase):
+	def setUp(self):
+		self.employee = _an_active_employee()
+
+	def test_the_action_is_an_option_on_the_preparation_row(self):
+		options = frappe.get_meta("Preparation Record").get_field("renewal_or_extend").options
+		self.assertIn(ACTION, options.split("\n"))
+
+	def test_the_work_permit_type_is_an_option(self):
+		options = frappe.get_meta("Work Permit").get_field("work_permit_type").options
+		self.assertIn(ACTION, options.split("\n"))
+
+	def test_a_fee_row_can_be_configured_for_the_action(self):
+		# Without the option on the costing table there is no government rate to fetch.
+		options = frappe.get_meta("GRD Renewal Extension Cost").get_field("renewal_or_extend").options
+		self.assertIn(ACTION, options.split("\n"))
+
+	def test_the_action_opens_the_same_four_documents_as_overseas(self):
+		self.assertEqual(
+			set(NEW_ACTION_DOCUMENTS[ACTION]),
+			set(NEW_ACTION_DOCUMENTS["Overseas"]),
+		)
+
+	def test_the_work_permit_carries_the_government_type(self):
+		self.assertEqual(NEW_ACTION_DOCUMENTS[ACTION]["work_permit"], ACTION)
+
+	def test_residency_treats_it_as_a_first_residency(self):
+		self.assertEqual(MOI_CATEGORY_BY_ACTION[ACTION], ("First Time", None))
+
+	def test_preparation_owns_the_residency_rather_than_the_extend_branch(self):
+		# The extend branch reads as "anything that is not a renewal is an extension", so
+		# an Action missing from here gets a second Residency categorised as Extend.
+		self.assertIn(ACTION, ACTIONS_HANDLED_ON_SUBMIT)
+
+	def test_submitting_the_row_opens_all_four_documents(self):
+		preparation = frappe.get_doc(
+			{
+				"doctype": "Preparation",
+				"posting_date": nowdate(),
+				"preparation_record": [{"employee": self.employee.name, "renewal_or_extend": ACTION}],
+			}
+		)
+		preparation.flags.ignore_permissions = True
+		preparation.insert()
+
+		create_documents_for_row(preparation.preparation_record[0], preparation.name)
+
+		for doctype in SUB_DOCUMENTS:
+			self.assertTrue(
+				frappe.db.exists(doctype, {"preparation": preparation.name, "employee": self.employee.name}),
+				f"{doctype} was not opened for {ACTION}",
+			)
+
+		self.assertEqual(
+			frappe.db.get_value(
+				"Work Permit",
+				{"preparation": preparation.name, "employee": self.employee.name},
+				"work_permit_type",
+			),
+			ACTION,
+		)
+		self.assertEqual(
+			frappe.db.get_value(
+				"Medical Insurance",
+				{"preparation": preparation.name, "employee": self.employee.name},
+				"insurance_status",
+			),
+			"New",
+		)
+		self.assertEqual(
+			frappe.db.get_value(
+				"Residency",
+				{"preparation": preparation.name, "employee": self.employee.name},
+				"category",
+			),
+			"First Time",
+		)
+		self.assertEqual(
+			frappe.db.get_value(
+				"PACI",
+				{"preparation": preparation.name, "employee": self.employee.name},
+				"category",
+			),
+			"New Application",
+		)

--- a/one_fm/grd/doctype/preparation_record/preparation_record.json
+++ b/one_fm/grd/doctype/preparation_record/preparation_record.json
@@ -65,7 +65,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Action",
-   "options": "\nNew Kuwaiti\nOverseas\nRenewal (Kuwaiti)\nRenewal (Non-Kuwaiti)\nExtend 1 month\nExtend 2 months\nExtend 3 months\nLocal Transfer\nCancellation"
+   "options": "\nNew Kuwaiti\nOverseas\nOverseas (Government)\nRenewal (Kuwaiti)\nRenewal (Non-Kuwaiti)\nExtend 1 month\nExtend 2 months\nExtend 3 months\nLocal Transfer\nCancellation"
   },
   {
    "allow_on_submit": 1,
@@ -146,7 +146,7 @@
  "grid_page_length": 50,
  "istable": 1,
  "links": [],
- "modified": "2026-08-05 12:00:00.000000",
+ "modified": "2026-08-12 10:30:00.000000",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Preparation Record",

--- a/one_fm/grd/doctype/residency/residency.py
+++ b/one_fm/grd/doctype/residency/residency.py
@@ -149,7 +149,9 @@ class Residency(Document):
 # the "for extend" branch below (WI-001824). Without this the branch - which reads as
 # "anything that is not a renewal is an extension" - would open a second Residency for
 # them, categorised as Extend.
-ACTIONS_HANDLED_ON_SUBMIT = ('Renewal (Non-Kuwaiti)', 'New Kuwaiti', 'Overseas', 'Local Transfer')
+ACTIONS_HANDLED_ON_SUBMIT = (
+    'Renewal (Non-Kuwaiti)', 'New Kuwaiti', 'Overseas', 'Overseas (Government)', 'Local Transfer'
+)
 
 # The Residency a category opens, and how many days before the residency expires it is
 # applied for. Anything not listed is an extension, applied for a week ahead.
@@ -162,6 +164,9 @@ MOI_CATEGORY_BY_ACTION = {
     # First residency for an overseas hire (WI-001881): there is no expiry to count
     # back from, so it is applied for the day the Preparation was submitted.
     'Overseas': ('First Time', None),
+    # WI-002024: a government-contract overseas hire gets the same first residency. MOI
+    # does not care which file the work permit was raised against.
+    'Overseas (Government)': ('First Time', None),
 }
 
 

--- a/one_fm/grd/doctype/work_permit/work_permit.json
+++ b/one_fm/grd/doctype/work_permit/work_permit.json
@@ -153,7 +153,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Work Permit Type",
-   "options": "\nRenewal Non Kuwaiti\nRenewal Kuwaiti\nOverseas\nLocal Transfer\nNew Kuwaiti\nCancellation",
+   "options": "\nRenewal Non Kuwaiti\nRenewal Kuwaiti\nOverseas\nOverseas (Government)\nLocal Transfer\nNew Kuwaiti\nCancellation",
    "permlevel": 1,
    "reqd": 1
   },
@@ -969,7 +969,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-07 12:00:00.000000",
+ "modified": "2026-08-12 10:30:00.000000",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Work Permit",


### PR DESCRIPTION
PAM charges a lower work permit fee for an overseas hire raised against a
government contract file than for the same hire on a private file. With one
"Overseas" Action there was nowhere for that difference to live, so the wrong
fee was fetched and corrected by hand afterwards.

Every document the new Action opens is the one Overseas opens - the same first
work permit, insurance, residency and civil ID application. What differs is the
file the permit is raised against, and therefore its fee. It is a separate Action
rather than a flag beside Overseas because the operator's Action dropdown is
where the distinction is actually made, and because the fee is fetched by Action.

The option is added to the GRD Renewal Extension Cost table as well, alongside
New Kuwaiti and Overseas. The BA site has not added them there, so without this
there is no row to configure and no government rate to fetch - the whole point of
the story. Flagged for the BA to mirror.

Residency lists the Action as one it does not own, so the "anything that is not a
renewal is an extension" branch cannot open a second Residency for it, and maps
it to a First Time residency: MOI does not care which file the permit came from.
Medical Insurance opens it as New for the same reason.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Chain: **WI-002024** → WI-002031 → WI-002033. Merge this first.

Tests: 8 passing (`--module one_fm.grd.doctype.preparation.test_overseas_government_action`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)