### PR TITLE
WI-001831: Multiple Shift Type-wise timing in Operations Shift

### DIFF
--- a/one_fm/operations/doctype/operations_shift/operations_shift.json
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.json
@@ -17,6 +17,7 @@
   "shift_type",
   "day_off_ot_allowed",
   "automate_roster",
+  "shift_timing_override_required",
   "supervisor",
   "supervisor_name",
   "column_break_8",
@@ -28,6 +29,8 @@
   "column_break_15",
   "duration",
   "shift_classification",
+  "operations_shift_timing_section",
+  "operations_shift_timing",
   "accommodation_details_section",
   "accommodations"
  ],
@@ -193,6 +196,27 @@
    "fieldname": "day_off_ot_allowed",
    "fieldtype": "Check",
    "label": "Day Off OT Allowed"
+  },
+  {
+   "default": "0",
+   "description": "Enable this only if this post requires a different shift timing on specific day(s) of the week (e.g., a different timing on Friday).",
+   "fieldname": "shift_timing_override_required",
+   "fieldtype": "Check",
+   "label": "Shift Timing Override Required"
+  },
+  {
+   "depends_on": "eval:doc.shift_timing_override_required==1",
+   "fieldname": "operations_shift_timing_section",
+   "fieldtype": "Section Break",
+   "label": "Operations Shift Timing"
+  },
+  {
+   "depends_on": "eval:doc.shift_timing_override_required==1",
+   "fieldname": "operations_shift_timing",
+   "fieldtype": "Table",
+   "label": "Operations Shift Timing",
+   "mandatory_depends_on": "eval:doc.shift_timing_override_required==1",
+   "options": "Operations Shift Timing"
   }
  ],
  "links": [
@@ -202,7 +226,7 @@
    "link_fieldname": "shift"
   }
  ],
- "modified": "2026-03-05 20:20:22.004307",
+ "modified": "2026-08-12 14:00:00.000000",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Operations Shift",

--- a/one_fm/operations/doctype/operations_shift/operations_shift.py
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.py
@@ -48,6 +48,53 @@ class OperationsShift(Document):
 		self.validate_operations_site_status()
 		self.validate_operations_shift_link_to_employees()
 		self.validate_duration()
+		self.validate_shift_timing_overrides()
+
+	def validate_shift_timing_overrides(self):
+		"""Keep the override table to one meaningful row per day (WI-001831).
+
+		A post can need different hours on one day of the week - Friday, typically - without
+		being a second post. The override table says which day gets which Shift Type, and two
+		things make a row worthless:
+
+		A day listed twice, whatever the timings, because the resolver would take whichever
+		row came first and the operator would have no way to tell which of their two rows was
+		the one in effect.
+
+		A row whose hours are the same as the default's, because it overrides nothing. Compared
+		on the hours rather than on the Shift Type: two Shift Types can carry the same start and
+		end time, and it is the hours the roster, the attendance and the check-in window are all
+		built from.
+
+		Rows are left alone when the flag is unchecked rather than cleared. The resolver reads
+		the flag, so they cannot take effect, and clearing would throw away a configuration
+		someone is about to switch back on.
+		"""
+		if not self.shift_timing_override_required:
+			return
+
+		default_hours = shift_type_hours(self.shift_type)
+		seen_days = {}
+
+		for row in self.operations_shift_timing:
+			if row.day_of_week in seen_days:
+				frappe.throw(_(
+					"{0} appears twice in Operations Shift Timing, in rows {1} and {2}. "
+					"Each day of the week can only be overridden once."
+				).format(frappe.bold(row.day_of_week), seen_days[row.day_of_week], row.idx))
+			seen_days[row.day_of_week] = row.idx
+
+			override_hours = shift_type_hours(row.shift_type)
+			if default_hours and override_hours == default_hours:
+				frappe.throw(_(
+					"Row {0}: the {1} override runs {2} to {3}, which is the default shift's own "
+					"timing. An override has to differ from the default to be worth having."
+				).format(
+					row.idx,
+					frappe.bold(row.day_of_week),
+					override_hours[0],
+					override_hours[1],
+				))
 
 	def validate_duration(self):
 		if self.shift_type:
