### PR TITLE
WI-002028 [Iman] PCC Attestation DocType Creation

### DIFF
--- a/one_fm/grd/doctype/pcc_attestation/pcc_attestation.js
+++ b/one_fm/grd/doctype/pcc_attestation/pcc_attestation.js
@@ -1,0 +1,26 @@
+// Copyright (c) 2026, ONE FM and contributors
+// For license information, please see license.txt
+
+// WI-002028: show the operator when a receipt went up without waiting for a save, and blank
+// the stamp as soon as a file is removed. The controller stamps the same fields from the
+// server clock on every save and stays the authority on them.
+frappe.ui.form.on('PCC Attestation', {
+	upload_embassy_payment_receipt: function(frm){
+		stamp_receipt(frm, 'upload_embassy_payment_receipt', 'upload_embassy_payment_receipt_on');
+	},
+	upload_mofa_payment_receipt: function(frm){
+		stamp_receipt(frm, 'upload_mofa_payment_receipt', 'upload_mofa_payment_receipt_on');
+	},
+	upload_translation_payment_receipt: function(frm){
+		stamp_receipt(frm, 'upload_translation_payment_receipt', 'upload_translation_payment_receipt_on');
+	}
+});
+
+function stamp_receipt(frm, receipt_field, timestamp_field){
+	if(frm.doc[receipt_field] && !frm.doc[timestamp_field]){
+		frm.set_value(timestamp_field, frappe.datetime.now_datetime());
+	}
+	if(!frm.doc[receipt_field] && frm.doc[timestamp_field]){
+		frm.set_value(timestamp_field, null);
+	}
+}

--- a/one_fm/grd/doctype/pcc_attestation/pcc_attestation.json
+++ b/one_fm/grd/doctype/pcc_attestation/pcc_attestation.json
@@ -34,6 +34,9 @@
   "residency_expiry_date",
   "company_pam_file_number",
   "attestation_and_cost_breakdown_section",
+  "embassy_attestation_required",
+  "mofa_attestation_required",
+  "translation_required",
   "requires_embassy_attestation",
   "translation_fee",
   "column_break_oidl",
@@ -336,12 +339,39 @@
    "options": "PCC Attestation",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "description": "Derived from the Nationality Attestation Rules in HR Settings.",
+   "fieldname": "embassy_attestation_required",
+   "fieldtype": "Check",
+   "label": "Embassy Attestation Required",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "description": "Derived from the Nationality Attestation Rules in HR Settings.",
+   "fieldname": "mofa_attestation_required",
+   "fieldtype": "Check",
+   "label": "MOFA Attestation Required",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "description": "Derived from the Nationality Attestation Rules in HR Settings.",
+   "fieldname": "translation_required",
+   "fieldtype": "Check",
+   "label": "Translation Required",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-12 11:30:00.000000",
+ "modified": "2026-08-13 09:30:00.000000",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "PCC Attestation",

