### PR TITLE
WI-002018: Auto-Delete all remaining Employee Schedules for "Not Returned from Leave"

### DIFF
--- a/one_fm/operations/doctype/post_scheduler_checker/post_scheduler_checker.py
+++ b/one_fm/operations/doctype/post_scheduler_checker/post_scheduler_checker.py
@@ -211,9 +211,22 @@ def get_post_scheduler_items(contract, project):
 
 	return items
 
-def schedule_roster_checker():
+def schedule_roster_checker(projects=None):
+	"""Rebuild today's Post Scheduler Checker for every active contract, or just some.
+
+	WI-002018: `projects` narrows it to the projects whose roster has just changed, so a
+	staffing gap opened by a cleanup is reported the moment it appears rather than waiting
+	for tomorrow's scheduled run. Left empty it behaves exactly as the scheduled job always
+	has, which is how it is still called from the scheduler.
+	"""
+	conditions = ""
+	values = {}
+	if projects:
+		conditions = " AND p.name IN %(projects)s"
+		values["projects"] = tuple(projects)
+
 	contracts = frappe.db.sql("""SELECT c.name, p.name as project from `tabContracts` c JOIN `tabProject` p ON p.name = c.project WHERE c.workflow_state = 'Active'
-						   		  AND p.is_active = 'Yes' """, as_dict=1)
+						   		  AND p.is_active = 'Yes' """ + conditions, values, as_dict=1)
 	if not contracts:
 		return
 

--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -240,9 +240,9 @@ class EmployeeOverride(EmployeeMaster):
         self.notify_employee_id_update()
         self.remove_user_on_employee_left()
         self.notify_supervisor_of_status_change()
-        if self.has_value_changed("status") and self.status == "Not Returned from Leave":
+        if self.has_value_changed("status") and self.status == NOT_RETURNED_FROM_LEAVE:
             self.inform_employee_status_update()
-            frappe.enqueue(delete_employee_schedules_for_next_7_days, queue='default', timeout=300, employee_id=self.name)
+            self.clear_schedules_for_non_return()
 
         self.setup_wiki_introduction_for_new_employee()
 
@@ -405,6 +405,49 @@ class EmployeeOverride(EmployeeMaster):
                 message = status_validate.message()
                 if message:
                     frappe.throw(message)
+
+    def clear_schedules_for_non_return(self):
+        """Queue the roster cleanup for an employee who has not come back from leave (WI-002018).
+
+        Cleared from the Resumption Date of their latest approved Leave Application, which is
+        the first day they were expected and did not appear - so every shift from that day on
+        is one nobody is going to work, and the roster should say so.
+
+        The previous rule cleared a fixed seven days from today. That was both too little and
+        too much: it left everything past the seventh day rostered to someone who is not
+        coming, and it removed days before the resumption date that they were legitimately on
+        leave for and that no one has any reason to re-staff.
+
+        Without a resumption date there is no day to clear from, so nothing is queued and the
+        reason is recorded - silence here would look identical to a cleanup that ran.
+        """
+        from_date = latest_resumption_date(self.name)
+
+        if not from_date:
+            frappe.log_error(
+                title=f"WI-002018: no Resumption Date for {self.name}",
+                message=(
+                    f"{self.employee_name} was set to {NOT_RETURNED_FROM_LEAVE} but has no "
+                    "approved Leave Application carrying a Resumption Date, so there is no "
+                    "date to clear their Employee Schedules from. Their roster is unchanged."
+                ),
+            )
+            return
+
+        frappe.enqueue(
+            clear_schedules_for_non_return,
+            queue='long',
+            timeout=1500,
+            employee=self.name,
+            from_date=from_date,
+        )
+        frappe.msgprint(
+            _("Schedule cleanup queued. Employee Schedules on or after {0} are being removed.").format(
+                frappe.utils.formatdate(from_date)
+            ),
+            alert=True,
+            indicator='orange',
+        )
 
     def inform_employee_status_update(self):
         try:
@@ -970,29 +1013,44 @@ def get_assurance_level_of_employee(doc, method):
             frappe.log_error(message=frappe.get_traceback(), title=f"DSS returned NONE values,No API key")
 
 
-def delete_employee_schedules_for_next_7_days(employee_id):
-        start_date = today()
-        end_date = add_days(start_date, 6)
+def latest_resumption_date(employee):
+    """The Resumption Date of the employee's most recent approved Leave Application.
 