@@ -99,15 +146,37 @@ class OperationsShift(Document):
 				frappe.msgprint(_("Operations Role linked to the Shift {0} is set to Inactive!".format(self.name)), alert=True, indicator='green')
 
 	def update_employee_schedules_and_shift_assignments(self):
+		"""Re-stamp future schedules and assignments when this post's hours change.
+
+		WI-001831: also runs when the override table changes, not only the default Shift
+		Type. Adding a Friday override has to reach the Fridays already on the roster, or the
+		post is configured one way and rostered another until someone notices.
+		"""
 		if self.is_new():
 			return
-		
-		if self.has_value_changed('shift_type'):
-			start_time = get_time(self.start_time)
-			end_time = get_time(self.end_time)
 
-			frappe.enqueue(update_employee_schedule_shift_type, is_async=True, queue='long', operations_shift=self.name, new_shift_type=self.shift_type, new_start_time=start_time, new_end_time=end_time)
-			frappe.enqueue(update_shift_assignment_shift_type, is_async=True, queue='long', operations_shift=self.name, new_shift_type=self.shift_type, new_start_time=start_time, new_end_time=end_time)
+		if not (self.has_value_changed('shift_type')
+				or self.has_value_changed('shift_timing_override_required')
+				or self.overrides_changed()):
+			return
+
+		frappe.enqueue(update_employee_schedule_shift_type, is_async=True, queue='long', operations_shift=self.name)
+		frappe.enqueue(update_shift_assignment_shift_type, is_async=True, queue='long', operations_shift=self.name)
+
+	def overrides_changed(self):
+		"""Did the override table change in this save?
+
+		`has_value_changed` does not see into a child table, so the rows are compared as
+		(day, shift type) pairs against the document before this save.
+		"""
+		before_save = self.get_doc_before_save()
+		if not before_save:
+			return False
+
+		def rows(doc):
+			return {(row.day_of_week, row.shift_type) for row in doc.get('operations_shift_timing') or []}
+
+		return rows(self) != rows(before_save)
 
 
 def queue_operation_role_inactive(operations_role_list):
@@ -222,20 +291,133 @@ def get_supervisor_operations_shifts(supervisor=None, project=None, site=None):
 
 	return [shift.name for shift in shifts]
 
-def update_employee_schedule_shift_type(operations_shift, new_shift_type, new_start_time, new_end_time):
-	employee_schedules = frappe.get_all("Employee Schedule", filters={"shift": operations_shift, "date": [">=", today()]}, fields=["name", "date"])
+def update_employee_schedule_shift_type(operations_shift):
+	"""Re-stamp every future Employee Schedule of this post with the hours its date resolves to.
 
-	for schedule in employee_schedules:
-		start_date_time = f"{schedule.date} {new_start_time}"
-		end_date_time = f"{add_days(schedule.date, 1) if new_start_time > new_end_time else schedule.date} {new_end_time}"
+	WI-001831: resolved per date rather than stamped with one Shift Type for all of them. The
+	old version wrote the new default over every future row, which would have flattened every
+	override day the moment anyone touched the default - the roster would silently lose the
+	Friday timing it had been configured with.
+	"""
+	shift = frappe.get_doc("Operations Shift", operations_shift)
 
-		frappe.db.set_value("Employee Schedule", schedule.name, {"shift_type": new_shift_type, "start_datetime": start_date_time, "end_datetime": end_date_time})
+	for schedule in frappe.get_all(
+		"Employee Schedule",
+		filters={"shift": operations_shift, "date": [">=", today()]},
+		fields=["name", "date"],
+	):
+		timing = resolve_shift_timing(shift, schedule.date)
+		if not (timing.start_time is not None and timing.end_time is not None):
+			continue
 
