### PR TITLE
WI-001834: Multiple Shift Type-wise timing integration in Shift Request

### DIFF
--- a/one_fm/custom/custom_field/shift_request.py
+++ b/one_fm/custom/custom_field/shift_request.py
@@ -292,6 +292,30 @@ def get_shift_request_custom_fields():
                 "label": "Reason",
                 "reqd": 1,
                 "translatable": 1
+            },
+            # WI-001834: the approver sees how timing varies across the requested range
+            # before approving it. Both fields hang off the preview being non-empty, so a
+            # range that is all default days shows nothing at all - which is the third
+            # acceptance criterion, and keeps the form as it is today for the common case.
+            {
+                "fieldname": "custom_section_break_z4s37",
+                "fieldtype": "Section Break",
+                "insert_after": "custom_project_manager_user",
+                "label": "Shift Preview",
+                "depends_on": "eval:doc.custom_shift_preview && doc.custom_shift_preview.length"
+            },
+            {
+                "fieldname": "custom_shift_preview",
+                "fieldtype": "Table",
+                "insert_after": "custom_section_break_z4s37",
+                "label": "Shift Preview",
+                "options": "Shift Preview",
+                # Read-only on the grid rather than on each of the child doctype's three
+                # fields: one property instead of three, and the rows are system-derived, so
+                # there is nothing here for a requester to fill in.
+                "read_only": 1,
+                "depends_on": "eval:doc.custom_shift_preview && doc.custom_shift_preview.length",
+                "description": "Filled automatically when the requested range covers a day whose Operations Shift timing differs from the default."
             }
         ]
     }

--- a/one_fm/operations/doctype/shift_preview/shift_preview.json
+++ b/one_fm/operations/doctype/shift_preview/shift_preview.json
@@ -1,0 +1,57 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-08-12 15:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "date",
+  "column_break_pkkx",
+  "day",
+  "column_break_kybe",
+  "shift_type"
+ ],
+ "fields": [
+  {
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Date"
+  },
+  {
+   "fieldname": "column_break_pkkx",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "day",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Day",
+   "options": "\nSunday\nMonday\nTuesday\nWednesday\nThursday\nFriday\nSaturday"
+  },
+  {
+   "fieldname": "column_break_kybe",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "shift_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Shift Type",
+   "options": "Shift Type"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-08-12 15:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Operations",
+ "name": "Shift Preview",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/one_fm/operations/doctype/shift_preview/shift_preview.py
+++ b/one_fm/operations/doctype/shift_preview/shift_preview.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class ShiftPreview(Document):
+	pass

--- a/one_fm/overrides/shift_request.py
+++ b/one_fm/overrides/shift_request.py
@@ -12,7 +12,7 @@ from one_fm.utils import (
 )
 from one_fm.api.notification import get_employee_user_id
 from one_fm.operations.doctype.operations_shift.operations_shift import (
-    get_supervisor_operations_shifts, get_shift_supervisor
+    get_supervisor_operations_shifts, get_shift_supervisor, resolve_shift_timing
 )
 
 
@@ -82,6 +82,62 @@ class ShiftRequestOverride(ShiftRequest):
                 )).insert()
                 sa.submit()
 
+def build_shift_preview(doc):
+    """Show the approver how timing varies across the requested range (WI-001834).
+
+    One row per date, but only when the range actually contains a day whose Operations
+    Shift resolves to something other than the post's default - a request that is all
+    default days gets an empty table, and the section is hidden on `depends_on`, so the
+    form stays exactly as it is today for the common case.
+
+    The table is also the record of what was approved. Once it is filled, the Shift
+    Assignments and Employee Schedules raised on submit read their Shift Type from it
+    rather than from the request's single shift_type field, so what the approver saw and
+    what gets created are the same thing by construction.
+    """
+    doc.set("custom_shift_preview", [])
+
+    if not (doc.operations_shift and doc.from_date and doc.to_date):
+        return
+
+    operations_shift = frappe.get_cached_doc("Operations Shift", doc.operations_shift)
+    if not operations_shift.shift_timing_override_required:
+        return
+
+    rows = []
+    varies = False
+
+    for date in pd.date_range(start=doc.from_date, end=doc.to_date):
+        date = date.date()
+        timing = resolve_shift_timing(operations_shift, date)
+        if timing.is_override:
+            varies = True
+        rows.append({
+            "date": date,
+            "day": date.strftime("%A"),
+            "shift_type": timing.shift_type,
+        })
+
+    if not varies:
+        return
+
+    for row in rows:
+        doc.append("custom_shift_preview", row)
+
+
+def shift_type_on(doc, date):
+    """The Shift Type this request resolves to on one date of its range (WI-001834).
+
+    The preview table when it has been filled, the request's own shift_type otherwise -
+    so a request over default-only days behaves exactly as it did before.
+    """
+    for row in doc.get("custom_shift_preview") or []:
+        if row.date and getdate(row.date) == getdate(date):
+            return row.shift_type or doc.shift_type
+
+    return doc.shift_type
+
+
 def validate(doc, event=None):
     # ensure status is not pending
     if doc.is_new():
