### PR TITLE
WI-002033 [Iman] Automated Category mapping from Preparation doctype to linked Sub-Doctypes

### DIFF
--- a/one_fm/grd/doctype/medical_insurance/medical_insurance.py
+++ b/one_fm/grd/doctype/medical_insurance/medical_insurance.py
@@ -97,10 +97,24 @@ def transfer_insurance_already_open(employee):
     }))
 
 
-def create_mi_record(WorkPermit):
+def create_mi_record(WorkPermit, insurance_status=None):
+    """Open the insurance a Work Permit calls for.
+
+    WI-002033: a caller that already knows the classification - a Preparation row, whose
+    Action states it in NEW_ACTION_DOCUMENTS - passes it in. The derivation below is kept
+    for the callers that do not: the transfer path and the renewal path arrive with a Work
+    Permit and nothing else.
+    """
     new_medical_insurance = frappe.new_doc('Medical Insurance')
 
-    if(WorkPermit.work_permit_type == "Renewal Non Kuwaiti"):
+    if insurance_status:
+        Insurance_status = insurance_status
+        # The application date still follows the Work Permit's, which is the fact the
+        # caller does not have and this function does.
+        new_medical_insurance.date_of_application = (
+            today() if insurance_status == "Local Transfer" else WorkPermit.date_of_application
+        )
+    elif(WorkPermit.work_permit_type == "Renewal Non Kuwaiti"):
         Insurance_status = "Renewal"
         new_medical_insurance.date_of_application = WorkPermit.date_of_application #setting the same date of application of wp
     elif(WorkPermit.work_permit_type in ("Overseas", "Overseas (Government)")):

--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -36,20 +36,25 @@ from one_fm.processor import sendemail
 # New Kuwaiti gets a Work Permit and nothing else: a Kuwaiti has no residency, no civil
 # ID application and no medical insurance process to open.
 #