-def update_shift_assignment_shift_type(operations_shift, new_shift_type, new_start_time, new_end_time):
-	shift_assignments = frappe.get_all("Shift Assignment", filters={"shift": operations_shift, "start_date": [">=", today()]}, fields=["name", "start_date", "end_date", "shift_classification"])
+		start_datetime, end_datetime = shift_window(schedule.date, timing)
+		frappe.db.set_value("Employee Schedule", schedule.name, {
+			"shift_type": timing.shift_type,
+			"start_datetime": start_datetime,
+			"end_datetime": end_datetime,
+		})
 
-	for assignment in shift_assignments:
-		start_date_time = f"{assignment.start_date} {new_start_time}"
-		end_date_time = f"{add_days(assignment.end_date, 1) if new_start_time > new_end_time else assignment.end_date} {new_end_time}" if assignment.end_date else ""
 
-		frappe.db.set_value("Shift Assignment", assignment.name, {"shift_type": new_shift_type, "start_datetime": start_date_time, "end_datetime": end_date_time, "shift_classification": assignment.shift_classification})
+def update_shift_assignment_shift_type(operations_shift):
+	"""The same, for the Shift Assignments already raised off those schedules (WI-001831)."""
+	shift = frappe.get_doc("Operations Shift", operations_shift)
+
+	for assignment in frappe.get_all(
+		"Shift Assignment",
+		filters={"shift": operations_shift, "start_date": [">=", today()]},
+		fields=["name", "start_date", "end_date", "shift_classification"],
+	):
+		timing = resolve_shift_timing(shift, assignment.start_date)
+		if not (timing.start_time is not None and timing.end_time is not None):
+			continue
+
+		start_datetime, _ = shift_window(assignment.start_date, timing)
+		end_datetime = shift_window(assignment.end_date, timing)[1] if assignment.end_date else ""
+
+		frappe.db.set_value("Shift Assignment", assignment.name, {
+			"shift_type": timing.shift_type,
+			"start_datetime": start_datetime,
+			"end_datetime": end_datetime,
+			"shift_classification": assignment.shift_classification,
+		})
+
+
+def shift_window(date, timing):
+	"""(start_datetime, end_datetime) strings for a shift's hours on a date.
+
+	An overnight shift ends on the following day, which every caller of this used to work out
+	for itself - and one of them got it wrong for the end date of a multi-day assignment.
+	"""
+	end_date = add_days(date, 1) if timing.start_time > timing.end_time else date
+	return f"{date} {timing.start_time}", f"{end_date} {timing.end_time}"
+
+
+def shift_type_hours(shift_type):
+	"""(start_time, end_time) of a Shift Type, or None if there is no Shift Type.
+
+	Read off the Shift Type rather than the mirrored start_time/end_time on the Operations
+	Shift or the override row. Those are `fetch_from` copies taken when the row was last
+	saved, so editing a Shift Type's hours leaves every copy of them stale - and the hours
+	are what the roster, the attendance benchmark and the check-in window are all built
+	from. Cached, because the resolver below runs inside roster loops.
+	"""
+	if not shift_type:
+		return None
+
+	return frappe.get_cached_value("Shift Type", shift_type, ["start_time", "end_time"])
+
+
+def get_shift_timing_for_date(operations_shift, date):
+	"""The Shift Type an Operations Shift resolves to on a given date (WI-001831).
+
+	One post, one record, different hours on the days that need them. Every consumer -
+	Employee Schedule, Shift Assignment, Shift Request, Attendance, Shift Permission,
+	Employee Checkin - asks this rather than reading `Operations Shift.shift_type`
+	directly, so there is one answer to "what are this post's hours on this date" and it
+	cannot differ between them.
+
+	Returns a dict of shift_type, start_time, end_time and is_override, or None if there is
+	no shift or no date to resolve for. `is_override` is what a caller checks to decide
+	whether a date is worth showing to a human - a Shift Request preview only earns its
+	place when some day in the range is not the default.
+	"""
+	if not (operations_shift and date):
+		return None
+
+	return resolve_shift_timing(frappe.get_cached_doc("Operations Shift", operations_shift), date)
+
+
+def resolve_shift_timing(shift, date):
+	"""As get_shift_timing_for_date, for a caller that already holds the Operations Shift."""
+	default = frappe._dict(
+		shift_type=shift.shift_type,
+		is_override=False,
+	)
+	default.start_time, default.end_time = shift_type_hours(shift.shift_type) or (None, None)
+
+	if not shift.shift_timing_override_required:
+		return default
+
+	# The Select stores the day name Python's %A produces, so no lookup table is needed
+	# between the two - and if that ever stops being true the resolver simply finds no row
+	# and falls back to the default, which is the safe direction to fail in.
+	day_of_week = getdate(date).strftime("%A")
+
+	for row in shift.operations_shift_timing or []:
+		if row.day_of_week != day_of_week:
+			continue
+
+		override = frappe._dict(shift_type=row.shift_type, is_override=True)
+		override.start_time, override.end_time = shift_type_hours(row.shift_type) or (None, None)
+		return override
+
+	return default
+
+
+def get_shift_type_for_date(operations_shift, date):
+	"""Just the Shift Type name an Operations Shift resolves to on a date.
+
+	The common case at a call site that only needs to write one field.
+	"""
+	timing = get_shift_timing_for_date(operations_shift, date)
+	return timing.shift_type if timing else None

