### PR TITLE
WI-002031 [Iman] HR Settings Action Fee Master Configuration & Preparation Cost Auto-Fetching

### DIFF
--- a/one_fm/grd/doctype/preparation/preparation.js
+++ b/one_fm/grd/doctype/preparation/preparation.js
@@ -36,29 +36,54 @@ frappe.ui.form.on('Preparation Record',{
 	}
 });
 
+// WI-002031: the Actions whose master fee row is keyed by the number of years too. Kept
+// in step with YEAR_SCOPED_ACTIONS in preparation.py and with the costing table's own
+// depends_on.
+const YEAR_SCOPED_ACTIONS = ['Renewal (Kuwaiti)', 'Renewal (Non-Kuwaiti)'];
+const COST_COMPONENT_FIELDS = [
+	'work_permit_amount',
+	'medical_insurance_amount',
+	'residency_stamp_amount',
+	'civil_id_amount'
+];
+
 var set_preparation_record_costing = function(frm, cdt, cdn) {
 	var row = locals[cdt][cdn];
-	if(row.renewal_or_extend){
-		if(row.renewal_or_extend == 'Renewal' & !row.no_of_years){
-			frappe.model.set_value(row.doctype, row.name, "no_of_years", '1 Year');
+	if(!row.renewal_or_extend){
+		return;
+	}
+
+	// The years only mean something for a renewal. Cleared otherwise, because the field is
+	// hidden rather than emptied when the Action changes, and a stale "1 Year" left on an
+	// Extend row is a year the master lookup would have been scoped by.
+	if(YEAR_SCOPED_ACTIONS.includes(row.renewal_or_extend)){
+		if(!row.no_of_years){
+			frappe.model.set_value(row.doctype, row.name, 'no_of_years', '1 Year');
+		}
+	} else if(row.no_of_years){
+		frappe.model.set_value(row.doctype, row.name, 'no_of_years', '');
+	}
+
+	// Cleared before the fetch, not inside a successful callback. Switching to an Action
+	// with no master row configured used to leave the fees of the previous Action sitting
+	// in the row, which is exactly the case the story calls out.
+	COST_COMPONENT_FIELDS.forEach(field => frappe.model.set_value(row.doctype, row.name, field, 0));
+	frappe.model.set_value(row.doctype, row.name, 'total_amount', 0);
+	frm.refresh_field('preparation_record');
+
+	frappe.call({
+		method: 'one_fm.grd.doctype.preparation.preparation.get_grd_renewal_extension_cost',
+		args: {'renewal_or_extend': row.renewal_or_extend, 'no_of_years': row.no_of_years},
+		callback: function(r) {
+			if(!r.message){
+				return;
+			}
+			var cost = r.message;
+			COST_COMPONENT_FIELDS.forEach(field =>
+				frappe.model.set_value(row.doctype, row.name, field, cost[field] || 0));
 			frm.refresh_field('preparation_record');
 		}
-		frappe.call({
-			method: 'one_fm.grd.doctype.preparation.preparation.get_grd_renewal_extension_cost',
-			args: {'renewal_or_extend': row.renewal_or_extend, 'no_of_years': row.no_of_years},
-			callback: function(r) {
-				if(r.message){
-					var cost = r.message;
-					frappe.model.set_value(row.doctype, row.name, "work_permit_amount", cost.work_permit_amount);
-					frappe.model.set_value(row.doctype, row.name, "medical_insurance_amount", cost.medical_insurance_amount);
-					frappe.model.set_value(row.doctype, row.name, "residency_stamp_amount", cost.residency_stamp_amount);
-					frappe.model.set_value(row.doctype, row.name, "civil_id_amount", cost.civil_id_amount);
-					frappe.model.set_value(row.doctype, row.name, "total_amount", cost.total_amount);
-					frm.refresh_field('preparation_record');
-				}
-			}
-		});
-	}
+	});
 };
 
 var caclulate_renewal_extension_cost_total = function(frm, child) {

--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -6,7 +6,10 @@
 
 from __future__ import unicode_literals
 import frappe
+from frappe import _
 from frappe.model.document import Document
+from frappe.query_builder import DocType
+from frappe.utils import flt
 from frappe.utils import (
     today,
     add_months,
@@ -75,12 +78,47 @@ NEW_ACTION_DOCUMENTS = {
 }
 
 
+# WI-002031: the fee components a master row and a Preparation row both carry, and which
+# the Total Amount on each is the sum of. Named once because HR Settings and Preparation
+# have to agree on the list - a component added to one and not the other silently drops
+# out of the total on the other side.
+COST_COMPONENT_FIELDS = (
+    'work_permit_amount',
+    'medical_insurance_amount',
+    'residency_stamp_amount',
+    'civil_id_amount',
+)
+
+# The Actions whose master fee row is keyed by the number of years as well as the Action.
+# Mirrors the depends_on the costing table already puts on its No. of Years field.
+YEAR_SCOPED_ACTIONS = ('Renewal (Kuwaiti)', 'Renewal (Non-Kuwaiti)')
+
+
 class Preparation(Document):
     def update_total_amount(self):
-        doc_total =  sum(i.total_amount or 0 for i in self.preparation_record if i)
+        """Derive each row's Total Amount from its components, then the document total.
+
+        The row total was summed only in the browser (WI-002031), which left the field -
+        read-only, and the number finance is emailed - holding whatever the last client to
+        touch the row happened to compute. A row whose components were edited after submit,
+        or filled by any path other than the Action dropdown, kept a total that did not
+        match its own parts.
+
+        Rows are written with `db_set` once the document is submitted, because
+        `on_update_after_submit` runs after the child rows are already saved and a plain
+        assignment there would be discarded.
+        """
+        for row in self.preparation_record:
+            row_total = sum(flt(row.get(field)) for field in COST_COMPONENT_FIELDS)
+            if self.docstatus == 1:
+                row.db_set('total_amount', row_total)
+            else:
+                row.total_amount = row_total
+
+        doc_total = sum(flt(row.total_amount) for row in self.preparation_record)
         frappe.db.set_value(self.doctype,self.name,'total_payment',doc_total)
         self.total_payment = doc_total
-                     
+
     def on_update_after_submit(self):
         self.compare_preparation_record()
         self.update_total_amount()
@@ -229,11 +267,16 @@ class Preparation(Document):
 
             preparation.renewal_or_extend = extension_type if renew_all else ""
             preparation.no_of_years = no_of_years if renew_all else ""
-            preparation.work_permit_amount = costing.work_permit_amount if renew_all else ""
-            preparation.medical_insurance_amount = costing.medical_insurance_amount if renew_all else ""
-            preparation.residency_stamp_amount = costing.residency_stamp_amount if renew_all else ""
-            preparation.civil_id_amount = costing.civil_id_amount if renew_all else ""
-            preparation.total_amount = costing.total_amount if renew_all else ""
+            # A nationality with no master row configured used to fail here on
+            # `None.work_permit_amount`, taking the whole "renew all" action down with it
+            # (WI-002031). The row is left at zero instead, which the operator can see and
+            # fill, and the totals below stay consistent with it.
+            costing = costing or frappe._dict()
+            for field in COST_COMPONENT_FIELDS:
+                preparation.set(field, flt(costing.get(field)) if renew_all else 0)
+            preparation.total_amount = sum(
+                flt(preparation.get(field)) for field in COST_COMPONENT_FIELDS
+            )
 
 # Calculate the date of the next month (First & Last) (monthly cron in hooks)
 def auto_create_preparation_record():
@@ -342,25 +385,47 @@ def create_notification_log(subject, message, for_users, reference_doc):
         doc.insert(ignore_permissions=True)
 
 @frappe.whitelist()
-def get_grd_renewal_extension_cost(renewal_or_extend, no_of_years=False):
-	if renewal_or_extend == 'Renewal' and not no_of_years:
-		return False
-	else:
-		query = """
-			select
-				*
-			from
-				`tabGRD Renewal Extension Cost`
-			where
-				parent = 'HR Settings'
-				and
-				renewal_or_extend = '{0}'
-		""".format(renewal_or_extend)
-		if renewal_or_extend == 'Renewal':
-			query += " and no_of_years = '{0}'".format(no_of_years)
-		result = frappe.db.sql(query, as_dict=True)
-		if result and len(result) > 0:
-			return result[0]
+def get_grd_renewal_extension_cost(renewal_or_extend: str, no_of_years: str = None):
+    """The master fee breakdown HR Settings holds for an Action (WI-002031).
+
+    Rewritten off `frappe.db.sql` with the Action interpolated into the string. The Action
+    arrives from the browser through a whitelisted method, so that was an injection hole
+    open to any logged-in user, and the method had no permission check at all. Both are
+    closed here: the Query Builder parameterises the value, and the caller has to be
+    someone who could fill in a Preparation row, which is the only thing this feeds.
+
+    The old version filtered on the number of years only when the Action was exactly
+    "Renewal" - a value the field has not offered since the options became
+    "Renewal (Kuwaiti)" and "Renewal (Non-Kuwaiti)". The filter was therefore dead, and a
+    renewal with three configured rows (1, 2 and 3 Years) got whichever the database
+    handed back first. The years now scope the lookup for the two renewal Actions, which
+    are the ones whose master rows are keyed by it.
+
+    Deliberately not scoped by years for any other Action: the field is hidden for them
+    but not cleared, so a row switched from Renewal (Non-Kuwaiti) to Extend 1 month still
+    carries "1 Year", and filtering on it would find nothing and quietly return no fees.
+    """
+    if not frappe.has_permission('Preparation', 'write'):
+        frappe.throw(_("Not permitted to read the GRD renewal and extension costing."),
+                     frappe.PermissionError)
+
+    if renewal_or_extend in YEAR_SCOPED_ACTIONS and not no_of_years:
+        return False
+
+    Cost = DocType('GRD Renewal Extension Cost')
+    query = (
+        frappe.qb.from_(Cost)
+        .select('*')
+        .where(Cost.parent == 'HR Settings')
+        .where(Cost.parenttype == 'HR Settings')
+        .where(Cost.renewal_or_extend == renewal_or_extend)
+    )
+    if renewal_or_extend in YEAR_SCOPED_ACTIONS:
+        query = query.where(Cost.no_of_years == no_of_years)
+
+    result = query.run(as_dict=True)
+    if result:
+        return result[0]
 
 def create_documents_for_new_actions(preparation_name):
     """Generate the sub-documents the New Kuwaiti and Overseas Actions ask for (WI-001824).

--- a/one_fm/grd/doctype/preparation/test_action_fee_master.py
+++ b/one_fm/grd/doctype/preparation/test_action_fee_master.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002031: master fee rows in HR Settings and how a Preparation row fetches them."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import nowdate
+
+from one_fm.grd.doctype.preparation.preparation import (
+	COST_COMPONENT_FIELDS,
+	YEAR_SCOPED_ACTIONS,
+	get_grd_renewal_extension_cost,
+)
+from one_fm.grd.utils import set_renewal_extension_cost_totals
+
+GOVERNMENT = "Overseas (Government)"
+PRIVATE = "Overseas"
+
+
+def _an_active_employee():
+	name = frappe.db.get_value(
+		"Employee",
+		{"status": "Active", "relieving_date": ["is", "not set"]},
+		"name",
+		order_by="creation asc",
+	)
+	if not name:
+		raise frappe.DoesNotExistError("No active employee on this site to test against")
+	return name
+
+
+def _master_rows(rows):
+	"""Replace the HR Settings costing table with the given rows and save."""
+	settings = frappe.get_doc("HR Settings")
+	settings.set("renewal_extension_cost", [])
+	for row in rows:
+		settings.append("renewal_extension_cost", row)
+	settings.flags.ignore_permissions = True
+	settings.save()
+	return settings
+
+
+class TestActionFeeMaster(FrappeTestCase):
+	def test_the_hr_settings_totals_hook_is_registered(self):
+		self.assertIn(
+			"one_fm.grd.utils.set_renewal_extension_cost_totals",
+			frappe.get_hooks("doc_events").get("HR Settings", {}).get("validate", []),
+		)
+
+	def test_a_master_row_total_is_the_sum_of_its_components(self):
+		doc = frappe._dict(
+			renewal_extension_cost=[
+				frappe._dict(
+					work_permit_amount=210,
+					medical_insurance_amount=50,
+					residency_stamp_amount=10,
+					civil_id_amount=5,
+					total_amount=0,
+				)
+			]
+		)
+		# _dict has no .get_ semantics for child rows, so mimic what a Document gives us.
+		doc.get = lambda field, default=None: doc.__dict__.get(field, default)
+
+		set_renewal_extension_cost_totals(doc)
+
+		self.assertEqual(doc.renewal_extension_cost[0].total_amount, 275)
+
+	def test_a_zero_component_contributes_nothing_to_the_master_total(self):
+		row = frappe._dict(
+			work_permit_amount=210,
+			medical_insurance_amount=0,
+			residency_stamp_amount=0,
+			civil_id_amount=0,
+			total_amount=999,
+		)
+		doc = frappe._dict(renewal_extension_cost=[row])
+		doc.get = lambda field, default=None: doc.__dict__.get(field, default)
+
+		set_renewal_extension_cost_totals(doc)
+
+		self.assertEqual(row.total_amount, 210)
+
+	def test_saving_hr_settings_derives_the_row_total(self):
+		settings = _master_rows(
+			[
+				{
+					"renewal_or_extend": GOVERNMENT,
+					"work_permit_amount": 60,
+					"medical_insurance_amount": 0,
+					"residency_stamp_amount": 0,
+					"civil_id_amount": 0,
+					"total_amount": 12345,  # a stale total the read-only field was holding
+				}
+			]
+		)
+		self.assertEqual(settings.renewal_extension_cost[0].total_amount, 60)
+
+	def test_each_action_fetches_its_own_work_permit_rate(self):
+		_master_rows(
+			[
+				{"renewal_or_extend": PRIVATE, "work_permit_amount": 210},
+				{"renewal_or_extend": GOVERNMENT, "work_permit_amount": 60},
+			]
+		)
+
+		self.assertEqual(get_grd_renewal_extension_cost(PRIVATE)["work_permit_amount"], 210)
+		self.assertEqual(get_grd_renewal_extension_cost(GOVERNMENT)["work_permit_amount"], 60)
+
+	def test_a_renewal_is_scoped_by_the_number_of_years(self):
+		# The old lookup filtered on the years only when the Action was exactly "Renewal",
+		# a value the field has not offered for years, so this used to return whichever row
+		# the database handed back first.
+		action = YEAR_SCOPED_ACTIONS[1]
+		_master_rows(
+			[
+				{"renewal_or_extend": action, "no_of_years": "1 Year", "work_permit_amount": 100},
+				{"renewal_or_extend": action, "no_of_years": "2 Years", "work_permit_amount": 200},
+				{"renewal_or_extend": action, "no_of_years": "3 Years", "work_permit_amount": 300},
+			]
+		)
+
+		self.assertEqual(get_grd_renewal_extension_cost(action, "2 Years")["work_permit_amount"], 200)
+		self.assertEqual(get_grd_renewal_extension_cost(action, "3 Years")["work_permit_amount"], 300)
+
+	def test_a_renewal_without_a_year_fetches_nothing(self):
+		self.assertFalse(get_grd_renewal_extension_cost(YEAR_SCOPED_ACTIONS[0]))
+
+	def test_a_non_renewal_action_ignores_a_stale_year(self):
+		# The field is hidden but not cleared when the Action changes, so an Extend row can
+		# still carry "1 Year". Scoping by it would find nothing and return no fees.
+		_master_rows([{"renewal_or_extend": "Extend 1 month", "work_permit_amount": 25}])
+
+		self.assertEqual(
+			get_grd_renewal_extension_cost("Extend 1 month", "1 Year")["work_permit_amount"], 25
+		)
+
+	def test_an_unconfigured_action_returns_nothing_rather_than_a_wrong_row(self):
+		_master_rows([{"renewal_or_extend": PRIVATE, "work_permit_amount": 210}])
+
+		self.assertFalse(get_grd_renewal_extension_cost(GOVERNMENT))
+
+	def test_the_action_is_not_interpolated_into_the_query(self):
+		# The Action arrives from the browser through a whitelisted method. Under the old
+		# string-formatted SQL this closed the quote and ran on.
+		self.assertFalse(get_grd_renewal_extension_cost("' OR 1=1 -- "))
+
+	def test_a_preparation_row_total_is_derived_from_its_components(self):
+		preparation = frappe.get_doc(
+			{
+				"doctype": "Preparation",
+				"posting_date": nowdate(),
+				"preparation_record": [
+					{
+						"employee": _an_active_employee(),
+						"renewal_or_extend": GOVERNMENT,
+						"work_permit_amount": 60,
+						"medical_insurance_amount": 0,
+						"residency_stamp_amount": 10,
+						"civil_id_amount": 5,
+						"total_amount": 9999,  # not what the components add up to
+					}
+				],
+			}
+		)
+		preparation.flags.ignore_permissions = True
+		preparation.insert()
+
+		self.assertEqual(preparation.preparation_record[0].total_amount, 75)
+		self.assertEqual(preparation.total_payment, 75)
+
+	def test_the_component_list_matches_the_master_and_the_row(self):
+		for doctype in ("GRD Renewal Extension Cost", "Preparation Record"):
+			meta = frappe.get_meta(doctype)
+			for field in COST_COMPONENT_FIELDS:
+				self.assertTrue(meta.get_field(field), f"{doctype} has no {field}")

--- a/one_fm/grd/utils.py
+++ b/one_fm/grd/utils.py
@@ -5,7 +5,7 @@ import frappe
 from frappe import _
 from frappe.utils import today, add_days, get_url, date_diff, getdate
 from frappe.model.document import Document
-from frappe.utils import cstr, cint, get_fullname
+from frappe.utils import cstr, cint, get_fullname, flt
 from frappe.utils import today, add_days, get_url
 from datetime import date
 from frappe.model.mapper import get_mapped_doc
@@ -147,3 +147,21 @@ def attach_employee_document(employee, document_name, attach, valid_till, issued
     })
     row.db_insert()
     return row.name
+
+
+def set_renewal_extension_cost_totals(doc, method=None):
+    """Sum each master fee row's components into its Total Amount (WI-002031).
+
+    Runs on HR Settings validate. The sum was only ever done in the browser, so a row
+    saved by any other route - a data import, a patch, the API - kept a Total Amount that
+    did not match its own components, and every Preparation row that fetched it inherited
+    the mismatch. The field is read-only, so nobody could correct it by hand either.
+
+    Imported inside the function: the module is loaded by HR Settings' validate hook, and
+    importing Preparation at module scope makes HR Settings depend on the GRD doctype
+    module for a four-item tuple.
+    """
+    from one_fm.grd.doctype.preparation.preparation import COST_COMPONENT_FIELDS
+
+    for row in doc.get('renewal_extension_cost') or []:
+        row.total_amount = sum(flt(row.get(field)) for field in COST_COMPONENT_FIELDS)

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -240,6 +240,11 @@ doc_events = {
 			"one_fm.overrides.todo.delete_linked_todos"
 		]
 	},
+	"HR Settings": {
+		"validate": [
+			"one_fm.grd.utils.set_renewal_extension_cost_totals"
+		]
+	},
 	"Stock Entry": {
 		"validate": [
 			"one_fm.overrides.stock_entry.alert_item_multiple_entry",


### PR DESCRIPTION
Three things stood between the HR Settings costing table and a correct
Preparation row.

The Total Amount was summed only in the browser, on both sides. The field is
read-only and the number finance is emailed, yet a master row saved by any other
route - an import, a patch, the API - and a Preparation row whose components were
edited after submit both kept a total that did not match their own parts, with no
way to correct it by hand. Both are now derived server-side, from one named list
of components so the two sides cannot drift apart.

Switching a row's Action left the previous Action's fees in place whenever the new
one had no master row configured, because the client only wrote fees inside a
successful callback. The row is cleared before the fetch instead, which is the
case the story calls out: change Overseas to Overseas (Government) and see the
government breakdown or nothing, never the private one.

The lookup itself filtered on the number of years only when the Action was exactly
"Renewal" - a value the field stopped offering when the options became
"Renewal (Kuwaiti)" and "Renewal (Non-Kuwaiti)". The filter was dead, so a renewal
with 1, 2 and 3 Year rows configured got whichever the database returned first.
The years now scope the two renewal Actions and are ignored for the rest, because
the field is hidden but not cleared when the Action changes and a stale "1 Year"
on an Extend row would scope it to nothing.

Two things found while rewriting that lookup and fixed here rather than left:

- It was a whitelisted method with no permission check that formatted its Action
  straight into a SQL string. Any logged-in user could reach it and the value came
  from the browser. It now uses the Query Builder and requires write access to
  Preparation, which is the only thing it feeds.
- "Set renewal for all" crashed on None.work_permit_amount for any nationality
  with no master row configured, taking the whole batch down. Those rows are left
  at zero, which the operator can see and fill.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Chain: WI-002024 → **WI-002031** → WI-002033. Based on #6683, retarget to staging once that merges.

Note: adds a `"HR Settings": {"validate": [...]}` block to hooks.py. WI-002025 (#6686) adds one too — expect a trivial conflict merging the second of the two; keep both entries in the list.

Tests: 12 passing (`--module one_fm.grd.doctype.preparation.test_action_fee_master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)