### PR TITLE
WI-002019: Auto-Delete Post-Relieving Date Schedules on Exit

### DIFF
--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -419,16 +419,40 @@ class EmployeeOverride(EmployeeMaster):
             frappe.log_error(message=f"Failed to send status update notification: {str(e)}", title="Employee Status Update Notification")
 
     def clear_schedules(self):
-        # clear future employee schedules
-        if(self.has_value_changed('relieving_date') or self.has_value_changed('status')):
-            if self.status == 'Left' or self.relieving_date:
-                frappe.db.sql(f"""
-                    DELETE FROM `tabEmployee Schedule` WHERE employee = '{self.name}'
-                    AND date > '{self.relieving_date}'
-                """)
-                frappe.msgprint(f"""
-                    Employee Schedule cleared for {self.employee_name} starting from {add_days(self.relieving_date, 1)}
-                """)
+        """Drop the schedules an exiting employee can no longer work (WI-002019).
+
+        Enqueued rather than run inline: a long-serving employee can carry a month of
+        future rows across several projects, and the person setting a relieving date should
+        not wait on the delete - nor have their save fail because of it.
+
+        Gated on a relieving date being present. The previous version also ran for status
+        'Left' with no relieving date, where it interpolated None into the comparison and
+        comfortably deleted nothing while reporting success; there is no meaningful "after"
+        without a date to be after. Nothing new can be scheduled for them either way, since
+        Employee Schedule refuses a non-Active employee on insert.
+        """
+        if not (self.has_value_changed('relieving_date') or self.has_value_changed('status')):
+            return
+
+        if not self.relieving_date:
+            return
+
+        first_date_to_clear = add_days(getdate(self.relieving_date), 1)
+
+        frappe.enqueue(
+            delete_employee_schedules_from,
+            queue='long',
+            timeout=1500,
+            employee=self.name,
+            from_date=first_date_to_clear,
+        )
+        frappe.msgprint(
+            _("Schedule cleanup queued. Employee Schedules for {0} on or after {1} are being removed.").format(
+                self.employee_name, first_date_to_clear
+            ),
+            alert=True,
+            indicator='orange',
+        )
 
     def notify_supervisor_of_status_change(self):
         """
@@ -969,3 +993,27 @@ def delete_employee_schedules_for_next_7_days(employee_id):
                 title=f"Employee Schedule Deletion Error - {employee_id}"
             )
             raise
+
+
+def delete_employee_schedules_from(employee, from_date):
+    """Delete every Employee Schedule for an employee dated on or after `from_date`.
+
+    Shared by the two exit paths that have to clear a roster - a relieving date being set
+    (WI-002019) and a non-return from leave (WI-002018) - so there is one definition of what
+    clearing a roster means, and one place where the boundary is inclusive.
+
+    Returns the projects the deleted rows belonged to, which is what a caller needs to know
+    in order to re-run the checkers over the gaps this has just opened.
+    """
+    affected = frappe.get_all(
+        "Employee Schedule",
+        filters={"employee": employee, "date": [">=", getdate(from_date)]},
+        fields=["name", "project"],
+    )
+    if not affected:
+        return []
+
+    frappe.db.delete("Employee Schedule", {"name": ["in", [row.name for row in affected]]})
+    frappe.db.commit()
+
+    return sorted({row.project for row in affected if row.project})

--- a/one_fm/tests/test_delete_post_relieving_schedules.py
+++ b/one_fm/tests/test_delete_post_relieving_schedules.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002019: clearing an exiting employee's roster past their relieving date."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, getdate, today
+
+from one_fm.overrides.employee import delete_employee_schedules_from
+
+
+def _an_operations_shift():
+	"""An Active Operations Shift, as a plain dict of the three fields a schedule needs.
+
+	Read with db.get_value rather than loaded as a document: this story has nothing to do
+	with Operations Shift's controller, and not loading it keeps the test independent of
+	whatever that controller currently requires.
+	"""
+	shift = frappe.db.get_value(
+		"Operations Shift",
+		{"status": "Active", "shift_type": ["is", "set"]},
+		["name", "site", "project", "shift_type"],
+		order_by="creation asc",
+		as_dict=True,
+	)
+	if not shift:
+		raise frappe.DoesNotExistError("No active Operations Shift on this site to test against")
+	return shift
+
+
+def _an_active_employee():
+	name = frappe.db.get_value(
+		"Employee",
+		{"status": "Active", "relieving_date": ["is", "not set"]},
+		"name",
+		order_by="creation asc",
+	)
+	if not name:
+		raise frappe.DoesNotExistError("No active employee on this site to test against")
+	return name
+
+
+class TestDeletePostRelievingSchedules(FrappeTestCase):
+	def setUp(self):
+		self.employee = _an_active_employee()
+		self.shift = _an_operations_shift()
+		self.shift_name = self.shift.name
+
+		# Well clear of anything the site has really rostered.
+		self.relieving_date = add_days(today(), 40)
+		self.before = add_days(self.relieving_date, -1)
+		self.on = self.relieving_date
+		self.after = add_days(self.relieving_date, 1)
+		self.well_after = add_days(self.relieving_date, 10)
+
+		for date in (self.before, self.on, self.after, self.well_after):
+			frappe.db.delete("Employee Schedule", {"employee": self.employee, "date": date})
+
+	def _schedule(self, date):
+		schedule = frappe.get_doc({
+			"doctype": "Employee Schedule",
+			"employee": self.employee,
+			"date": date,
+			"shift": self.shift_name,
+			"site": self.shift.site,
+			"project": self.shift.project,
+			"employee_availability": "Working",
+			"shift_type": self.shift.shift_type,
+			"roster_type": "Basic",
+		})
+		schedule.flags.ignore_permissions = True
+		schedule.insert()
+		return schedule
+
+	def _exists(self, date):
+		return bool(frappe.db.exists("Employee Schedule", {"employee": self.employee, "date": date}))
+
+	# --------------------------------------------------------------- the boundary
+
+	def test_the_boundary_is_inclusive_of_the_date_given(self):
+		self._schedule(self.after)
+		self._schedule(self.well_after)
+
+		delete_employee_schedules_from(self.employee, self.after)
+
+		self.assertFalse(self._exists(self.after))
+		self.assertFalse(self._exists(self.well_after))
+
+	def test_earlier_schedules_are_left_alone(self):
+		self._schedule(self.before)
+		self._schedule(self.on)
+		self._schedule(self.after)
+
+		delete_employee_schedules_from(self.employee, self.after)
+
+		self.assertTrue(self._exists(self.before))
+		self.assertTrue(self._exists(self.on))
+		self.assertFalse(self._exists(self.after))
+
+	def test_the_relieving_date_itself_is_a_working_day(self):
+		# The employee works their last day; only what follows it is cleared.
+		self._schedule(self.on)
+		self._schedule(self.after)
+
+		delete_employee_schedules_from(self.employee, add_days(getdate(self.relieving_date), 1))
+
+		self.assertTrue(self._exists(self.on))
+		self.assertFalse(self._exists(self.after))
+
+	def test_another_employee_is_untouched(self):
+		other = frappe.db.get_value(
+			"Employee",
+			{"status": "Active", "name": ["!=", self.employee]},
+			"name",
+			order_by="creation asc",
+		)
+		if not other:
+			self.skipTest("Only one active employee on this site")
+		frappe.db.delete("Employee Schedule", {"employee": other, "date": self.after})
+		theirs = frappe.get_doc({
+			"doctype": "Employee Schedule",
+			"employee": other,
+			"date": self.after,
+			"shift": self.shift_name,
+			"site": self.shift.site,
+			"project": self.shift.project,
+			"employee_availability": "Working",
+			"shift_type": self.shift.shift_type,
+			"roster_type": "Basic",
+		})
+		theirs.flags.ignore_permissions = True
+		theirs.insert()
+
+		delete_employee_schedules_from(self.employee, self.after)
+
+		self.assertTrue(frappe.db.exists("Employee Schedule", theirs.name))
+
+	# ------------------------------------------------- what the caller gets back
+
+	def test_it_reports_the_projects_it_emptied(self):
+		self._schedule(self.after)
+
+		projects = delete_employee_schedules_from(self.employee, self.after)
+
+		self.assertEqual(projects, [self.shift.project])
+
+	def test_nothing_to_delete_reports_nothing(self):
+		self.assertEqual(delete_employee_schedules_from(self.employee, self.after), [])
+
+	def test_projects_are_reported_once_each(self):
+		self._schedule(self.after)
+		self._schedule(self.well_after)
+
+		projects = delete_employee_schedules_from(self.employee, self.after)
+
+		self.assertEqual(len(projects), len(set(projects)))
+
+	# ------------------------------------------------------------- the trigger
+
+	def test_setting_a_relieving_date_queues_the_cleanup(self):
+		self._schedule(self.after)
+		employee = frappe.get_doc("Employee", self.employee)
+		employee.relieving_date = self.relieving_date
+
+		enqueued = []
+		original = frappe.enqueue
+
+		def capture(method, **kwargs):
+			enqueued.append((method, kwargs))
+			return None
+
+		frappe.enqueue = capture
+		try:
+			employee.clear_schedules()
+		finally:
+			frappe.enqueue = original
+
+		self.assertEqual(len(enqueued), 1)
+		method, kwargs = enqueued[0]
+		self.assertIs(method, delete_employee_schedules_from)
+		self.assertEqual(kwargs["employee"], self.employee)
+		self.assertEqual(getdate(kwargs["from_date"]), getdate(self.after))
+
+	def test_no_relieving_date_queues_nothing(self):
+		# The old version interpolated None into the comparison and deleted nothing while
+		# reporting success. Doing nothing deliberately is the same outcome, said honestly.
+		employee = frappe.get_doc("Employee", self.employee)
+		employee.relieving_date = None
+		employee.status = "Left"
+
+		enqueued = []
+		original = frappe.enqueue
+		frappe.enqueue = lambda method, **kwargs: enqueued.append(method)
+		try:
+			employee.clear_schedules()
+		finally:
+			frappe.enqueue = original
+
+		self.assertEqual(enqueued, [])
+
+	def test_an_unchanged_employee_queues_nothing(self):
+		employee = frappe.get_doc("Employee", self.employee)
+
+		enqueued = []
+		original = frappe.enqueue
+		frappe.enqueue = lambda method, **kwargs: enqueued.append(method)
+		try:
+			employee.clear_schedules()
+		finally:
+			frappe.enqueue = original
+
+		self.assertEqual(enqueued, [])


### PR DESCRIPTION
## WI-002019 — Auto-Delete Post-Relieving Date Schedules on Exit

**Independent of the timing-override chain (#6690–#6696) — branched off `staging`.** WI-002018 stacks on this one, for the shared helper.

### Acceptance criteria

| AC | Status |
|---|---|
| Relieving Date populated, active schedules exist after it, Relieving Date set and saved → a **background job** deletes those Employee Schedule records | ✅ |

### The deletion already existed — inline, and with three problems

`EmployeeOverride.clear_schedules()` was already deleting post-relieving schedules. What it was not doing was any of it safely:

1. **Not a background job.** The story asks for one, and the work deserves it — a long-serving employee can carry a month of future rows across several projects, and whoever sets a relieving date should not wait on the delete, nor have their save fail because of it.

2. **It silently did nothing for a `Left` employee with no relieving date.** The condition was `if self.status == 'Left' or self.relieving_date`, so a `Left` employee with no date reached an f-string that produced `date > 'None'` — MariaDB compares and matches nothing. It then printed "Employee Schedule cleared for … starting from …", so it reported success having changed nothing.

3. **That same message would have raised** on `add_days(None, 1)`, so in that branch the honest path never ran either.

The rule is now gated on a relieving date being present — there is no meaningful "after" without a date to be after. Nothing new can be scheduled for such an employee regardless: Employee Schedule already refuses a non-Active employee on insert.

**Raw f-string SQL replaced with `frappe.db.delete`,** per the app's own standard.

### Why the delete is a shared helper

WI-002018 clears a roster for a different reason (a non-return from leave). The two must not disagree about what clearing a roster means, or about whether the boundary date is included. `delete_employee_schedules_from(employee, from_date)` is inclusive of `from_date`; this story passes `relieving_date + 1` day, because the employee works their last day.

It returns the projects whose rows it removed — what a caller needs in order to re-run the checkers over the gaps just opened. WI-002018 uses that; this story does not need it.

### Tests

10 tests, all passing: `bench run-tests --module one_fm.tests.test_delete_post_relieving_schedules`

Including the boundary in both directions, that another employee's rows are untouched, and that no relieving date now queues nothing rather than pretending to work.

### Behaviour change worth your attention

A `Left` employee with **no** relieving date no longer triggers a cleanup attempt. Previously it attempted one and deleted nothing, so the observable outcome is identical — but if you *want* those employees' future rows cleared, that needs a rule for which date to clear from, and I would rather you decide it than guess.

### To deploy

`bench migrate` then `bench restart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