-        try:
-            frappe.db.sql("""
-                DELETE FROM `tabEmployee Schedule`
-                WHERE employee = %(employee)s
-                AND date BETWEEN %(start_date)s AND %(end_date)s
-            """, {
-                'employee': employee_id,
-                'start_date': start_date,
-                'end_date': end_date
-            })
-            
-            frappe.db.commit()
+    Most recent by the leave it covers rather than by when the record was created, because a
+    correction filed after the fact should not lose to the row that was entered first.
+    """
+    return frappe.db.get_value(
+        "Leave Application",
+        {
+            "employee": employee,
+            "status": "Approved",
+            "docstatus": 1,
+            "resumption_date": ["is", "set"],
+        },
+        "resumption_date",
+        order_by="to_date desc, modified desc",
+    )
 
-        except Exception as e:
-            frappe.log_error(
-                message=f"Error deleting schedules: {str(e)}",
-                title=f"Employee Schedule Deletion Error - {employee_id}"
-            )
-            raise
+
+def clear_schedules_for_non_return(employee, from_date):
+    """Clear a non-returning employee's roster and re-check the gaps it opens (WI-002018).
+
+    The two halves are one job because the second is meaningless without the first: the
+    checkers have to run against the roster as it is once the rows are gone, so they cannot
+    be enqueued alongside and race it.
+    """
+    projects = delete_employee_schedules_from(employee, from_date)
+    if not projects:
+        return
+
+    # Imported here rather than at module scope: post_scheduler_checker imports from the
+    # operations tree, and Employee is loaded early enough that a top-level import of it
+    # closes a cycle.
+    from one_fm.operations.doctype.post_scheduler_checker.post_scheduler_checker import (
+        schedule_roster_checker,
+    )
+
+    schedule_roster_checker(projects=projects)
 
 
 def delete_employee_schedules_from(employee, from_date):

--- a/one_fm/tests/test_delete_schedules_not_returned.py
+++ b/one_fm/tests/test_delete_schedules_not_returned.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002018: clearing the roster of an employee who did not come back from leave."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, getdate, today
+
+from one_fm.overrides.employee import (
+	NOT_RETURNED_FROM_LEAVE,
+	clear_schedules_for_non_return,
+	delete_employee_schedules_from,
+	latest_resumption_date,
+)
+
+
+def _an_operations_shift():
+	shift = frappe.db.get_value(
+		"Operations Shift",
+		{"status": "Active", "shift_type": ["is", "set"]},
+		["name", "site", "project", "shift_type"],
+		order_by="creation asc",
+		as_dict=True,
+	)
+	if not shift:
+		raise frappe.DoesNotExistError("No active Operations Shift on this site to test against")
+	return shift
+
+
+def _an_active_employee():
+	name = frappe.db.get_value(
+		"Employee",
+		{"status": "Active", "relieving_date": ["is", "not set"]},
+		"name",
+		order_by="creation asc",
+	)
+	if not name:
+		raise frappe.DoesNotExistError("No active employee on this site to test against")
+	return name
+
+
+class TestDeleteSchedulesNotReturned(FrappeTestCase):
+	def setUp(self):
+		self.employee = _an_active_employee()
+		self.shift = _an_operations_shift()
+
+		self.resumption_date = add_days(today(), 30)
+		self.before = add_days(self.resumption_date, -1)
+		self.on = self.resumption_date
+		self.after = add_days(self.resumption_date, 1)
+		self.well_after = add_days(self.resumption_date, 20)
+
+		for date in (self.before, self.on, self.after, self.well_after):
+			frappe.db.delete("Employee Schedule", {"employee": self.employee, "date": date})
+
+	def _schedule(self, date):
+		schedule = frappe.get_doc({
+			"doctype": "Employee Schedule",
+			"employee": self.employee,
+			"date": date,
+			"shift": self.shift.name,
+			"site": self.shift.site,
+			"project": self.shift.project,
+			"employee_availability": "Working",
+			"shift_type": self.shift.shift_type,
+			"roster_type": "Basic",
+		})
+		schedule.flags.ignore_permissions = True
+		schedule.insert()
+		return schedule
+
+	def _exists(self, date):
+		return bool(frappe.db.exists("Employee Schedule", {"employee": self.employee, "date": date}))
+
+	# ------------------------------------------------- the date it clears from
+
+	def test_the_resumption_date_itself_is_cleared(self):
+		# The first day they were expected and did not appear is a day nobody will work.
+		self._schedule(self.on)
+		self._schedule(self.after)
+
+		delete_employee_schedules_from(self.employee, self.resumption_date)
+
+		self.assertFalse(self._exists(self.on))
+		self.assertFalse(self._exists(self.after))
+
+	def test_days_they_were_legitimately_on_leave_are_kept(self):
+		# The old rule cleared a fixed seven days from today, which removed days before the
+		# resumption date that nobody has any reason to re-staff.
+		self._schedule(self.before)
+		self._schedule(self.on)
+
+		delete_employee_schedules_from(self.employee, self.resumption_date)
+
+		self.assertTrue(self._exists(self.before))
+		self.assertFalse(self._exists(self.on))
+
+	def test_everything_past_the_seventh_day_is_cleared_too(self):
+		# The old rule stopped after seven days and left the rest rostered to someone who is
+		# not coming back.
+		self._schedule(self.well_after)
+
+		delete_employee_schedules_from(self.employee, self.resumption_date)
+
+		self.assertFalse(self._exists(self.well_after))
+
+	# --------------------------------------------------- finding the resumption date
+
+	def test_it_reads_the_latest_approved_leave_application(self):
+		found = latest_resumption_date(self.employee)
+		expected = frappe.db.get_value(
+			"Leave Application",
+			{
+				"employee": self.employee,
+				"status": "Approved",
+				"docstatus": 1,
+				"resumption_date": ["is", "set"],
+			},
+			"resumption_date",
+			order_by="to_date desc, modified desc",
+		)
+
+		self.assertEqual(found, expected)
+
+	def test_an_employee_with_no_such_leave_gets_no_date(self):
+		employee_without = frappe.db.sql(
+			"""
+			SELECT e.name FROM `tabEmployee` e
+			WHERE e.status = 'Active'
+			AND NOT EXISTS (
+				SELECT 1 FROM `tabLeave Application` la
+				WHERE la.employee = e.name AND la.status = 'Approved'
+				AND la.docstatus = 1 AND la.resumption_date IS NOT NULL
+			)
+			LIMIT 1
+			""",
+			as_dict=True,
+		)
+		if not employee_without:
+			self.skipTest("Every active employee on this site has a resumption date")
+
+		self.assertIsNone(latest_resumption_date(employee_without[0].name))
+
+	# ------------------------------------------------------------- the queued job
+
+	def test_the_job_clears_and_then_rechecks(self):
+		self._schedule(self.on)
+		called = []
+		import one_fm.operations.doctype.post_scheduler_checker.post_scheduler_checker as checker
+
+		original = checker.schedule_roster_checker
+		checker.schedule_roster_checker = lambda projects=None: called.append(projects)
+		try:
+			clear_schedules_for_non_return(self.employee, self.resumption_date)
+		finally:
+			checker.schedule_roster_checker = original
+
+		self.assertFalse(self._exists(self.on))
+		self.assertEqual(called, [[self.shift.project]])
+
+	def test_nothing_deleted_means_no_checker_run(self):
+		called = []
+		import one_fm.operations.doctype.post_scheduler_checker.post_scheduler_checker as checker
+
+		original = checker.schedule_roster_checker
+		checker.schedule_roster_checker = lambda projects=None: called.append(projects)
+		try:
+			clear_schedules_for_non_return(self.employee, self.resumption_date)
+		finally:
+			checker.schedule_roster_checker = original
+
+		self.assertEqual(called, [])
+
+	# ---------------------------------------------------------------- the trigger
+
+	def test_the_status_change_queues_the_cleanup(self):
+		employee = frappe.get_doc("Employee", self.employee)
+		if not latest_resumption_date(self.employee):
+			self.skipTest("This employee has no approved leave carrying a resumption date")
+
+		enqueued = []
+		original = frappe.enqueue
+		frappe.enqueue = lambda method, **kwargs: enqueued.append((method, kwargs))
+		try:
+			employee.clear_schedules_for_non_return()
+		finally:
+			frappe.enqueue = original
+
+		self.assertEqual(len(enqueued), 1)
+		method, kwargs = enqueued[0]
+		self.assertIs(method, clear_schedules_for_non_return)
+		self.assertEqual(kwargs["employee"], self.employee)
+		self.assertEqual(
+			getdate(kwargs["from_date"]), getdate(latest_resumption_date(self.employee))
+		)
+
+	def test_no_resumption_date_queues_nothing_and_says_so(self):
+		employee_without = frappe.db.sql(
+			"""
+			SELECT e.name FROM `tabEmployee` e
+			WHERE e.status = 'Active'
+			AND NOT EXISTS (
+				SELECT 1 FROM `tabLeave Application` la
+				WHERE la.employee = e.name AND la.status = 'Approved'
+				AND la.docstatus = 1 AND la.resumption_date IS NOT NULL
+			)
+			LIMIT 1
+			""",
+			as_dict=True,
+		)
+		if not employee_without:
+			self.skipTest("Every active employee on this site has a resumption date")
+
+		employee = frappe.get_doc("Employee", employee_without[0].name)
+		before = frappe.db.count("Error Log")
+
+		enqueued = []
+		original = frappe.enqueue
+		frappe.enqueue = lambda method, **kwargs: enqueued.append(method)
+		try:
+			employee.clear_schedules_for_non_return()
+		finally:
+			frappe.enqueue = original
+
+		self.assertEqual(enqueued, [])
+		# Silence would look identical to a cleanup that ran, so the reason is recorded.
+		self.assertGreater(frappe.db.count("Error Log"), before)
+
+	def test_the_status_is_spelled_the_way_the_app_defines_it(self):
+		"""The constant matches the option one_fm's own property setter installs.
+
+		Asserted against the definition in code rather than against frappe.get_meta, because
+		the option reaches the Select through a property setter and a site whose property
+		setters have not been applied yet would fail on its own configuration rather than on
+		anything this story changed. A mismatch here, by contrast, means the trigger below can
+		never fire - the comparison would silently never match.
+		"""
+		from one_fm.custom.property_setter.employee import get_employee_properties
+
+		status_options = [
+			entry["value"]
+			for entry in get_employee_properties()
+			if entry["field_name"] == "status" and entry["property"] == "options"
+		]
+
+		self.assertTrue(status_options, "no options property setter defined for Employee.status")
+		self.assertIn(NOT_RETURNED_FROM_LEAVE, status_options[0].split("\n"))
+
+	def test_the_checker_still_runs_over_everything_when_unfiltered(self):
+		# The scheduled job calls it with no arguments and must keep its old behaviour.
+		import inspect
+
+		from one_fm.operations.doctype.post_scheduler_checker.post_scheduler_checker import (
+			schedule_roster_checker,
+		)
+
+		signature = inspect.signature(schedule_roster_checker)
+		self.assertIsNone(signature.parameters["projects"].default)


### PR DESCRIPTION
## WI-002018 — Auto-Delete all remaining Employee Schedules for "Not Returned from Leave"

**Stacked on #6697 (WI-002019)** for the shared delete helper. Independent of the timing-override chain.

### Acceptance criteria

| AC | Status |
|---|---|
| Status set to "Not Returned from Leave" → background job deletes all Employee Schedules where date ≥ Resumption Date of the latest Leave Application | ✅ |
| Notification: "Schedule cleanup queued. Employee Schedules on or after {Resumption Date} are being removed." | ✅ wording as specified |
| On completion, trigger the required Checker for the impacted Projects and Sales Items | ✅ Post Scheduler Checker, scoped to the affected projects |

### The trigger existed but cleared the wrong window

It enqueued `delete_employee_schedules_for_next_7_days` — a fixed seven days from today. That was wrong in **both** directions:

- it left every shift **past the seventh day** rostered to someone who is not coming back
- it removed days **before** the resumption date that the employee was legitimately on leave for, and that nobody has any reason to re-staff

Now cleared from the **Resumption Date of the latest approved Leave Application** — the first day they were expected and did not appear. The "latest" is taken by the leave it covers (`to_date desc`) rather than by when the record was created, so a correction filed after the fact does not lose to the row entered first.

### Why the delete and the re-check are one job

AC2 requires the checkers to run *after* the deletion completes. Two separate enqueues would race, and the checker would read the roster as it was. So `clear_schedules_for_non_return` deletes, then re-checks, in that order, in one job.

**Post Scheduler Checker** is the checker that reports staffing gaps per project and sale item (`"No operations roles created with sale item X in project Y"`). It gains an **optional `projects` filter** rather than a second copy of itself — called with no arguments it behaves exactly as it always has, which is how the scheduled job still calls it. Only the projects the deleted rows belonged to are re-checked, so one employee's exit does not rebuild every active contract's checker.

### When there is no resumption date

Nothing is queued and the reason is written to the Error Log. Silence there would look identical to a cleanup that ran, while the roster quietly kept shifts nobody is going to work.

### One thing you need to know before testing

**`Not Returned from Leave` is not currently in the Employee `status` Select on this site.** The option is defined in one_fm's own property setters (`custom/property_setter/employee.py`), but this site's DB has not had them applied — its options are `Active / Court Case / Absconding / Left / Vacation`. Until they are applied, the status cannot be selected in the UI and this trigger cannot fire at all.

That is why the spelling test asserts against the app's property-setter definition rather than against `frappe.get_meta` — otherwise it would fail on site configuration rather than on anything this PR changed. Please run the property setters as part of your migrate before manual testing.

### Tests

11 tests, all passing: `bench run-tests --module one_fm.tests.test_delete_schedules_not_returned`

Covering the boundary in both directions, the two specific failures of the old seven-day rule, the ordering of delete-then-check, and that nothing is deleted → no checker run.

### To deploy

`bench migrate` then `bench restart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
