### PR TITLE
WI-001832: Multiple Shift Type-wise timing integration in Employee Schedule

### DIFF
--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -17,6 +17,7 @@ from frappe.query_builder import DocType, Order
 
 from one_fm.one_fm.page.roster.employee_map  import CreateMap, PostMap
 from one_fm.api.v1.utils import response
+from one_fm.operations.doctype.operations_shift.operations_shift import resolve_shift_timing
 
 
 
@@ -912,9 +913,24 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
 
 	# make data structure for the roster
 	shift_start_time, shift_end_time = frappe.db.get_value("Operations Shift", shift, ["start_time", "end_time"])
-	next_day = False
-	if shift_start_time > shift_end_time:
-		next_day = True
+
+	# WI-001832: the hours are resolved per date rather than once for the whole batch. A post
+	# with a Friday override runs different hours that day, so one pair of times for the
+	# range would have written the default over every Friday in it.
+	timing_cache = {}
+
+	def schedule_timing(date):
+		"""(shift_type, start_datetime, end_datetime) this post resolves to on one date."""
+		if date not in timing_cache:
+			timing = resolve_shift_timing(operations_shift_doc, date)
+			end_date = add_days(date, 1) if timing.start_time > timing.end_time else date
+			timing_cache[date] = (
+				timing.shift_type,
+				datetime.strptime(f"{date} {timing.start_time}", "%Y-%m-%d %H:%M:%S"),
+				datetime.strptime(f"{end_date} {timing.end_time}", "%Y-%m-%d %H:%M:%S"),
+			)
+		return timing_cache[date]
+
 	employees_date_dict = {}
 	for i in employees:
 		# Ensure employee exists in employees_dict and has date_of_joining
@@ -925,15 +941,14 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
 			relieving_date = employee_detail.get("relieving_date")
 
 			if joining_date <= current_date and (not relieving_date or current_date <= getdate(relieving_date)):
-				if employees_date_dict.get(i["employee"]):
-					employees_date_dict[i["employee"]].append({
-						"date":i["date"],
-						"start_datetime": datetime.strptime(f"{i['date']} {shift_start_time}", "%Y-%m-%d %H:%M:%S"), 
-						"end_datetime":datetime.strptime(f"{add_days(i['date'], 1) if next_day else i['date']} {shift_end_time}", "%Y-%m-%d %H:%M:%S"),
-						"day_off_ot": i.get("day_off_ot")
-					})
-				else:
-					employees_date_dict[i["employee"]] =[{"date":i["date"], "start_datetime": datetime.strptime(f"{i['date']} {shift_start_time}", "%Y-%m-%d %H:%M:%S"), "end_datetime":datetime.strptime(f"{add_days(i['date'], 1) if next_day else i['date']} {shift_end_time}", "%Y-%m-%d %H:%M:%S")}]
+				day_shift_type, day_start, day_end = schedule_timing(i["date"])
+				employees_date_dict.setdefault(i["employee"], []).append({
+					"date": i["date"],
+					"shift_type": day_shift_type,
+					"start_datetime": day_start,
+					"end_datetime": day_end,
+					"day_off_ot": i.get("day_off_ot")
+				})
 		else:
 			# Log or handle cases where employee details or date_of_joining is missing
 			frappe.log_error(message=f"Employee {i.get('employee')} missing details or date_of_joining.", title="Extreme Schedule Data Prep")