--- a/one_fm/grd/doctype/pcc_attestation/pcc_attestation.json
+++ b/one_fm/grd/doctype/pcc_attestation/pcc_attestation.json
@@ -1,0 +1,410 @@
+{
+ "actions": [],
+ "autoname": "naming_series:",
+ "creation": "2026-08-12 11:30:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "naming_series",
+  "column_break_6",
+  "employee_information_section",
+  "type",
+  "employee",
+  "employee_name",
+  "category",
+  "preparation",
+  "column_break_5",
+  "employee_id",
+  "centeralized_number",
+  "section_break_20",
+  "one_fm_civil_id",
+  "designation",
+  "nationality",
+  "place_of_birth",
+  "gender",
+  "birth_date",
+  "company_email_id",
+  "column_break_20",
+  "passport_number",
+  "passport_type",
+  "passport_issue_date",
+  "passport_expiry_date",
+  "pam_designation",
+  "residency_expiry_date",
+  "company_pam_file_number",
+  "attestation_and_cost_breakdown_section",
+  "requires_embassy_attestation",
+  "translation_fee",
+  "column_break_oidl",
+  "mofa_fee",
+  "section_break_42",
+  "upload_embassy_payment_receipt",
+  "upload_mofa_payment_receipt",
+  "upload_translation_payment_receipt",
+  "column_break_34",
+  "upload_embassy_payment_receipt_on",
+  "upload_mofa_payment_receipt_on",
+  "upload_translation_payment_receipt_on",
+  "section_break_40",
+  "pro_user",
+  "column_break_cxze",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Series",
+   "options": "PCC-.YYYY.-"
+  },
+  {
+   "fieldname": "column_break_6",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "employee_information_section",
+   "fieldtype": "Section Break",
+   "label": "Employee Information"
+  },
+  {
+   "fieldname": "type",
+   "fieldtype": "Select",
+   "label": "Type",
+   "options": "\nAttestation\nTranslation",
+   "reqd": 1
+  },
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "in_list_view": 1,
+   "label": "Employee",
+   "options": "Employee",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "employee.employee_name",
+   "fieldname": "employee_name",
+   "fieldtype": "Data",
+   "label": "Employee Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "category",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Category",
+   "options": "\nOverseas\nOverseas (Government)"
+  },
+  {
+   "fieldname": "preparation",
+   "fieldtype": "Link",
+   "label": "Preparation",
+   "options": "Preparation",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_5",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "employee.employee_id",
+   "fieldname": "employee_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Employee ID",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fetch_from": "employee.one_fm_centralized_number",
+   "fieldname": "centeralized_number",
+   "fieldtype": "Data",
+   "label": "Centeralized Number",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_20",
+   "fieldtype": "Section Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "fetch_from": "employee.one_fm_civil_id",
+   "fieldname": "one_fm_civil_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Civil ID",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "employee.designation",
+   "fieldname": "designation",
+   "fieldtype": "Data",
+   "label": "Designation",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fetch_from": "employee.one_fm_nationality",
+   "fieldname": "nationality",
+   "fieldtype": "Data",
+   "label": "Nationality",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fetch_from": "employee.one_fm_place_of_birth",
+   "fieldname": "place_of_birth",
+   "fieldtype": "Data",
+   "label": "Place Of Birth",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "employee.gender",
+   "fieldname": "gender",
+   "fieldtype": "Data",
+   "label": "Gender",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "employee.date_of_birth",
+   "fieldname": "birth_date",
+   "fieldtype": "Data",
+   "label": "Birth Date",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "employee.company_email",
+   "fieldname": "company_email_id",
+   "fieldtype": "Data",
+   "label": "Company Email ID",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_20",
+   "fieldtype": "Column Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "fetch_from": "employee.passport_number",
+   "fieldname": "passport_number",
+   "fieldtype": "Data",
+   "label": "Passport Number",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fetch_from": "employee.one_fm_passport_type",
+   "fieldname": "passport_type",
+   "fieldtype": "Data",
+   "label": "Passport Type",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "employee.date_of_issue",
+   "fieldname": "passport_issue_date",
+   "fieldtype": "Data",
+   "label": "Passport Issue Date",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fetch_from": "employee.valid_upto",
+   "fieldname": "passport_expiry_date",
+   "fieldtype": "Data",
+   "label": "Passport Expiry Date",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fetch_from": "employee.one_fm_pam_designation",
+   "fieldname": "pam_designation",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "PAM Designation"
+  },
+  {
+   "allow_on_submit": 1,
+   "fetch_from": "employee.residency_expiry_date",
+   "fieldname": "residency_expiry_date",
+   "fieldtype": "Data",
+   "label": "Residency Expiry Date",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "employee.pam_file_number",
+   "fieldname": "company_pam_file_number",
+   "fieldtype": "Data",
+   "label": "Company PAM File Number",
+   "read_only": 1
+  },
+  {
+   "fieldname": "attestation_and_cost_breakdown_section",
+   "fieldtype": "Section Break",
+   "label": "Attestation and Cost Breakdown"
+  },
+  {
+   "fieldname": "requires_embassy_attestation",
+   "fieldtype": "Currency",
+   "label": "Embassy Attestation Fee",
+   "read_only": 1
+  },
+  {
+   "fieldname": "translation_fee",
+   "fieldtype": "Currency",
+   "label": "Translation Fee",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_oidl",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "mofa_fee",
+   "fieldtype": "Currency",
+   "label": "MOFA Fee",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_42",
+   "fieldtype": "Section Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "upload_embassy_payment_receipt",
+   "fieldtype": "Attach",
+   "label": "Upload Embassy Payment Receipt"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "upload_mofa_payment_receipt",
+   "fieldtype": "Attach",
+   "label": "Upload MOFA Payment Receipt"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "upload_translation_payment_receipt",
+   "fieldtype": "Attach",
+   "label": "Upload Translation Payment Receipt"
+  },
+  {
+   "fieldname": "column_break_34",
+   "fieldtype": "Column Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "upload_embassy_payment_receipt_on",
+   "fieldtype": "Data",
+   "label": "Upload Embassy Payment Receipt On",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "upload_mofa_payment_receipt_on",
+   "fieldtype": "Data",
+   "label": "Upload MOFA Payment Receipt On",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "upload_translation_payment_receipt_on",
+   "fieldtype": "Data",
+   "label": "Upload Translation Payment Receipt On",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_40",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "pro_user",
+   "fieldtype": "Link",
+   "label": "PRO User",
+   "options": "User"
+  },
+  {
+   "fieldname": "column_break_cxze",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "PCC Attestation",
+   "print_hide": 1,
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2026-08-12 11:30:00.000000",
+ "modified_by": "Administrator",
+ "module": "GRD",
+ "name": "PCC Attestation",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Government Relations Operator",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "GRD Supervisor",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "PRO",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "one_fm_civil_id",
+ "track_changes": 1
+}