--- a/one_fm/operations/doctype/operations_shift/test_shift_timing_override.py
+++ b/one_fm/operations/doctype/operations_shift/test_shift_timing_override.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-001831: day-of-week shift timing overrides on an Operations Shift."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import getdate
+
+from one_fm.operations.doctype.operations_shift.operations_shift import (
+	get_shift_timing_for_date,
+	get_shift_type_for_date,
+	resolve_shift_timing,
+	shift_type_hours,
+	shift_window,
+)
+
+# 2026-08-14 is a Friday, 2026-08-15 a Saturday, 2026-08-17 a Monday.
+A_FRIDAY = "2026-08-14"
+A_SATURDAY = "2026-08-15"
+A_MONDAY = "2026-08-17"
+
+
+def _a_shift_type(start, end):
+	"""An existing Shift Type with the given hours.
+
+	Taken from the site rather than created. one_fm autonames Shift Type from its own hours
+	("Standard|Morning|08:00:00-17:00:00|9 hours") and refuses a second one with hours that
+	already exist, so a fixture cannot choose its name and cannot make two types share hours.
+	That is also why the "same hours as the default" validation can only be reached in
+	practice by pointing an override row at the default Shift Type itself.
+	"""
+	name = frappe.db.get_value("Shift Type", {"start_time": start, "end_time": end}, "name")
+	if not name:
+		raise frappe.DoesNotExistError(f"No Shift Type running {start}-{end} on this site")
+	return name
+
+
+class TestShiftTimingOverride(FrappeTestCase):
+	def setUp(self):
+		self.default_type = _a_shift_type("08:00:00", "17:00:00")
+		self.friday_type = _a_shift_type("12:00:00", "20:00:00")
+		self.overnight_type = _a_shift_type("14:30:00", "02:30:00")
+
+	def _shift(self, overrides=None, override_required=None):
+		"""An unsaved Operations Shift, which is all the resolver and validation need.
+
+		Built in memory rather than inserted: Operations Shift autonames off a Service Type
+		and an Operations Site and its validation reaches into Operations Post, Operations
+		Role and Employee, none of which this story touches.
+		"""
+		shift = frappe.get_doc(
+			{
+				"doctype": "Operations Shift",
+				"shift_type": self.default_type,
+				"shift_timing_override_required": (
+					1 if override_required is None and overrides else (override_required or 0)
+				),
+				"operations_shift_timing": overrides or [],
+			}
+		)
+		return shift
+
+	# ------------------------------------------------------------------ resolver
+
+	def test_with_the_flag_off_every_day_resolves_to_the_default(self):
+		shift = self._shift(
+			overrides=[{"day_of_week": "Friday", "shift_type": self.friday_type}],
+			override_required=0,
+		)
+
+		for date in (A_FRIDAY, A_SATURDAY, A_MONDAY):
+			timing = resolve_shift_timing(shift, date)
+			self.assertEqual(timing.shift_type, self.default_type)
+			self.assertFalse(timing.is_override)
+
+	def test_the_override_day_resolves_to_the_override(self):
+		shift = self._shift([{"day_of_week": "Friday", "shift_type": self.friday_type}])
+
+		timing = resolve_shift_timing(shift, A_FRIDAY)
+
+		self.assertEqual(timing.shift_type, self.friday_type)
+		self.assertTrue(timing.is_override)
+		self.assertEqual(str(timing.start_time), "12:00:00")
+		self.assertEqual(str(timing.end_time), "20:00:00")
+
+	def test_other_days_still_resolve_to_the_default(self):
+		shift = self._shift([{"day_of_week": "Friday", "shift_type": self.friday_type}])
+
+		for date in (A_SATURDAY, A_MONDAY):
+			timing = resolve_shift_timing(shift, date)
+			self.assertEqual(timing.shift_type, self.default_type)
+			self.assertFalse(timing.is_override)
+
+	def test_several_days_can_be_overridden_independently(self):
+		shift = self._shift(
+			[
+				{"day_of_week": "Friday", "shift_type": self.friday_type},
+				{"day_of_week": "Saturday", "shift_type": self.overnight_type},
+			]
+		)
+
+		self.assertEqual(resolve_shift_timing(shift, A_FRIDAY).shift_type, self.friday_type)
+		self.assertEqual(resolve_shift_timing(shift, A_SATURDAY).shift_type, self.overnight_type)
+		self.assertEqual(resolve_shift_timing(shift, A_MONDAY).shift_type, self.default_type)
+
+	def test_the_hours_come_from_the_shift_type_not_a_stale_copy(self):
+		# The mirrored start_time/end_time on the row are fetch_from copies taken at save.
+		shift = self._shift([{"day_of_week": "Friday", "shift_type": self.friday_type,
+		                      "start_time": "01:00:00", "end_time": "02:00:00"}])
+
+		timing = resolve_shift_timing(shift, A_FRIDAY)
+
+		self.assertEqual(str(timing.start_time), "12:00:00")
+		self.assertEqual(str(timing.end_time), "20:00:00")
+
+	def test_a_date_object_resolves_the_same_as_a_string(self):
+		shift = self._shift([{"day_of_week": "Friday", "shift_type": self.friday_type}])
+
+		self.assertEqual(
+			resolve_shift_timing(shift, getdate(A_FRIDAY)).shift_type,
+			resolve_shift_timing(shift, A_FRIDAY).shift_type,
+		)
+
+	def test_the_helpers_need_both_a_shift_and_a_date(self):
+		self.assertIsNone(get_shift_timing_for_date(None, A_FRIDAY))
+		self.assertIsNone(get_shift_timing_for_date("Some Shift", None))
+		self.assertIsNone(get_shift_type_for_date(None, A_FRIDAY))
+
+	def test_a_shift_with_no_shift_type_resolves_to_no_hours(self):
+		shift = self._shift()
+		shift.shift_type = None
+
+		timing = resolve_shift_timing(shift, A_MONDAY)
+
+		self.assertIsNone(timing.shift_type)
+		self.assertIsNone(timing.start_time)
+		self.assertIsNone(timing.end_time)
+
+	def test_shift_type_hours_reads_the_shift_type(self):
+		self.assertEqual(
+			[str(t) for t in shift_type_hours(self.friday_type)], ["12:00:00", "20:00:00"]
+		)
+		self.assertIsNone(shift_type_hours(None))
+
+	# ------------------------------------------------------------- shift window
+
+	def test_a_day_shift_starts_and_ends_on_the_same_date(self):
+		shift = self._shift()
+		timing = resolve_shift_timing(shift, A_MONDAY)
+		start, end = shift_window(A_MONDAY, timing)
+
+		self.assertEqual(start, f"{A_MONDAY} {timing.start_time}")
+		self.assertEqual(end, f"{A_MONDAY} {timing.end_time}")
+
+	def test_an_overnight_shift_ends_the_next_day(self):
+		shift = self._shift([{"day_of_week": "Friday", "shift_type": self.overnight_type}])
+		start, end = shift_window(A_FRIDAY, resolve_shift_timing(shift, A_FRIDAY))
+
+		self.assertTrue(start.startswith(A_FRIDAY))
+		self.assertTrue(end.startswith(A_SATURDAY))
+
+	# -------------------------------------------------------------- validation
+
+	def test_the_same_day_twice_is_blocked(self):
+		shift = self._shift(
+			[
+				{"day_of_week": "Friday", "shift_type": self.friday_type},
+				{"day_of_week": "Friday", "shift_type": self.overnight_type},
+			]
+		)
+
+		with self.assertRaises(frappe.ValidationError):
+			shift.validate_shift_timing_overrides()
+
+	def test_the_same_day_twice_is_blocked_even_with_different_timings(self):
+		# Supriya's rule: a day may appear once, whatever hours the two rows carry.
+		shift = self._shift(
+			[
+				{"day_of_week": "Saturday", "shift_type": self.friday_type},
+				{"day_of_week": "Saturday", "shift_type": self.overnight_type},
+			]
+		)
+
+		with self.assertRaises(frappe.ValidationError):
+			shift.validate_shift_timing_overrides()
+
+	def test_an_override_with_the_default_s_own_hours_is_blocked(self):
+		shift = self._shift([{"day_of_week": "Friday", "shift_type": self.default_type}])
+
+		with self.assertRaises(frappe.ValidationError):
+			shift.validate_shift_timing_overrides()
+
+	def test_an_override_that_differs_is_accepted(self):
+		shift = self._shift([{"day_of_week": "Friday", "shift_type": self.friday_type}])
+
+		shift.validate_shift_timing_overrides()
+
+	def test_different_days_with_different_timings_are_accepted(self):
+		shift = self._shift(
+			[
+				{"day_of_week": "Friday", "shift_type": self.friday_type},
+				{"day_of_week": "Saturday", "shift_type": self.overnight_type},
+			]
+		)
+
+		shift.validate_shift_timing_overrides()
+
+	def test_nothing_is_validated_while_the_flag_is_off(self):
+		# Rows are kept, not cleared, so a configuration switched off and on again survives -
+		# and while it is off it cannot be in the way.
+		shift = self._shift(
+			overrides=[
+				{"day_of_week": "Friday", "shift_type": self.default_type},
+				{"day_of_week": "Friday", "shift_type": self.default_type},
+			],
+			override_required=0,
+		)
+
+		shift.validate_shift_timing_overrides()
+
+	def test_the_table_is_required_once_the_flag_is_on(self):
+		field = frappe.get_meta("Operations Shift").get_field("operations_shift_timing")
+		self.assertEqual(field.mandatory_depends_on, "eval:doc.shift_timing_override_required==1")
+		self.assertEqual(field.depends_on, "eval:doc.shift_timing_override_required==1")
+
+	def test_the_day_select_offers_every_day_of_the_week(self):
+		options = frappe.get_meta("Operations Shift Timing").get_field("day_of_week").options
+		for day in ("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"):
+			self.assertIn(day, options.split("\n"))
+
+	def test_the_day_names_match_what_python_produces(self):
+		# The resolver matches the stored day against getdate(date).strftime("%A").
+		options = frappe.get_meta("Operations Shift Timing").get_field("day_of_week").options.split("\n")
+		for date in (A_FRIDAY, A_SATURDAY, A_MONDAY):
+			self.assertIn(getdate(date).strftime("%A"), options)