-# A key means "open this document"; its value is the classification we have to hand the
-# creator. None where the creator works it out itself and its other callers rely on it
-# doing so - Medical Insurance maps the status off the Work Permit type, Residency maps
-# the category off the Action (see MOI_CATEGORY_BY_ACTION in residency.py). PACI writes
-# whatever it is given, so its category is named here. The values that result are the
-# mapping WI-001881 defines.
+# A key means "open this document"; its value is the government classification that
+# document is opened under. WI-002033: every value is stated here rather than left to the
+# creator to derive. Three of the four used to be None, meaning "Medical Insurance will
+# map the status off the Work Permit type and Residency will map the category off the
+# Action" - so this table, the one place an operator or a reviewer looks to see what an
+# Action produces, did not actually say what three of the four documents would get, and a
+# change to either creator's own mapping silently changed what Preparation produced.
+#
+# The creators keep their derivations for their other callers, which do not come through a
+# Preparation row and have nothing to pass. Residency still takes its application date
+# from MOI_CATEGORY_BY_ACTION; only the category is handed to it.
 NEW_ACTION_DOCUMENTS = {
     "New Kuwaiti": {
         "work_permit": "New Kuwaiti",
     },
     "Overseas": {
         "work_permit": "Overseas",
-        "medical_insurance": None,
-        "residency": None,
+        "medical_insurance": "New",
+        "residency": "First Time",
         "paci": "New Application",
     },
     # WI-002024: the same overseas hire, but against a government contract file rather
@@ -61,8 +66,8 @@ NEW_ACTION_DOCUMENTS = {
     # distinction is actually made.
     "Overseas (Government)": {
         "work_permit": "Overseas (Government)",
-        "medical_insurance": None,
-        "residency": None,
+        "medical_insurance": "New",
+        "residency": "First Time",
         "paci": "New Application",
     },
     # The process map groups Local Transfer with Overseas and the non-Kuwaiti renewal:
@@ -71,8 +76,8 @@ NEW_ACTION_DOCUMENTS = {
     # assuming one.
     "Local Transfer": {
         "work_permit": "Local Transfer",
-        "medical_insurance": None,
-        "residency": None,
+        "medical_insurance": "Local Transfer",
+        "residency": "Transfer",
         "paci": "Transfer",
     },
 }
@@ -464,10 +469,14 @@ def create_documents_for_row(row, preparation_name):
     )
 
     if "medical_insurance" in plan:
-        medical_insurance.create_mi_record(work_permit_doc)
+        medical_insurance.create_mi_record(
+            work_permit_doc, insurance_status=plan["medical_insurance"]
+        )
 
     if "residency" in plan:
-        residency.create_moi_record(employee_doc, row.renewal_or_extend, preparation_name)
+        residency.create_moi_record(
+            employee_doc, row.renewal_or_extend, preparation_name, category=plan["residency"]
+        )
 
     if "paci" in plan:
         paci.create_PACI(employee_doc, plan["paci"], preparation_name)

--- a/one_fm/grd/doctype/preparation/test_action_category_mapping.py
+++ b/one_fm/grd/doctype/preparation/test_action_category_mapping.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002033: the Action's classification reaches every sub-document it opens."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import nowdate
+
+from one_fm.grd.doctype.preparation.preparation import (
+	NEW_ACTION_DOCUMENTS,
+	create_documents_for_row,
+)
+
+# The field on each sub-document that carries the Action's classification.
+CLASSIFICATION_FIELD = {
+	"work_permit": ("Work Permit", "work_permit_type"),
+	"medical_insurance": ("Medical Insurance", "insurance_status"),
+	"residency": ("Residency", "category"),
+	"paci": ("PACI", "category"),
+}
+
+
+def _an_active_employee():
+	name = frappe.db.get_value(
+		"Employee",
+		{"status": "Active", "relieving_date": ["is", "not set"]},
+		"name",
+		order_by="creation asc",
+	)
+	if not name:
+		raise frappe.DoesNotExistError("No active employee on this site to test against")
+	return frappe.get_doc("Employee", name)
+
+
+class TestActionCategoryMapping(FrappeTestCase):
+	def setUp(self):
+		self.employee = _an_active_employee()
+
+	def _documents_for(self, action):
+		preparation = frappe.get_doc(
+			{
+				"doctype": "Preparation",
+				"posting_date": nowdate(),
+				"preparation_record": [{"employee": self.employee.name, "renewal_or_extend": action}],
+			}
+		)
+		preparation.flags.ignore_permissions = True
+		preparation.insert()
+		create_documents_for_row(preparation.preparation_record[0], preparation.name)
+		return preparation.name
+
+	def test_every_planned_classification_is_stated_not_derived(self):
+		# The point of the story: the table says what each document gets, rather than three
+		# of the four reading None and leaving it to the creator.
+		for action, plan in NEW_ACTION_DOCUMENTS.items():
+			for document, classification in plan.items():
+				self.assertIsNotNone(
+					classification, f"{action} does not state what its {document} is opened as"
+				)
+
+	def test_the_plan_only_names_classifications_the_field_accepts(self):
+		for action, plan in NEW_ACTION_DOCUMENTS.items():
+			for document, classification in plan.items():
+				doctype, fieldname = CLASSIFICATION_FIELD[document]
+				options = frappe.get_meta(doctype).get_field(fieldname).options.split("\n")
+				self.assertIn(
+					classification,
+					options,
+					f"{action} opens its {document} as {classification!r}, which {doctype}.{fieldname} "
+					"does not offer",
+				)
+
+	def test_overseas_government_maps_all_four_documents(self):
+		action = "Overseas (Government)"
+		preparation = self._documents_for(action)
+
+		self.assertEqual(self._classification(preparation, "Work Permit", "work_permit_type"), action)
+		self.assertEqual(
+			self._classification(preparation, "Medical Insurance", "insurance_status"), "New"
+		)
+		self.assertEqual(self._classification(preparation, "Residency", "category"), "First Time")
+		self.assertEqual(self._classification(preparation, "PACI", "category"), "New Application")
+
+	def test_local_transfer_maps_all_four_documents(self):
+		preparation = self._documents_for("Local Transfer")
+
+		self.assertEqual(
+			self._classification(preparation, "Work Permit", "work_permit_type"), "Local Transfer"
+		)
+		self.assertEqual(
+			self._classification(preparation, "Medical Insurance", "insurance_status"), "Local Transfer"
+		)
+		self.assertEqual(self._classification(preparation, "Residency", "category"), "Transfer")
+		self.assertEqual(self._classification(preparation, "PACI", "category"), "Transfer")
+
+	def test_overseas_maps_all_four_documents(self):
+		preparation = self._documents_for("Overseas")
+
+		self.assertEqual(self._classification(preparation, "Work Permit", "work_permit_type"), "Overseas")
+		self.assertEqual(
+			self._classification(preparation, "Medical Insurance", "insurance_status"), "New"
+		)
+		self.assertEqual(self._classification(preparation, "Residency", "category"), "First Time")
+		self.assertEqual(self._classification(preparation, "PACI", "category"), "New Application")
+
+	def test_what_the_plan_says_is_what_the_documents_get(self):
+		# The guard the story is really asking for: the table and reality cannot drift.
+		for action, plan in NEW_ACTION_DOCUMENTS.items():
+			preparation = self._documents_for(action)
+			for document, classification in plan.items():
+				doctype, fieldname = CLASSIFICATION_FIELD[document]
+				self.assertEqual(
+					self._classification(preparation, doctype, fieldname),
+					classification,
+					f"{action}: {doctype}.{fieldname} does not match the plan",
+				)
+
+	def test_a_submitted_sub_document_still_carries_its_classification(self):
+		preparation = self._documents_for("Overseas (Government)")
+		paci = frappe.get_doc(
+			"PACI", {"preparation": preparation, "employee": self.employee.name}
+		)
+		paci.flags.ignore_permissions = True
+		paci.new_civil_id_expiry_date = nowdate()
+		paci.submit()
+
+		self.assertEqual(frappe.db.get_value("PACI", paci.name, "category"), "New Application")
+		self.assertEqual(paci.docstatus, 1)
+
+	def _classification(self, preparation, doctype, fieldname):
+		return frappe.db.get_value(
+			doctype, {"preparation": preparation, "employee": self.employee.name}, fieldname
+		)

--- a/one_fm/grd/doctype/residency/residency.py
+++ b/one_fm/grd/doctype/residency/residency.py
@@ -296,9 +296,20 @@ def create_moi_for_transfer(work_permit_name):
             # field only risked a second lookup failing.
             create_moi_record(employee,"Transfer")
 
-def create_moi_record(employee,Renewal_or_Extend,preparation_name = None):
+def create_moi_record(employee,Renewal_or_Extend,preparation_name = None, category=None):
+    """Open the Residency an Action calls for.
 
-    category, days_before_expiry = MOI_CATEGORY_BY_ACTION.get(Renewal_or_Extend, ("Extend", -7))
+    WI-002033: a Preparation row states the category in NEW_ACTION_DOCUMENTS and passes it
+    in, so the table an operator reads to see what an Action produces is the one the
+    document is actually opened under. The map below still supplies the application date -
+    how many days before the residency expires it is applied for - which the caller does
+    not know, and still supplies the category for the callers that pass none: the transfer
+    path and the extend branch.
+    """
+    mapped_category, days_before_expiry = MOI_CATEGORY_BY_ACTION.get(
+        Renewal_or_Extend, ("Extend", -7)
+    )
+    category = category or mapped_category
     start_date = add_days(employee.residency_expiry_date, days_before_expiry) if days_before_expiry else today()
 
 


### PR DESCRIPTION
NEW_ACTION_DOCUMENTS is the one place an operator or a reviewer looks to see what
an Action produces, and for three of the four documents it did not say. Medical
Insurance and Residency read None, meaning "the creator will work it out" - the
insurance status off the Work Permit type, the residency category off the Action.
So the table documented one thing and the system did another, and a change to
either creator's own mapping silently changed what a Preparation produced.

Every classification is now stated in the table and handed to the creator. Both
creators keep their derivations for the callers that have nothing to pass - the
transfer path and the renewal path arrive with a Work Permit and no Action - and
Residency still takes its application date from MOI_CATEGORY_BY_ACTION, which is
the fact the caller does not have.

The test that matters is the last one: for every Action in the table, open its
documents and assert each carries what the table promised. The table and reality
cannot drift apart without it failing.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Chain: WI-002024 → WI-002031 → **WI-002033**. Based on #6684, retarget once that merges.

Tests: 7 passing (`--module one_fm.grd.doctype.preparation.test_action_category_mapping`), plus the existing new-actions and MI-transfer suites re-run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)