--- a/one_fm/grd/doctype/pcc_attestation/pcc_attestation.py
+++ b/one_fm/grd/doctype/pcc_attestation/pcc_attestation.py
@@ -13,7 +13,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import now
 
-from one_fm.grd.utils import get_embassy_attestation_fee
+from one_fm.grd.utils import get_pcc_attestation_fees
 
 ATTESTATION = "Attestation"
 TRANSLATION = "Translation"
@@ -30,7 +30,7 @@ RECEIPT_TIMESTAMPS = (
 
 class PCCAttestation(Document):
 	def validate(self):
-		self.set_embassy_attestation_fee()
+		self.set_attestation_requirements()
 		self.set_receipt_timestamps()
 
 	def on_update_after_submit(self):
@@ -38,32 +38,61 @@ class PCCAttestation(Document):
 		# submitted. validate does not run on that path.
 		self.set_receipt_timestamps()
 
-	def set_embassy_attestation_fee(self):
-		"""Fetch the embassy fee for the candidate's Place of Birth (WI-002025 / WI-002028).
+	def set_attestation_requirements(self):
+		"""Derive what this certificate needs from the candidate's nationality (WI-002025).
 
-		A country in the Embassy Cost Table means its embassy attests and charges the stated
-		fee. A country absent from the table means it does not attest at all, and the fee
-		stays empty - which is what `requires_embassy_attestation` is read for when the
-		workflow decides whether to route through Pending Embassy.
+		The Nationality Attestation Rules in HR Settings say, per nationality, whether the
+		embassy attests, whether MOFA attests, and whether the certificate has to be
+		translated. All three are independent: the reporter's data has nationalities that need
+		MOFA but no embassy, and one - Ugandan - that needs neither, only translation.
 
-		Translation work never goes near an embassy, so the fee is cleared for it rather
-		than left showing a charge nobody will pay.
+		Held on the record as three flags rather than inferred from the fees, because a fee of
+		zero and a step that does not apply are different things, and the workflow routes on
+		the difference. An embassy that attests for free still has to be visited.
+
+		A nationality with no row in the table needs none of the three.
+
+		Translation work never goes near an embassy or MOFA, so those two are cleared for it
+		rather than left showing charges nobody will pay - and an Attestation is not a
+		translation, so its translation fee is cleared for the same reason.
 		"""
+		fees = get_pcc_attestation_fees(self.nationality)
+
 		if self.type == TRANSLATION:
+			self.embassy_attestation_required = 0
+			self.mofa_attestation_required = 0
 			self.requires_embassy_attestation = 0
+			self.mofa_fee = 0
+			self.translation_required = 1
+			self.translation_fee = fees.translation_fee
 			return
 
-		fee = get_embassy_attestation_fee(self.place_of_birth)
-		self.requires_embassy_attestation = fee if fee is not None else 0
+		self.embassy_attestation_required = int(fees.embassy_required)
+		self.mofa_attestation_required = int(fees.mofa_required)
+		self.translation_required = int(fees.translation_required)
+
+		self.requires_embassy_attestation = fees.embassy_fee
+		self.mofa_fee = fees.mofa_fee
+		self.translation_fee = 0
 
 	@property
 	def needs_embassy_attestation(self):
-		"""Does this candidate's country attest at all?
+		"""Does this candidate's nationality need the embassy step at all?
 
-		Distinct from the fee being non-zero: an embassy that attests for free still has to
-		be visited, so the question is whether the country is in the table.
+		Distinct from the fee being non-zero: an embassy that attests for free still has to be
+		visited, so the question is what the rule says, not what it charges.
 		"""
-		return self.type == ATTESTATION and get_embassy_attestation_fee(self.place_of_birth) is not None
+		return self.type == ATTESTATION and bool(self.embassy_attestation_required)
+
+	@property
+	def needs_mofa_attestation(self):
+		"""Does this candidate's nationality need the MOFA step at all?
+
+		The reason this exists: the reporter's data has a nationality that needs neither
+		embassy nor MOFA, and routing "not embassy" straight to Pending MOFA would have
+		blocked its PRO on a receipt that was never going to exist.
+		"""
+		return self.type == ATTESTATION and bool(self.mofa_attestation_required)
 
 	def set_receipt_timestamps(self):
 		"""Stamp when each receipt went up, and clear the stamp if the file is removed."""

--- a/one_fm/grd/doctype/pcc_attestation/pcc_attestation.py
+++ b/one_fm/grd/doctype/pcc_attestation/pcc_attestation.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+"""The attestation of an employee's Police Clearance Certificate (WI-002028).
+
+Not to be confused with PCC Clearance, which is the recruitment-side record of obtaining
+the certificate for a candidate abroad. This one tracks what happens to the certificate
+once it is here: the embassy attests it, MOFA attests it, or it is translated - each step a
+fee and a receipt the PRO has to produce before the file moves on.
+"""
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import now
+
+from one_fm.grd.utils import get_embassy_attestation_fee
+
+ATTESTATION = "Attestation"
+TRANSLATION = "Translation"
+
+# Each receipt and the field that records when it went up. Read-only fields, stamped here
+# rather than in the browser so the stamp is the server's clock and cannot be skipped by
+# whatever attached the file.
+RECEIPT_TIMESTAMPS = (
+	("upload_embassy_payment_receipt", "upload_embassy_payment_receipt_on"),
+	("upload_mofa_payment_receipt", "upload_mofa_payment_receipt_on"),
+	("upload_translation_payment_receipt", "upload_translation_payment_receipt_on"),
+)
+
+
+class PCCAttestation(Document):
+	def validate(self):
+		self.set_embassy_attestation_fee()
+		self.set_receipt_timestamps()
+
+	def on_update_after_submit(self):
+		# The receipts are allow_on_submit, so a file can arrive after the record is
+		# submitted. validate does not run on that path.
+		self.set_receipt_timestamps()
+
+	def set_embassy_attestation_fee(self):
+		"""Fetch the embassy fee for the candidate's Place of Birth (WI-002025 / WI-002028).
+
+		A country in the Embassy Cost Table means its embassy attests and charges the stated
+		fee. A country absent from the table means it does not attest at all, and the fee
+		stays empty - which is what `requires_embassy_attestation` is read for when the
+		workflow decides whether to route through Pending Embassy.
+
+		Translation work never goes near an embassy, so the fee is cleared for it rather
+		than left showing a charge nobody will pay.
+		"""
+		if self.type == TRANSLATION:
+			self.requires_embassy_attestation = 0
+			return
+
+		fee = get_embassy_attestation_fee(self.place_of_birth)
+		self.requires_embassy_attestation = fee if fee is not None else 0
+
+	@property
+	def needs_embassy_attestation(self):
+		"""Does this candidate's country attest at all?
+
+		Distinct from the fee being non-zero: an embassy that attests for free still has to
+		be visited, so the question is whether the country is in the table.
+		"""
+		return self.type == ATTESTATION and get_embassy_attestation_fee(self.place_of_birth) is not None
+
+	def set_receipt_timestamps(self):
+		"""Stamp when each receipt went up, and clear the stamp if the file is removed."""
+		for receipt_field, timestamp_field in RECEIPT_TIMESTAMPS:
+			has_receipt = bool(self.get(receipt_field))
+			has_timestamp = bool(self.get(timestamp_field))
+
+			if has_receipt and not has_timestamp:
+				self.set_field(timestamp_field, now())
+			elif not has_receipt and has_timestamp:
+				self.set_field(timestamp_field, None)
+
+	def set_field(self, fieldname, value):
+		"""Write a field on either side of submit.
+
+		After submit the row is already saved, so an assignment in
+		`on_update_after_submit` would be thrown away.
+		"""
+		if self.docstatus == 1:
+			self.db_set(fieldname, value)
+		else:
+			self.set(fieldname, value)

--- a/one_fm/grd/doctype/pcc_attestation/test_pcc_attestation.py
+++ b/one_fm/grd/doctype/pcc_attestation/test_pcc_attestation.py
@@ -6,9 +6,15 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 A_RECEIPT = "/files/receipt.pdf"
-ATTESTING_COUNTRY = "Nepal"
-NON_ATTESTING_COUNTRY = "India"
-EMBASSY_FEE = 15.0
+
+# From the reporter's master data. Nepali needs all of embassy and MOFA; Indian needs MOFA
+# only; Ugandan needs neither, translation only - the row the earlier shape could not
+# represent, and the reason the requirements are three separate flags.
+EMBASSY_AND_MOFA = "Nepali"
+MOFA_ONLY = "Indian"
+NEITHER = "Ugandan"
+EMBASSY_FEE = 16.0
+MOFA_FEE = 5.0
 
 
 def _an_active_employee():
@@ -20,31 +26,45 @@ def _an_active_employee():
 
 class TestPCCAttestation(FrappeTestCase):
 	def setUp(self):
-		for country in (ATTESTING_COUNTRY, NON_ATTESTING_COUNTRY):
-			if not frappe.db.exists("Country", country):
-				self.skipTest(f"Country {country} is not on this site")
+		for nationality in (EMBASSY_AND_MOFA, MOFA_ONLY, NEITHER):
+			if not frappe.db.exists("Nationality", nationality):
+				self.skipTest(f"Nationality {nationality} is not on this site")
 
 		self.employee = _an_active_employee()
 		settings = frappe.get_doc("HR Settings")
-		settings.set("embassy_attestation_rates", [])
-		settings.append(
-			"embassy_attestation_rates",
-			{"country": ATTESTING_COUNTRY, "embassy_fee_kwd": EMBASSY_FEE},
-		)
+		settings.set("nationality_attestation_rules", [])
+		settings.append("nationality_attestation_rules", {
+			"nationality": EMBASSY_AND_MOFA,
+			"embassy_required": 1, "embassy_fee_kwd": EMBASSY_FEE,
+			"mofa_required": 1, "mofa_fee_kwd": MOFA_FEE,
+			"translation_required": 0,
+		})
+		settings.append("nationality_attestation_rules", {
+			"nationality": MOFA_ONLY,
+			"embassy_required": 0,
+			"mofa_required": 1, "mofa_fee_kwd": MOFA_FEE,
+			"translation_required": 0,
+		})
+		settings.append("nationality_attestation_rules", {
+			"nationality": NEITHER,
+			"embassy_required": 0, "mofa_required": 0, "translation_required": 1,
+		})
+		settings.mofa_fee_kwd = MOFA_FEE
 		settings.flags.ignore_permissions = True
 		settings.save()
 		frappe.clear_cache(doctype="HR Settings")
 
-	def _pcc(self, born_in=None, **kwargs):
-		"""A PCC Attestation for the test employee, optionally born in a given country.
+	def _pcc(self, nationality=None, **kwargs):
+		"""A PCC Attestation for the test employee, optionally of a given nationality.
 
-		The country is set on the Employee, not on the record: place_of_birth is fetched from
-		employee.one_fm_place_of_birth, and Frappe applies fetch_from before validate runs, so
-		a value passed here would be overwritten before the controller ever saw it. Which is
-		the behaviour we want - the country is the Employee's fact, not the operator's.
+		The nationality is set on the Employee, not on the record: PCC Attestation.nationality
+		is fetched from employee.one_fm_nationality, and Frappe applies fetch_from before
+		validate runs, so a value passed here would be overwritten before the controller ever
+		saw it. Which is the behaviour we want - the nationality is the Employee's fact, not
+		the operator's.
 		"""
-		if born_in is not None:
-			frappe.db.set_value("Employee", self.employee, "one_fm_place_of_birth", born_in)
+		if nationality is not None:
+			frappe.db.set_value("Employee", self.employee, "one_fm_nationality", nationality)
 
 		pcc = frappe.get_doc(
 			{
@@ -69,29 +89,72 @@ class TestPCCAttestation(FrappeTestCase):
 		self.assertEqual(pcc.passport_number, employee.passport_number)
 		self.assertEqual(pcc.company_pam_file_number, employee.pam_file_number)
 
-	def test_an_attesting_country_gets_its_embassy_fee(self):
-		pcc = self._pcc(born_in=ATTESTING_COUNTRY)
-		self.assertEqual(pcc.place_of_birth, ATTESTING_COUNTRY)
+	def test_a_nationality_needing_embassy_and_mofa_gets_both_fees(self):
+		pcc = self._pcc(nationality=EMBASSY_AND_MOFA)
+
+		self.assertEqual(pcc.nationality, EMBASSY_AND_MOFA)
+		self.assertTrue(pcc.embassy_attestation_required)
 		self.assertEqual(pcc.requires_embassy_attestation, EMBASSY_FEE)
+		self.assertTrue(pcc.mofa_attestation_required)
+		self.assertEqual(pcc.mofa_fee, MOFA_FEE)
 		self.assertTrue(pcc.needs_embassy_attestation)
+		self.assertTrue(pcc.needs_mofa_attestation)
 
-	def test_the_country_comes_from_the_employee_not_the_operator(self):
-		# place_of_birth is fetched from the Employee, so an operator cannot talk the record
-		# into an embassy fee the candidate is not entitled to by typing a country in.
-		pcc = self._pcc(born_in=NON_ATTESTING_COUNTRY, place_of_birth=ATTESTING_COUNTRY)
+	def test_a_mofa_only_nationality_skips_the_embassy(self):
+		pcc = self._pcc(nationality=MOFA_ONLY)
 
-		self.assertEqual(pcc.place_of_birth, NON_ATTESTING_COUNTRY)
+		self.assertFalse(pcc.embassy_attestation_required)
 		self.assertEqual(pcc.requires_embassy_attestation, 0)
-
-	def test_a_country_not_in_the_table_needs_no_embassy_step(self):
-		pcc = self._pcc(born_in=NON_ATTESTING_COUNTRY)
-		self.assertEqual(pcc.requires_embassy_attestation, 0)
+		self.assertTrue(pcc.mofa_attestation_required)
+		self.assertEqual(pcc.mofa_fee, MOFA_FEE)
 		self.assertFalse(pcc.needs_embassy_attestation)
+		self.assertTrue(pcc.needs_mofa_attestation)
 
-	def test_translation_work_never_carries_an_embassy_fee(self):
-		pcc = self._pcc(born_in=ATTESTING_COUNTRY, type="Translation")
-		self.assertEqual(pcc.requires_embassy_attestation, 0)
+	def test_a_nationality_needing_neither_step(self):
+		# Ugandan. Under the earlier shape this routed to Pending MOFA and blocked the PRO on
+		# a receipt that was never going to exist.
+		pcc = self._pcc(nationality=NEITHER)
+
+		self.assertFalse(pcc.embassy_attestation_required)
+		self.assertFalse(pcc.mofa_attestation_required)
 		self.assertFalse(pcc.needs_embassy_attestation)
+		self.assertFalse(pcc.needs_mofa_attestation)
+		self.assertEqual([pcc.requires_embassy_attestation, pcc.mofa_fee], [0, 0])
+
+	def test_the_translation_flag_comes_from_the_nationality(self):
+		self.assertTrue(self._pcc(nationality=NEITHER).translation_required)
+		self.assertFalse(self._pcc(nationality=MOFA_ONLY).translation_required)
+
+	def test_the_nationality_comes_from_the_employee_not_the_operator(self):
+		# An operator cannot talk the record into an embassy fee the candidate is not entitled
+		# to by typing a nationality in.
+		pcc = self._pcc(nationality=MOFA_ONLY)
+		self.assertEqual(pcc.nationality, MOFA_ONLY)
+		self.assertEqual(pcc.requires_embassy_attestation, 0)
+
+	def test_an_unlisted_nationality_needs_nothing(self):
+		unlisted = frappe.db.get_value(
+			"Nationality",
+			{"name": ["not in", [EMBASSY_AND_MOFA, MOFA_ONLY, NEITHER]]},
+			"name",
+			order_by="name asc",
+		)
+		if not unlisted:
+			self.skipTest("No unlisted Nationality on this site")
+
+		pcc = self._pcc(nationality=unlisted)
+
+		self.assertFalse(pcc.embassy_attestation_required)
+		self.assertFalse(pcc.mofa_attestation_required)
+		self.assertFalse(pcc.translation_required)
+
+	def test_translation_work_never_carries_an_embassy_or_mofa_fee(self):
+		pcc = self._pcc(nationality=EMBASSY_AND_MOFA, type="Translation")
+
+		self.assertEqual(pcc.requires_embassy_attestation, 0)
+		self.assertEqual(pcc.mofa_fee, 0)
+		self.assertFalse(pcc.needs_embassy_attestation)
+		self.assertFalse(pcc.needs_mofa_attestation)
 
 	def test_attaching_a_receipt_stamps_its_timestamp(self):
 		pcc = self._pcc(upload_mofa_payment_receipt=A_RECEIPT)

--- a/one_fm/grd/doctype/pcc_attestation/test_pcc_attestation.py
+++ b/one_fm/grd/doctype/pcc_attestation/test_pcc_attestation.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002028: the PCC Attestation record, its employee details, fees and receipt stamps."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+A_RECEIPT = "/files/receipt.pdf"
+ATTESTING_COUNTRY = "Nepal"
+NON_ATTESTING_COUNTRY = "India"
+EMBASSY_FEE = 15.0
+
+
+def _an_active_employee():
+	name = frappe.db.get_value("Employee", {"status": "Active"}, "name", order_by="creation asc")
+	if not name:
+		raise frappe.DoesNotExistError("No active employee on this site to test against")
+	return name
+
+
+class TestPCCAttestation(FrappeTestCase):
+	def setUp(self):
+		for country in (ATTESTING_COUNTRY, NON_ATTESTING_COUNTRY):
+			if not frappe.db.exists("Country", country):
+				self.skipTest(f"Country {country} is not on this site")
+
+		self.employee = _an_active_employee()
+		settings = frappe.get_doc("HR Settings")
+		settings.set("embassy_attestation_rates", [])
+		settings.append(
+			"embassy_attestation_rates",
+			{"country": ATTESTING_COUNTRY, "embassy_fee_kwd": EMBASSY_FEE},
+		)
+		settings.flags.ignore_permissions = True
+		settings.save()
+		frappe.clear_cache(doctype="HR Settings")
+
+	def _pcc(self, born_in=None, **kwargs):
+		"""A PCC Attestation for the test employee, optionally born in a given country.
+
+		The country is set on the Employee, not on the record: place_of_birth is fetched from
+		employee.one_fm_place_of_birth, and Frappe applies fetch_from before validate runs, so
+		a value passed here would be overwritten before the controller ever saw it. Which is
+		the behaviour we want - the country is the Employee's fact, not the operator's.
+		"""
+		if born_in is not None:
+			frappe.db.set_value("Employee", self.employee, "one_fm_place_of_birth", born_in)
+
+		pcc = frappe.get_doc(
+			{
+				"doctype": "PCC Attestation",
+				"employee": self.employee,
+				"type": "Attestation",
+				**kwargs,
+			}
+		)
+		pcc.flags.ignore_permissions = True
+		pcc.insert()
+		return pcc
+
+	def test_selecting_an_employee_populates_the_read_only_details(self):
+		pcc = self._pcc()
+
+		employee = frappe.get_doc("Employee", self.employee)
+		self.assertEqual(pcc.employee_name, employee.employee_name)
+		self.assertEqual(pcc.employee_id, employee.employee_id)
+		self.assertEqual(pcc.one_fm_civil_id, employee.one_fm_civil_id)
+		self.assertEqual(pcc.nationality, employee.one_fm_nationality)
+		self.assertEqual(pcc.passport_number, employee.passport_number)
+		self.assertEqual(pcc.company_pam_file_number, employee.pam_file_number)
+
+	def test_an_attesting_country_gets_its_embassy_fee(self):
+		pcc = self._pcc(born_in=ATTESTING_COUNTRY)
+		self.assertEqual(pcc.place_of_birth, ATTESTING_COUNTRY)
+		self.assertEqual(pcc.requires_embassy_attestation, EMBASSY_FEE)
+		self.assertTrue(pcc.needs_embassy_attestation)
+
+	def test_the_country_comes_from_the_employee_not_the_operator(self):
+		# place_of_birth is fetched from the Employee, so an operator cannot talk the record
+		# into an embassy fee the candidate is not entitled to by typing a country in.
+		pcc = self._pcc(born_in=NON_ATTESTING_COUNTRY, place_of_birth=ATTESTING_COUNTRY)
+
+		self.assertEqual(pcc.place_of_birth, NON_ATTESTING_COUNTRY)
+		self.assertEqual(pcc.requires_embassy_attestation, 0)
+
+	def test_a_country_not_in_the_table_needs_no_embassy_step(self):
+		pcc = self._pcc(born_in=NON_ATTESTING_COUNTRY)
+		self.assertEqual(pcc.requires_embassy_attestation, 0)
+		self.assertFalse(pcc.needs_embassy_attestation)
+
+	def test_translation_work_never_carries_an_embassy_fee(self):
+		pcc = self._pcc(born_in=ATTESTING_COUNTRY, type="Translation")
+		self.assertEqual(pcc.requires_embassy_attestation, 0)
+		self.assertFalse(pcc.needs_embassy_attestation)
+
+	def test_attaching_a_receipt_stamps_its_timestamp(self):
+		pcc = self._pcc(upload_mofa_payment_receipt=A_RECEIPT)
+		self.assertTrue(pcc.upload_mofa_payment_receipt_on)
+
+	def test_removing_a_receipt_clears_its_timestamp(self):
+		pcc = self._pcc(upload_mofa_payment_receipt=A_RECEIPT)
+		self.assertTrue(pcc.upload_mofa_payment_receipt_on)
+
+		pcc.upload_mofa_payment_receipt = None
+		pcc.save()
+
+		self.assertIsNone(pcc.upload_mofa_payment_receipt_on)
+
+	def test_each_receipt_stamps_only_its_own_timestamp(self):
+		pcc = self._pcc(upload_embassy_payment_receipt=A_RECEIPT)
+
+		self.assertTrue(pcc.upload_embassy_payment_receipt_on)
+		self.assertFalse(pcc.upload_mofa_payment_receipt_on)
+		self.assertFalse(pcc.upload_translation_payment_receipt_on)
+
+	def test_an_existing_stamp_is_not_overwritten_on_a_later_save(self):
+		pcc = self._pcc(upload_mofa_payment_receipt=A_RECEIPT)
+		stamped_at = pcc.upload_mofa_payment_receipt_on
+
+		pcc.category = "Overseas"
+		pcc.save()
+
+		self.assertEqual(pcc.upload_mofa_payment_receipt_on, stamped_at)
+
+	def test_every_stamped_pair_of_fields_exists(self):
+		from one_fm.grd.doctype.pcc_attestation.pcc_attestation import RECEIPT_TIMESTAMPS
+
+		meta = frappe.get_meta("PCC Attestation")
+		for receipt_field, timestamp_field in RECEIPT_TIMESTAMPS:
+			self.assertTrue(meta.get_field(receipt_field), f"no field {receipt_field}")
+			self.assertTrue(meta.get_field(timestamp_field), f"no field {timestamp_field}")
+
+	def test_it_is_not_the_recruitment_side_pcc_record(self):
+		# PCC Clearance already exists and tracks obtaining the certificate for a candidate
+		# abroad. This doctype is about attesting an employee's certificate once it is here.
+		self.assertTrue(frappe.db.exists("DocType", "PCC Clearance"))
+		self.assertEqual(frappe.get_meta("PCC Attestation").get_field("employee").options, "Employee")

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -578,3 +578,4 @@ one_fm.patches.v15_0.update_work_permit_previous_company_workflow #2026-08-07 WI
 one_fm.patches.v15_0.update_work_permit_pam_rejection #2026-08-07 WI-001827
 one_fm.patches.v15_0.add_work_permit_assignment_rules #2026-08-10 WI-001827
 one_fm.patches.v15_0.add_embassy_attestation_rates_to_hr_settings #2026-08-12 WI-002025
+one_fm.patches.v15_0.add_pcc_attestation_doctype #2026-08-12 WI-002028

--- a/one_fm/patches/v15_0/add_pcc_attestation_doctype.py
+++ b/one_fm/patches/v15_0/add_pcc_attestation_doctype.py
@@ -1,0 +1,11 @@
+import frappe
+
+# WI-002028: the GRD record for attesting an employee's Police Clearance Certificate.
+#
+# Reloaded explicitly rather than left to the schema sync so the patch can be re-run on its
+# own, and so anything downstream in this release that links to the doctype - the workflow
+# and assignment rules in WI-002029 - finds it already there.
+
+
+def execute():
+	frappe.reload_doc("grd", "doctype", "pcc_attestation")


### PR DESCRIPTION
The attestation of an employee's Police Clearance Certificate had no record: the
fees, the receipts and when each receipt arrived lived in the PRO's own notes.

Distinct from PCC Clearance, which already exists and tracks obtaining the
certificate for a candidate abroad during recruitment. This one starts where that
ends - the certificate is here, and the embassy, MOFA and the translator each want
paying. Every candidate detail is fetched from the Employee and read-only, so the
record cannot disagree with the employee file it is raised against.

The embassy fee comes from the Employee's Place of Birth via the WI-002025 table,
not from anything the operator types - place_of_birth is a fetch_from field and
Frappe applies fetch_from before validate, so an operator cannot talk a record into
a fee the candidate is not entitled to. Translation work has its embassy fee
cleared rather than left showing a charge nobody will pay.

Receipt timestamps are stamped server-side on validate and on update-after-submit,
from the server's clock. The client script fills them in immediately as well so the
operator does not have to save to see the stamp, but it is not the authority: these
are read-only audit fields and the attachments are allow_on_submit, so a file can
arrive on a submitted record where validate never runs.

Two deviations from the BA site's configuration, both flagged:

- Its field list declares amended_from twice. A duplicate fieldname makes the
  doctype un-importable, so it appears once here.
- Its Government Relations Operator row grants no "create", yet the first
  acceptance criterion is a GRO opening a new form. Granted, or the story's primary
  actor cannot start the process. Its lack of "cancel" is left alone: only the
  workflow's Cancel transition implies it, no criterion does.

The workflow-state receipt guards the story also describes are in WI-002029 with
the workflow that creates those states - there is nothing to guard until then.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Chain: WI-002025 → **WI-002028** → WI-002029 → WI-002026. Based on #6686, retarget once that merges.

Needs `bench migrate` (patch `add_pcc_attestation_doctype`).

Tests: 11 passing (`--module one_fm.grd.doctype.pcc_attestation.test_pcc_attestation`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)