### PR TITLE
WI-001833: Multiple Shift Type-wise timing integration in Shift Assignment

### DIFF
--- a/one_fm/overrides/shift_assignment.py
+++ b/one_fm/overrides/shift_assignment.py
@@ -1,16 +1,61 @@
 import frappe
 from frappe import _
-from frappe.utils import add_days, now, today, now_datetime, get_link_to_form
+from frappe.utils import add_days, getdate, now, today, now_datetime, get_link_to_form
 from datetime import datetime, timedelta
 from hrms.hr.doctype.shift_assignment.shift_assignment import *
 from one_fm.api.v1.utils import response
+from one_fm.operations.doctype.operations_shift.operations_shift import resolve_shift_timing
 
 
 class ShiftAssignmentOverride(ShiftAssignment):
 
     def validate(self):
+        self.apply_shift_timing_override()
         self.set_datetime()
         super(ShiftAssignmentOverride, self).validate()
+
+    def apply_shift_timing_override(self):
+        """Carry the Shift Type this assignment's own date resolves to (WI-001833).
+
+        set_datetime() below derives start_datetime and end_datetime from shift_type, and
+        get_cut_off() derives the check-in and check-out window from the same field, so an
+        assignment holding the post's default on an override day is wrong about its hours in
+        both - the employee is measured against times they were never asked to work.
+
+        Only a single-day assignment is resolved. One assignment carries one Shift Type, so a
+        range spanning an override day and a default day has no single right answer; those
+        come from a Shift Request, which splits them by date itself.
+
+        Corrected only when the field still holds the post's default, which is the signature
+        of a caller that did not know about overrides. Unlike Employee Schedule.shift_type
+        this field is not a fetch_from mirror, so a deliberate choice does survive here and is
+        left alone.
+
+        shift_classification is re-derived from whichever Shift Type ends up in effect. It is
+        declared fetch_from: shift.shift_classification - the *post's* classification, taken
+        from the post's default Shift Type - so on an override day it would have read
+        "Morning" beside an Afternoon shift. Deriving it from the assignment's own Shift Type
+        also settles the case of a deliberately chosen type, where the two have always been
+        able to disagree.
+        """
+        if not (self.shift and self.start_date):
+            return
+
+        if self.end_date and getdate(self.end_date) != getdate(self.start_date):
+            return
+
+        operations_shift = frappe.get_cached_doc("Operations Shift", self.shift)
+        if operations_shift.shift_timing_override_required and (
+            not self.shift_type or self.shift_type == operations_shift.shift_type
+        ):
+            timing = resolve_shift_timing(operations_shift, self.start_date)
+            if timing.shift_type:
+                self.shift_type = timing.shift_type
+
+        if self.shift_type:
+            self.shift_classification = frappe.get_cached_value(
+                "Shift Type", self.shift_type, "shift_type"
+            )
 
     def validate_employee_checkin(self):
         """Block cancellation only when a checkin is actually linked to THIS

--- a/one_fm/tests/test_shift_assignment_timing_override.py
+++ b/one_fm/tests/test_shift_assignment_timing_override.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-001833: a Shift Assignment carries the Shift Type its own date resolves to."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days
+
+A_FRIDAY = "2027-01-01"
+A_MONDAY = "2027-01-04"
+
+
+def _an_operations_shift():
+	name = frappe.db.get_value(
+		"Operations Shift",
+		{"status": "Active", "shift_type": ["is", "set"]},
+		"name",
+		order_by="creation asc",
+	)
+	if not name:
+		raise frappe.DoesNotExistError("No active Operations Shift on this site to test against")
+	return name
+
+
+def _an_active_employee():
+	name = frappe.db.get_value(
+		"Employee",
+		{"status": "Active", "relieving_date": ["is", "not set"]},
+		"name",
+		order_by="creation asc",
+	)
+	if not name:
+		raise frappe.DoesNotExistError("No active employee on this site to test against")
+	return name
+
+
+class TestShiftAssignmentTimingOverride(FrappeTestCase):
+	def setUp(self):
+		self.employee = _an_active_employee()
+		self.shift_name = _an_operations_shift()
+		self.shift = frappe.get_doc("Operations Shift", self.shift_name)
+		self.default_type = self.shift.shift_type
+
+		default_hours = frappe.db.get_value(
+			"Shift Type", self.default_type, ["start_time", "end_time"], as_dict=True
+		)
+		self.override_type = frappe.db.get_value(
+			"Shift Type",
+			{"name": ["!=", self.default_type], "start_time": ["!=", default_hours.start_time]},
+			"name",
+			order_by="name asc",
+		)
+		if not self.override_type:
+			self.skipTest("No second Shift Type on this site to override with")
+
+		self.shift.shift_timing_override_required = 1
+		self.shift.set("operations_shift_timing", [])
+		self.shift.append(
+			"operations_shift_timing", {"day_of_week": "Friday", "shift_type": self.override_type}
+		)
+		self.shift.flags.ignore_permissions = True
+		self.shift.save()
+		frappe.clear_cache(doctype="Operations Shift")
+
+	def _assignment(self, start_date, **kwargs):
+		"""An unsaved Shift Assignment, validated rather than inserted.
+
+		validate() is where the resolution happens and is all these criteria are about;
+		inserting drags in the overlap checks against whatever the site already has rostered
+		for this employee.
+		"""
+		assignment = frappe.get_doc(
+			{
+				"doctype": "Shift Assignment",
+				"employee": self.employee,
+				"company": frappe.defaults.get_user_default("company"),
+				"shift": self.shift_name,
+				"shift_type": self.default_type,
+				"start_date": start_date,
+				"status": "Active",
+				**kwargs,
+			}
+		)
+		assignment.apply_shift_timing_override()
+		return assignment
+
+	def test_a_friday_assignment_takes_the_override(self):
+		self.assertEqual(self._assignment(A_FRIDAY).shift_type, self.override_type)
+
+	def test_a_non_override_day_keeps_the_default(self):
+		self.assertEqual(self._assignment(A_MONDAY).shift_type, self.default_type)
+
+	def test_the_datetimes_follow_the_resolved_shift_type(self):
+		assignment = self._assignment(A_FRIDAY)
+		assignment.set_datetime()
+
+		start_time = frappe.db.get_value("Shift Type", self.override_type, "start_time")
+		self.assertEqual(str(assignment.start_datetime), f"{A_FRIDAY} {start_time}")
+
+	def test_the_classification_follows_the_resolved_shift_type(self):
+		assignment = self._assignment(A_FRIDAY)
+
+		self.assertEqual(
+			assignment.shift_classification,
+			frappe.db.get_value("Shift Type", self.override_type, "shift_type"),
+		)
+
+	def test_the_classification_matches_the_default_on_a_default_day(self):
+		assignment = self._assignment(A_MONDAY)
+
+		self.assertEqual(
+			assignment.shift_classification,
+			frappe.db.get_value("Shift Type", self.default_type, "shift_type"),
+		)
+
+	def test_a_blank_shift_type_is_filled_from_the_post(self):
+		self.assertEqual(self._assignment(A_FRIDAY, shift_type=None).shift_type, self.override_type)
+
+	def test_a_deliberately_chosen_shift_type_survives(self):
+		# Unlike Employee Schedule.shift_type this field is not a fetch_from mirror, so a
+		# caller's choice is a real choice - an event or overtime assignment runs its own hours.
+		other = frappe.db.get_value(
+			"Shift Type",
+			{"name": ["not in", [self.default_type, self.override_type]]},
+			"name",
+			order_by="name asc",
+		)
+		if not other:
+			self.skipTest("No third Shift Type on this site")
+
+		self.assertEqual(self._assignment(A_FRIDAY, shift_type=other).shift_type, other)
+
+	def test_a_multi_day_assignment_is_left_alone(self):
+		# One assignment holds one Shift Type; a range covering both an override day and a
+		# default day has no single right answer, and Shift Request splits those by date.
+		assignment = self._assignment(A_FRIDAY, end_date=add_days(A_FRIDAY, 3))
+
+		self.assertEqual(assignment.shift_type, self.default_type)
+
+	def test_a_single_day_range_still_resolves(self):
+		assignment = self._assignment(A_FRIDAY, end_date=A_FRIDAY)
+
+		self.assertEqual(assignment.shift_type, self.override_type)
+
+	def test_nothing_happens_without_an_operations_shift(self):
+		assignment = self._assignment(A_FRIDAY, shift=None)
+
+		self.assertEqual(assignment.shift_type, self.default_type)
+
+	def test_the_default_is_kept_once_the_override_flag_is_off(self):
+		self.shift.shift_timing_override_required = 0
+		self.shift.flags.ignore_permissions = True
+		self.shift.save()
+		frappe.clear_cache(doctype="Operations Shift")
+
+		self.assertEqual(self._assignment(A_FRIDAY).shift_type, self.default_type)


### PR DESCRIPTION
## WI-001833 — Multiple Shift Type-wise timing integration in Shift Assignment

`set_datetime()` derives `start_datetime` / `end_datetime` from `shift_type`, and `get_cut_off()` derives the **check-in and check-out window** from the same field. An assignment left holding the post's default on an override day was therefore wrong about its hours in both, and the employee was measured against times nobody asked them to work.

**Stacked on #6691 (WI-001832) → #6690 (WI-001831).** Review in order.

### Acceptance criteria

| AC | Status |
|---|---|
| Employee Schedule with an override Shift Type → the Shift Assignment created from it carries the same Shift Type and Start/End Datetime | ✅ |
| Employee Schedule with the default Shift Type → behaviour unchanged | ✅ |

### The daily AM/PM job needed nothing

It builds each assignment from its Employee Schedule's `shift_type`, which WI-001832 already made day-resolved, and its AM/PM bucketing keys off that **same** field. So a Friday override that moves a post from 08:00 to 14:00 is simply picked up by the PM run instead of the AM run. The two buckets are complementary and exhaustive (`AM: 01:00 ≤ start < 13:00`, `PM: start < 01:00 OR start ≥ 13:00`), so nothing is dropped or assigned twice.

I checked `resolve_shift_type()`'s fallback chain for the case where an override's Shift Type is outside the time bucket being processed — it does a DB lookup before falling back to the hardcoded default, so the datetimes stay correct. No change needed there.

### What did change

Resolution in the Shift Assignment controller, immediately before `set_datetime()`, so an insert and a later save land on the same answer. This covers the ORM paths the raw-SQL job does not: event staff, overtime, manual creation.

**Only single-day assignments are resolved.** One assignment carries one Shift Type, so a range spanning an override day and a default day has no single right answer — those come from a Shift Request, which is WI-001834's job to split by date.

**A deliberately chosen Shift Type survives.** Unlike `Employee Schedule.shift_type`, this field is not a `fetch_from` mirror, so a caller's choice is a real choice — an event or overtime assignment runs its own hours. Only a field still holding the post's default is treated as one whose caller did not know about overrides.

### One inconsistency fixed

`shift_classification` was declared `fetch_from: shift.shift_classification` — the **post's** classification, itself taken from the post's *default* Shift Type. On an override day it read "Morning" beside an Afternoon shift. It is now derived from the assignment's own Shift Type, which also settles the older case of a deliberately chosen type, where the two have always been able to disagree.

### Tests

11 tests, all passing: `bench run-tests --module one_fm.tests.test_shift_assignment_timing_override`

Two of them failed on first run purely because this machine's Redis queue was down (WI-001831's re-stamp enqueues); they pass with it up. Worth knowing if CI is flaky here.

### To deploy

`bench migrate` then `bench restart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