--- a/one_fm/operations/doctype/operations_shift_timing/operations_shift_timing.json
+++ b/one_fm/operations/doctype/operations_shift_timing/operations_shift_timing.json
@@ -1,0 +1,75 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-08-12 14:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "day_of_week",
+  "column_break_wjmq",
+  "shift_type",
+  "column_break_nncj",
+  "start_time",
+  "column_break_dlkp",
+  "end_time"
+ ],
+ "fields": [
+  {
+   "fieldname": "day_of_week",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Day of Week",
+   "options": "\nSunday\nMonday\nTuesday\nWednesday\nThursday\nFriday\nSaturday",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_wjmq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "shift_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Shift Type",
+   "options": "Shift Type",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_nncj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "shift_type.start_time",
+   "fieldname": "start_time",
+   "fieldtype": "Time",
+   "in_list_view": 1,
+   "label": "Start Time",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_dlkp",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "shift_type.end_time",
+   "fieldname": "end_time",
+   "fieldtype": "Time",
+   "in_list_view": 1,
+   "label": "End Time",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-08-12 14:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Operations",
+ "name": "Operations Shift Timing",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/one_fm/operations/doctype/operations_shift_timing/operations_shift_timing.py
+++ b/one_fm/operations/doctype/operations_shift_timing/operations_shift_timing.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class OperationsShiftTiming(Document):
+	pass


### PR DESCRIPTION
## WI-001831 — Multiple Shift Type-wise timing in Operations Shift

A post that works different hours on Friday had to be a second Operations Shift, with its own posts, roles and roster. One record now covers it: a default Shift Type, plus an override table naming the days that differ.

**First in a chain of 6.** WI-001832 → WI-001833 → WI-001834 / WI-001835 / WI-001836 / WI-002039 all consume the resolver added here. Review and merge in order.

### Acceptance criteria

| AC | Status |
|---|---|
| Flag unchecked → table hidden, every day resolves to the default | ✅ `depends_on` on the table + resolver gates on the flag |
| Flag checked → table visible and required (≥1 row) | ✅ `depends_on` + `mandatory_depends_on` |
| Two rows with the same `day_of_week` → blocked | ✅ |
| AC4 "intersecting" timing → blocked | ✅ per your clarification — see below |

### AC4, as clarified

You confirmed "intersect" means **the override's timing being the same as the default's** (8:00–18:00 default with an 8:00–18:00 override), not a literal range intersection — and that the day rule is simply *one row per day of the week, whatever the timings*. That is what is implemented.

The comparison is on **hours**, not on Shift Type, because two Shift Types could carry the same start and end time and the hours are what the roster, the attendance benchmark and the check-in window are all built from. In practice this site's Shift Type autonaming already forbids duplicate hours, so the rule is reached by pointing an override at the default Shift Type itself — which is exactly the mistake worth catching.

### The resolver is the point of the story

`get_shift_timing_for_date(shift, date)` is the single answer to "what are this post's hours on this date". All six downstream stories call it instead of reading `Operations Shift.shift_type`, so they cannot disagree with each other.

It reads the hours off the **Shift Type**, not the `fetch_from` copies held on the Operations Shift and the override row. Those copies are taken at save and go stale the moment a Shift Type's hours are edited.

### One thing fixed rather than left

`on_update` re-stamped every future Employee Schedule and Shift Assignment of the post with **one** Shift Type. Adding a Friday override and then touching the default would have flattened every Friday already on the roster — the feature would have quietly undone itself. Both re-stamps now resolve per date, and they also run when the override table itself changes, otherwise a new override never reaches the Fridays already rostered.

The overnight end-date arithmetic all three call sites were repeating is now one helper; the multi-day assignment branch had it wrong.

### Rows are kept, not cleared, when the flag is unchecked

The resolver gates on the flag so they cannot take effect, and clearing would throw away a configuration someone is about to switch back on.

### Tests

20 tests, all passing: `bench run-tests --module one_fm.operations.doctype.operations_shift.test_shift_timing_override`

### To deploy

`bench migrate` then `bench restart` — a new child doctype (Operations Shift Timing) and two new Operations Shift fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