@@ -107,6 +163,7 @@ def validate(doc, event=None):
                                                 ])
         if not shift_assignemnt_exists:
             frappe.throw("Employee does not have an existing assignment. Even employees with day off do not have an existing assignment. If you want to assign a shift to an employee with a day off please use Assign Unrostered Employee.")
+    build_shift_preview(doc)  # WI-001834: before the assignments below read it
     process_shift_assignment(doc)  # set shift assignment and employee schedule
 
 
@@ -322,9 +379,10 @@ def process_shift_assignment(doc, event=None):
                     if schedule_name:
                         existing_schedule = frappe.get_doc("Employee Schedule", schedule_name)
                         
+                        date_shift_type = shift_type_on(doc, date)
                         start_time, end_time = frappe.db.get_value(
                             "Shift Type", 
-                            doc.shift_type,
+                            date_shift_type,
                             ['start_time', 'end_time']
                         )
                         
@@ -334,7 +392,7 @@ def process_shift_assignment(doc, event=None):
                         
                         update_data = {
                             'shift': doc.operations_shift,
-                            'shift_type': doc.shift_type,
+                            'shift_type': date_shift_type,
                             'start_datetime': f"{existing_schedule.date} {start_time}",
                             'end_datetime': f"{end_date} {end_time}",
                             'operations_role': doc.operations_role,
@@ -357,7 +415,7 @@ def process_shift_assignment(doc, event=None):
                         "company": doc.company,
                         "operations_shift": doc.operations_shift,
                         "roster_type": doc.roster_type,
-                        "shift_type": doc.shift_type,
+                        "shift_type": shift_type_on(doc, date),
                         "employee": doc.employee,
                         "from_date": date,
                         "name": doc.name,
@@ -616,13 +674,14 @@ def replace_employee_schedule(doc, existing_schedules, schedule_date_range):
         # replace existing schedule
         for es in existing_schedules:
             role_abbr = frappe.db.get_value("Operations Role", doc.operations_role, 'post_abbrv')
-            start_time, end_time = frappe.db.get_value("Shift Type", doc.shift_type, ['start_time', 'end_time'])
+            date_shift_type = shift_type_on(doc, es.date)
+            start_time, end_time = frappe.db.get_value("Shift Type", date_shift_type, ['start_time', 'end_time'])
             end_date = es.date
             if start_time > end_time:
                 end_date = add_days(end_date, 1)
             frappe.db.set_value('Employee Schedule', es.name, {
                 'shift': doc.operations_shift,
-                'shift_type': doc.shift_type,
+                'shift_type': date_shift_type,
                 'start_datetime': f"{es.date} {start_time}",
                 'end_datetime': f"{end_date} {end_time}",
                 'operations_role': doc.operations_role,
@@ -656,7 +715,9 @@ def create_shift_assignment_from_request(shift_request, submit=True,day_off_ot =
     assignment_doc.company = shift_request.company
     assignment_doc.shift = shift_request.operations_shift
     assignment_doc.roster_type = shift_request.roster_type
-    assignment_doc.shift_type = shift_request.shift_type
+    # WI-001834: one assignment covers one date (start_date, no end_date), so it takes that
+    # date's Shift Type off the preview rather than the request's single field.
+    assignment_doc.shift_type = shift_type_on(shift_request, shift_request.from_date)
     assignment_doc.employee = shift_request.employee
     assignment_doc.start_date = shift_request.from_date
     assignment_doc.shift_request = shift_request.name
@@ -681,7 +742,7 @@ def create_employee_schedule_from_request(doc, date):
     schedule.employee = doc.employee
     schedule.date = date
     schedule.shift = doc.operations_shift
-    schedule.shift_type = doc.shift_type
+    schedule.shift_type = shift_type_on(doc, date)
     schedule.operations_role = doc.operations_role
     # schedule.post_abbrv = frappe.db.get_value("Operations Role", doc.operations_role, 'post_abbrv')
     schedule.employee_availability = 'Working'

--- a/one_fm/patches/v15_0/add_shift_request_shift_preview.py
+++ b/one_fm/patches/v15_0/add_shift_request_shift_preview.py
@@ -1,0 +1,24 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+from one_fm.custom.custom_field.shift_request import get_shift_request_custom_fields
+
+# WI-001834: the Shift Preview grid an approver reads before approving a multi-day request.
+# create_custom_fields is idempotent, so the whole Shift Request set is handed to it rather
+# than the two new rows being singled out - that also repairs any of the others a previous
+# install missed.
+FIELDS = ("custom_section_break_z4s37", "custom_shift_preview")
+
+
+def execute():
+	create_custom_fields(get_shift_request_custom_fields())
+
+	missing = [
+		fieldname
+		for fieldname in FIELDS
+		if not frappe.db.exists("Custom Field", {"dt": "Shift Request", "fieldname": fieldname})
+	]
+	if missing:
+		frappe.throw(f"WI-001834: Shift Request is still missing {missing}")
+
+	frappe.clear_cache(doctype="Shift Request")

--- a/one_fm/tests/test_shift_request_preview.py
+++ b/one_fm/tests/test_shift_request_preview.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-001834: the Shift Preview an approver reads, and what gets created from it."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days
+
+from one_fm.overrides.shift_request import build_shift_preview, shift_type_on
+
+# 2027-01-01 is a Friday; the week after it contains exactly one more Friday.
+A_FRIDAY = "2027-01-01"
+A_MONDAY = "2027-01-04"
+A_TUESDAY = "2027-01-05"
+
+
+def _an_operations_shift():
+	name = frappe.db.get_value(
+		"Operations Shift",
+		{"status": "Active", "shift_type": ["is", "set"]},
+		"name",
+		order_by="creation asc",
+	)
+	if not name:
+		raise frappe.DoesNotExistError("No active Operations Shift on this site to test against")
+	return name
+
+
+class TestShiftRequestPreview(FrappeTestCase):
+	def setUp(self):
+		self.shift_name = _an_operations_shift()
+		self.shift = frappe.get_doc("Operations Shift", self.shift_name)
+		self.default_type = self.shift.shift_type
+
+		default_hours = frappe.db.get_value(
+			"Shift Type", self.default_type, ["start_time", "end_time"], as_dict=True
+		)
+		self.override_type = frappe.db.get_value(
+			"Shift Type",
+			{"name": ["!=", self.default_type], "start_time": ["!=", default_hours.start_time]},
+			"name",
+			order_by="name asc",
+		)
+		if not self.override_type:
+			self.skipTest("No second Shift Type on this site to override with")
+
+		self._set_override(True)
+
+	def tearDown(self):
+		self._set_override(False)
+
+	def _set_override(self, on):
+		"""Configure the post without saving it, which would enqueue the WI-001831 re-stamp."""
+		frappe.db.set_value(
+			"Operations Shift", self.shift_name, "shift_timing_override_required", int(on),
+			update_modified=False,
+		)
+		frappe.db.delete(
+			"Operations Shift Timing",
+			{"parent": self.shift_name, "parenttype": "Operations Shift"},
+		)
+		if on:
+			row = frappe.get_doc({
+				"doctype": "Operations Shift Timing",
+				"parent": self.shift_name,
+				"parenttype": "Operations Shift",
+				"parentfield": "operations_shift_timing",
+				"idx": 1,
+				"day_of_week": "Friday",
+				"shift_type": self.override_type,
+			})
+			row.db_insert()
+		frappe.clear_document_cache("Operations Shift", self.shift_name)
+
+	def _request(self, from_date, to_date):
+		"""An in-memory Shift Request. build_shift_preview reads only these four fields."""
+		return frappe.get_doc({
+			"doctype": "Shift Request",
+			"operations_shift": self.shift_name,
+			"shift_type": self.default_type,
+			"from_date": from_date,
+			"to_date": to_date,
+		})
+
+	# ------------------------------------------------------------------- AC 1 & 3
+
+	def test_a_range_containing_an_override_day_is_previewed(self):
+		request = self._request(A_FRIDAY, A_TUESDAY)
+
+		build_shift_preview(request)
+
+		self.assertEqual(len(request.custom_shift_preview), 5)
+
+	def test_every_previewed_row_carries_date_day_and_shift_type(self):
+		request = self._request(A_FRIDAY, A_TUESDAY)
+
+		build_shift_preview(request)
+
+		for row in request.custom_shift_preview:
+			self.assertTrue(row.date)
+			self.assertTrue(row.day)
+			self.assertTrue(row.shift_type)
+
+	def test_the_override_day_shows_the_override_and_the_rest_the_default(self):
+		request = self._request(A_FRIDAY, A_TUESDAY)
+
+		build_shift_preview(request)
+
+		by_day = {row.day: row.shift_type for row in request.custom_shift_preview}
+		self.assertEqual(by_day["Friday"], self.override_type)
+		self.assertEqual(by_day["Monday"], self.default_type)
+		self.assertEqual(by_day["Tuesday"], self.default_type)
+
+	def test_the_day_column_matches_the_date(self):
+		request = self._request(A_FRIDAY, A_TUESDAY)
+
+		build_shift_preview(request)
+
+		for row in request.custom_shift_preview:
+			self.assertEqual(row.day, frappe.utils.getdate(row.date).strftime("%A"))
+
+	def test_a_default_only_range_stays_empty(self):
+		# AC3: the section is hidden on depends_on, so an empty table is a hidden table.
+		request = self._request(A_MONDAY, A_TUESDAY)
+
+		build_shift_preview(request)
+
+		self.assertEqual(len(request.custom_shift_preview), 0)
+
+	def test_a_post_with_no_override_required_stays_empty(self):
+		self._set_override(False)
+		request = self._request(A_FRIDAY, A_TUESDAY)
+
+		build_shift_preview(request)
+
+		self.assertEqual(len(request.custom_shift_preview), 0)
+
+	def test_a_single_override_day_is_previewed(self):
+		request = self._request(A_FRIDAY, A_FRIDAY)
+
+		build_shift_preview(request)
+
+		self.assertEqual(len(request.custom_shift_preview), 1)
+		self.assertEqual(request.custom_shift_preview[0].shift_type, self.override_type)
+
+	def test_rebuilding_does_not_stack_rows(self):
+		request = self._request(A_FRIDAY, A_TUESDAY)
+
+		build_shift_preview(request)
+		build_shift_preview(request)
+
+		self.assertEqual(len(request.custom_shift_preview), 5)
+
+	def test_an_incomplete_request_is_left_alone(self):
+		for kwargs in (
+			{"from_date": None, "to_date": A_TUESDAY},
+			{"from_date": A_FRIDAY, "to_date": None},
+		):
+			request = self._request(**kwargs)
+			request.operations_shift = self.shift_name
+			build_shift_preview(request)
+			self.assertEqual(len(request.custom_shift_preview), 0)
+
+	def test_the_grid_is_read_only(self):
+		field = frappe.get_meta("Shift Request").get_field("custom_shift_preview")
+		self.assertTrue(field.read_only)
+		self.assertEqual(field.options, "Shift Preview")
+
+	def test_both_new_fields_hide_on_an_empty_preview(self):
+		meta = frappe.get_meta("Shift Request")
+		for fieldname in ("custom_section_break_z4s37", "custom_shift_preview"):
+			self.assertEqual(
+				meta.get_field(fieldname).depends_on,
+				"eval:doc.custom_shift_preview && doc.custom_shift_preview.length",
+			)
+
+	# ----------------------------------------------------------------------- AC 2
+
+	def test_what_gets_created_reads_the_previewed_date(self):
+		request = self._request(A_FRIDAY, A_TUESDAY)
+		build_shift_preview(request)
+
+		self.assertEqual(shift_type_on(request, A_FRIDAY), self.override_type)
+		self.assertEqual(shift_type_on(request, A_MONDAY), self.default_type)
+
+	def test_an_unpreviewed_request_falls_back_to_its_own_shift_type(self):
+		# A default-only range behaves exactly as it did before this story.
+		request = self._request(A_MONDAY, A_TUESDAY)
+		build_shift_preview(request)
+
+		self.assertEqual(shift_type_on(request, A_MONDAY), self.default_type)
+
+	def test_a_date_outside_the_preview_falls_back(self):
+		request = self._request(A_FRIDAY, A_FRIDAY)
+		build_shift_preview(request)
+
+		self.assertEqual(shift_type_on(request, add_days(A_FRIDAY, 40)), self.default_type)
+
+	def test_a_plain_dict_request_falls_back_without_error(self):
+		# One branch builds a frappe._dict rather than a document to hand on.
+		request = frappe._dict({"shift_type": self.default_type})
+
+		self.assertEqual(shift_type_on(request, A_FRIDAY), self.default_type)

--- a/patches.txt
+++ b/patches.txt
@@ -1,0 +1,1 @@
+one_fm.patches.v15_0.add_shift_request_shift_preview #2026-08-12 WI-001834


### PR DESCRIPTION
## WI-001834 — Multiple Shift Type-wise timing integration in Shift Request

A request spanning several days carried **one** Shift Type for all of them. An approver signing off a Friday-to-Tuesday range could not see that the Friday ran different hours, and the assignments raised on submit all took the single value.

**Stacked on #6692 (WI-001833) → #6691 → #6690.** Review in order.

### Acceptance criteria

| AC | Status |
|---|---|
| Range includes a day whose Shift Type differs from the default → on save, Shift Preview shows, fetches all fields, values read-only per row | ✅ |
| On submit, Shift Assignment fetches the Shift Type per the date in Shift Preview | ✅ |
| Range falls entirely within default-only days → Shift Preview stays hidden | ✅ |

### What was built

**New child doctype `Shift Preview`** (date / day / shift_type) exactly as configured on the BA site, plus the two Shift Request custom fields it links through — `custom_section_break_z4s37` and `custom_shift_preview`, with the `insert_after` positions the BA site specifies.

**The preview is filled on save**, one row per date, *only* when the range actually contains an override day. Both the table and its section hang off `depends_on: doc.custom_shift_preview.length`, so a default-only request shows nothing and the form is exactly as it is today. That is AC3, and it keeps this change invisible to the great majority of requests.

**The preview is then the record of what was approved.** The assignments and schedules raised on submit read their Shift Type from it rather than from the request's single `shift_type`, so what the approver saw and what gets created are the same thing by construction rather than by coincidence.

Five call sites moved onto `shift_type_on(doc, date)`:
- `create_shift_assignment_from_request` (single date — `start_date`, no `end_date`)
- `create_employee_schedule_from_request`
- the *Assign Unrostered Employee* branch's schedule update, and its assignment
- the *Replace Existing Assignment* branch — which now gives each replaced schedule **its own** date's timing instead of the request's one value

`shift_type_on` falls back to the request's own `shift_type` when there is no preview row for a date. That is what makes a default-only request behave exactly as before, and it keeps working for the one branch that hands on a `frappe._dict` rather than a document.

### Two small deviations from the BA config, both AC-driven

1. **Read-only** is set on the *grid* rather than on each of the child doctype's three fields — one property instead of three, and the rows are derived, so there is nothing for a requester to fill in. AC1 asks for read-only values; this delivers it.
2. The BA site put `read_only: 1` on the **section break** (which does nothing) and no `depends_on` anywhere. AC3 requires the preview to stay hidden, so `depends_on` is on both fields. Flagging it rather than silently differing.

### Tests

15 tests, all passing: `bench run-tests --module one_fm.tests.test_shift_request_preview`

### To deploy

`bench migrate` then `bench restart` — new child doctype plus patch `add_shift_request_shift_preview` for the two Shift Request custom fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