@@ -1042,7 +1057,7 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
 			query_values.append(f"""
 				(
 					'{name}', '{employee_name_iter}', '{employee_doc.employee_name}', '{employee_doc.department}', '{datevalue['date']}', '{operations_shift_doc.name}',
-					'{operations_shift_doc.site}', '{operations_shift_doc.project}', '{operations_shift_doc.shift_type}', 'Working',
+					'{operations_shift_doc.site}', '{operations_shift_doc.project}', '{datevalue.get('shift_type') or operations_shift_doc.shift_type}', 'Working',
 					'{operations_role_doc.name}', '{operations_role_doc.post_abbrv}', '{roster_type}',
 					{day_off_ot_val}, '{datevalue.get('start_datetime')}', '{datevalue.get('end_datetime')}', '{owner}', '{owner}', '{creation}', '{creation}',
 					0, NULL

--- a/one_fm/operations/doctype/employee_schedule/employee_schedule.py
+++ b/one_fm/operations/doctype/employee_schedule/employee_schedule.py
@@ -7,6 +7,7 @@ import frappe
 from frappe.model.document import Document
 from frappe import _
 from frappe.utils import cstr, add_days, getdate, get_last_day
+from one_fm.operations.doctype.operations_shift.operations_shift import resolve_shift_timing
 from one_fm.utils import get_week_start_end, get_month_start_end
 from one_fm.processor import sendemail
 
@@ -144,6 +145,7 @@ class EmployeeSchedule(Document):
 		self.validate_ojt_change()
 		self.validate_leave_application()
 		self.validate_relieving_date()
+		self.apply_shift_timing_override()
 		if self.employee_availability=='Working' and self.shift_type and self.date:
 			start_time, end_time = frappe.db.get_value("Shift Type", self.shift_type, ['start_time', 'end_time'])
 			end_date = self.date
@@ -163,6 +165,32 @@ class EmployeeSchedule(Document):
 			self.end_datetime = ''
 
 		# validate_operations_post_overfill({self.date: 1}, self.shift)
+
+	def apply_shift_timing_override(self):
+		"""Take the Shift Type the post resolves to on this row's date (WI-001832).
+
+		The start and end datetimes below are derived from shift_type, so getting the type
+		right here is what makes a Friday schedule carry Friday's hours. Placed in the
+		controller rather than in each creator because schedules are opened from a dozen
+		places - the Desk roster, the mobile and flutter roster APIs, Request Employee
+		Schedule, OJT, Client Event - and only a choke point catches all of them.
+
+		Applied unconditionally rather than only to rows that look untouched. `shift_type` is
+		read-only and declared `fetch_from: shift.shift_type` with no `fetch_if_empty`, so
+		Frappe already overwrites whatever a caller passed with the post's default before
+		validate runs. The field has always been a mirror of the post's Shift Type; this makes
+		it a mirror of the post's Shift Type *for that date*, which is the same contract.
+		"""
+		if not (self.shift and self.date) or self.employee_availability != 'Working':
+			return
+
+		operations_shift = frappe.get_cached_doc("Operations Shift", self.shift)
+		if not operations_shift.shift_timing_override_required:
+			return
+
+		timing = resolve_shift_timing(operations_shift, self.date)
+		if timing.shift_type:
+			self.shift_type = timing.shift_type
 
 	def validate_leave_application(self):
 		if self.employee and self.date:

--- a/one_fm/operations/doctype/employee_schedule/test_employee_schedule_override.py
+++ b/one_fm/operations/doctype/employee_schedule/test_employee_schedule_override.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-001832: an Employee Schedule carries the Shift Type its date resolves to."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+# Far enough out that the site has no real roster there. FrappeTestCase rolls back per
+# class rather than per test, so a row one test inserts is still present for the next -
+# _schedule clears the slot it is about to fill.
+A_FRIDAY = "2027-01-01"
+A_MONDAY = "2027-01-04"
+
+
+def _a_shift_type(start, end):
+	name = frappe.db.get_value("Shift Type", {"start_time": start, "end_time": end}, "name")
+	if not name:
+		raise frappe.DoesNotExistError(f"No Shift Type running {start}-{end} on this site")
+	return name
+
+
+def _an_operations_shift():
+	"""An Active Operations Shift on this site, with its own posts and roles already in place.
+
+	Taken from the site rather than created: Operations Shift autonames off a Service Type and
+	an Operations Site, and its validation reaches into Operations Post, Operations Role and
+	Employee.
+	"""
+	name = frappe.db.get_value(
+		"Operations Shift", {"status": "Active", "shift_type": ["is", "set"]}, "name", order_by="creation asc"
+	)
+	if not name:
+		raise frappe.DoesNotExistError("No active Operations Shift on this site to test against")
+	return name
+
+
+def _an_active_employee():
+	name = frappe.db.get_value(
+		"Employee",
+		{"status": "Active", "relieving_date": ["is", "not set"]},
+		"name",
+		order_by="creation asc",
+	)
+	if not name:
+		raise frappe.DoesNotExistError("No active employee on this site to test against")
+	return name
+
+
+class TestEmployeeScheduleOverride(FrappeTestCase):
+	def setUp(self):
+		self.employee = _an_active_employee()
+		self.shift_name = _an_operations_shift()
+		self.shift = frappe.get_doc("Operations Shift", self.shift_name)
+		self.default_type = self.shift.shift_type
+
+		# A Shift Type whose hours differ from this post's default, so the override is real.
+		default_hours = frappe.db.get_value(
+			"Shift Type", self.default_type, ["start_time", "end_time"], as_dict=True
+		)
+		self.override_type = frappe.db.get_value(
+			"Shift Type",
+			{"name": ["!=", self.default_type], "start_time": ["!=", default_hours.start_time]},
+			"name",
+			order_by="name asc",
+		)
+		if not self.override_type:
+			self.skipTest("No second Shift Type on this site to override with")
+
+	def _with_friday_override(self):
+		self.shift.shift_timing_override_required = 1
+		self.shift.set("operations_shift_timing", [])
+		self.shift.append(
+			"operations_shift_timing", {"day_of_week": "Friday", "shift_type": self.override_type}
+		)
+		self.shift.flags.ignore_permissions = True
+		self.shift.save()
+		frappe.clear_cache(doctype="Operations Shift")
+
+	def _without_override(self):
+		self.shift.shift_timing_override_required = 0
+		self.shift.flags.ignore_permissions = True
+		self.shift.save()
+		frappe.clear_cache(doctype="Operations Shift")
+
+	def _schedule(self, date, **kwargs):
+		frappe.db.delete("Employee Schedule", {"employee": self.employee, "date": date})
+		schedule = frappe.get_doc(
+			{
+				"doctype": "Employee Schedule",
+				"employee": self.employee,
+				"date": date,
+				"shift": self.shift_name,
+				"site": self.shift.site,
+				"project": self.shift.project,
+				"employee_availability": "Working",
+				"shift_type": self.default_type,
+				"roster_type": "Basic",
+				**kwargs,
+			}
+		)
+		schedule.flags.ignore_permissions = True
+		schedule.insert()
+		return schedule
+
+	def test_a_friday_schedule_takes_the_override(self):
+		self._with_friday_override()
+
+		schedule = self._schedule(A_FRIDAY)
+
+		self.assertEqual(schedule.shift_type, self.override_type)
+
+	def test_the_datetimes_follow_the_override(self):
+		self._with_friday_override()
+
+		schedule = self._schedule(A_FRIDAY)
+
+		start_time, end_time = frappe.db.get_value(
+			"Shift Type", self.override_type, ["start_time", "end_time"]
+		)
+		self.assertEqual(str(schedule.start_datetime), f"{A_FRIDAY} {start_time}")
+		self.assertTrue(str(schedule.end_datetime).endswith(str(end_time)))
+
+	def test_a_non_override_day_keeps_the_default(self):
+		self._with_friday_override()
+
+		schedule = self._schedule(A_MONDAY)
+
+		self.assertEqual(schedule.shift_type, self.default_type)
+
+	def test_with_no_override_required_every_day_keeps_the_default(self):
+		self._without_override()
+
+		for date in (A_FRIDAY, A_MONDAY):
+			self.assertEqual(self._schedule(date).shift_type, self.default_type)
+
+	def test_a_blank_shift_type_is_filled_from_the_post(self):
+		self._with_friday_override()
+
+		schedule = self._schedule(A_FRIDAY, shift_type=None)
+
+		self.assertEqual(schedule.shift_type, self.override_type)
+
+	def test_the_field_is_a_mirror_of_the_post_not_a_caller_s_choice(self):
+		# shift_type is read-only and declared fetch_from: shift.shift_type with no
+		# fetch_if_empty, so Frappe replaces whatever a caller passes with the post's own type
+		# before validate. The override therefore always wins, which is the field's existing
+		# contract - it has only ever mirrored the post.
+		self._with_friday_override()
+		other = frappe.db.get_value(
+			"Shift Type",
+			{"name": ["not in", [self.default_type, self.override_type]]},
+			"name",
+			order_by="name asc",
+		)
+		if not other:
+			self.skipTest("No third Shift Type on this site")
+
+		schedule = self._schedule(A_FRIDAY, shift_type=other)
+
+		self.assertEqual(schedule.shift_type, self.override_type)
+		self.assertTrue(frappe.get_meta("Employee Schedule").get_field("shift_type").read_only)
+
+	def test_a_day_off_row_is_not_given_a_shift_type(self):
+		self._with_friday_override()
+
+		schedule = self._schedule(A_FRIDAY, employee_availability="Day Off")
+
+		self.assertFalse(schedule.shift_type)
+
+	def test_a_row_with_no_operations_shift_is_untouched(self):
+		self._with_friday_override()
+
+		frappe.db.delete("Employee Schedule", {"employee": self.employee, "date": A_FRIDAY})
+		schedule = frappe.get_doc(
+			{
+				"doctype": "Employee Schedule",
+				"employee": self.employee,
+				"date": A_FRIDAY,
+				"employee_availability": "Day Off",
+				"roster_type": "Basic",
+			}
+		)
+		schedule.flags.ignore_permissions = True
+		schedule.insert()
+
+		self.assertFalse(schedule.shift)


### PR DESCRIPTION
## WI-001832 — Multiple Shift Type-wise timing integration in Employee Schedule

A Friday schedule generated from a post with a Friday override was still written with the post's **default** Shift Type, so the schedule and the post it came from said different things about the same day.

**Stacked on #6690 (WI-001831).** Review that one first — this PR's diff is only meaningful on top of it.

### Acceptance criteria

| AC | Status |
|---|---|
| Operations Shift with a Friday override → a Friday Employee Schedule takes the override, not the default | ✅ |
| No override required → any date takes the default (existing practice unchanged) | ✅ |

### Where the correction lives

In the **Employee Schedule controller**, not in each creator. Schedules are opened from a dozen places — the Desk roster, the mobile and flutter roster APIs, Request Employee Schedule, OJT, Client Event — and a choke point is the only thing that catches all of them.

`start_datetime` / `end_datetime` were already derived from `shift_type` a few lines further down, so fixing the type is what makes the datetimes follow.

### Why it is applied unconditionally

`Employee Schedule.shift_type` is **read-only** and declared `fetch_from: shift.shift_type` with **no** `fetch_if_empty`. Frappe therefore already replaces whatever a caller passed with the post's default before `validate` runs. The field has only ever been a mirror of the post's Shift Type — it is now a mirror of the post's Shift Type *for that date*, which is the same contract.

I initially wrote a guard to preserve a caller's deliberate choice. A test proved the guard unreachable: `fetch_from` had already overwritten the choice. Removing it is both simpler and more honest about what the field is.

### The Desk roster is also fixed at source

`roster.py` writes Employee Schedules with **raw SQL** and never reaches the controller. It read one pair of shift times for the whole batch and stamped every date with them — precisely wrong for a range containing an override day. Hours are resolved per date there now, cached per date so a 200-employee month does not re-resolve the same Friday 200 times.

### Tests

8 tests, all passing: `bench run-tests --module one_fm.operations.doctype.employee_schedule.test_employee_schedule_override`

### Note on other raw-SQL writers

The flutter/mobile roster endpoints (`api/v1/flutter/roster.py`, `api/v2/flutter/roster.py`) also insert Employee Schedules with raw SQL. They are **not** touched here — their rows self-heal on any later ORM save via the controller, but their value at insert is still the default. Say the word if you want those covered in this PR rather than followed up separately.

### To deploy

`bench migrate` then `bench restart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
