### PR TITLE
send_work_item_notify_assignee_demo_email to notifications

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -540,7 +540,7 @@ one_fm.patches.v15_0.seed_app_services
 one_fm.patches.v15_0.set_candidate_title_fields
 one_fm.patches.v15_0.update_attendance_check
 one_fm.patches.v15_0.update_employee_and_user_references
-one_fm.patches.v15_0.send_work_item_notify_assignee_demo_email #wi001663-notify-self-test
+one_fm.patches.v15_0.send_work_item_notify_assignee_demo_email #2026-08-13
 one_fm.patches.v15_0.mark_present_auto_attendance_missed_checkin_jul13
 one_fm.patches.v15_0.add_employee_schedule_suspension_workflow #2026-07-24
 one_fm.patches.v15_0.add_accommodation_leave_movement_assignment_rules #2026-07-30

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -540,7 +540,7 @@ one_fm.patches.v15_0.seed_app_services
 one_fm.patches.v15_0.set_candidate_title_fields
 one_fm.patches.v15_0.update_attendance_check
 one_fm.patches.v15_0.update_employee_and_user_references
-one_fm.patches.v15_0.send_work_item_notify_assignee_demo_email #2026-08-12
+one_fm.patches.v15_0.send_work_item_notify_assignee_demo_email #wi001663-notify-self-test
 one_fm.patches.v15_0.mark_present_auto_attendance_missed_checkin_jul13
 one_fm.patches.v15_0.add_employee_schedule_suspension_workflow #2026-07-24
 one_fm.patches.v15_0.add_accommodation_leave_movement_assignment_rules #2026-07-30

--- a/one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py
+++ b/one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py
@@ -2,23 +2,34 @@ import frappe
 from frappe import _
 
 SENDER = "notifications@one-fm.com"
-RECIPIENT = "s.shariff@one-fm.com"
+RECIPIENT = "notifications@one-fm.com"
 
-# Real, live BPMN Process Instance task for WI-001875's "Start Work" step —
-# not a synthetic demo. Must be in READY (16) or WAITING (8) state at the
-# time this runs; look these up fresh from the BPMN Process Instance's
-# `workflow_state` (not the older, possibly-stale `serialized_spec`) if
-# reusing this pattern for a different task.
-INSTANCE_NAME = "c57ogcqvmu"
-TASK_ID = "1c9b34b8-019e-4402-bd74-75905d15b0f6"
-WORK_ITEM_ID = "WI-001875"
-WORK_ITEM_TITLE = "1.2 Skills index in the static context and on-trigger body loading"
+# Real, live BPMN Process Instance task for WI-001663's "Start Work" step —
+# not a synthetic demo. Confirmed via both the instance's `workflow_state`
+# (task state 16 = READY) and its `active_tasks` child table (status
+# "Waiting", task_name "Start Work"). Must stay in READY (16) or WAITING (8)
+# state at the time this runs; look these up fresh from the BPMN Process
+# Instance's `workflow_state` (not the older, possibly-stale
+# `serialized_spec`) if reusing this pattern for a different task.
+INSTANCE_NAME = "orj9cj8ajr"
+TASK_ID = "bb085897-1b90-488a-836a-846672b4aacd"
+WORK_ITEM_ID = "WI-001663"
+WORK_ITEM_TITLE = "Refactor AI Model, AI Provider and AI Model pricing doctype"
+
+# The task's real assignee — the token must be issued for this user (not
+# RECIPIENT) since handle_amp_action checks it against the task's actual
+# assignment. RECIPIENT is only where this copy of the email is delivered
+# for inspection (notifications@one-fm.com itself, to verify the MIME/CORS
+# mechanics) — not who's expected to click it.
+ASSIGNEE_USER = "k.sharma@one-fm.com"
 
 
 def execute():
 	"""One-time trigger: send a real "Start Work" notification email — tied
-	to the actual live BPMN task for WI-001875 — from
-	notifications@one-fm.com to the real assignee (s.shariff@one-fm.com),
+	to the actual live BPMN task for WI-001663 — from
+	notifications@one-fm.com to notifications@one-fm.com itself (a
+	self-addressed copy, to inspect the MIME structure and CORS headers
+	directly via "Show original" before pointing this at a real assignee),
 	through the actual production sending pipeline.
 
 	The email's "Start Work" action is a genuine one-click AMP action tied
@@ -32,7 +43,9 @@ def execute():
 	`amp_workflow_actions` static allowlist, which is reserved for
 	documents with no BPMN engine behind them at all. Clicking the button
 	calls `complete_task` on the real Process Instance, genuinely advancing
-	it — a deliberate, confirmed side effect for this specific task.
+	it — a deliberate, confirmed side effect for this specific task, for
+	whoever actually clicks it (the token is issued to ASSIGNEE_USER, not
+	RECIPIENT).
 
 	This runs automatically, once, the first time `bench migrate` executes
 	on any site with this patch present (Frappe's Patch Log ensures it
@@ -49,7 +62,7 @@ def execute():
 		send()
 	except Exception:
 		frappe.log_error(
-			title="WI-001875 Start Work AMP notify failed",
+			title="WI-001663 Start Work AMP notify failed",
 			message=frappe.get_traceback(),
 		)
 
@@ -84,24 +97,24 @@ def send():
 <tr><td><b>Type</b></td><td>User Story</td></tr>
 <tr><td><b>Priority</b></td><td>Medium</td></tr>
 <tr><td><b>Sprint</b></td><td>AI-017 (Active)</td></tr>
-<tr><td><b>Story Points</b></td><td>5</td></tr>
-<tr><td><b>Epic</b></td><td>Agent Skills</td></tr>
+<tr><td><b>Story Points</b></td><td>3</td></tr>
+<tr><td><b>Epic</b></td><td>Processa</td></tr>
 <tr><td><b>Reported By</b></td><td><a href="mailto:k.sharma@one-fm.com">k.sharma@one-fm.com</a></td></tr>
-<tr><td><b>PR Required</b></td><td>Yes</td></tr>
+<tr><td><b>PR Required</b></td><td>No</td></tr>
 <tr><td><b>Research Required</b></td><td>No</td></tr>
 </tbody>
 </table>
 <p style="margin:1em 0!important"><b>Description</b><br></p>
-<p style="margin:0!important">Add skills-index rendering in context_assembler.build_static_context and active-skill tracking in the dispatcher's dynamic-preamble path.</p>
+<p style="margin:0!important">{WORK_ITEM_TITLE}</p>
 """.strip()
 
 	# Real BPMN-instance-tied token — the same mechanism
-	# compose_andsend_task_email uses for every other task action.
+	# compose_and_send_task_email uses for every other task action.
 	actions = build_email_actions(
 		instance_name=INSTANCE_NAME,
 		task_id=TASK_ID,
 		actions=[{"label": "Start Work", "primary": True}],
-		user=RECIPIENT,
+		user=ASSIGNEE_USER,
 	)
 
 	task_content = {


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
Rebinds the existing `send_work_item_notify_assignee_demo_email` patch from the earlier WI-001875 test data to WI-001663's real, live BPMN "Start Work" task (BPMN Process Instance `orj9cj8ajr`, task `bb085897-1b90-488a-836a-846672b4aacd`), and changes the delivery address to `notifications@one-fm.com` itself so the AMP MIME structure and CORS headers can be inspected via "Show original" before pointing this at a real assignee's inbox. The AMP "Start Work" button's action token is still issued to the task's real assignee (`k.sharma@one-fm.com`), not the delivery inbox, so clicking it would still genuinely advance the real process instance.


## Analysis and design (optional)
N/A — no design change. Reuses the existing dynamic BPMN-instance-token mechanism (`one_bpmn.utils.token.generate_action_token` / `one_bpmn.api.bpmn_task_actions.handle_amp_action`) already established for this patch; only the bound instance/task/recipient data changed.

## Solution description
- `one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py`: updated `INSTANCE_NAME`, `TASK_ID`, `WORK_ITEM_ID`, `WORK_ITEM_TITLE` to WI-001663's real values; changed `RECIPIENT` to `notifications@one-fm.com`; added a new `ASSIGNEE_USER` constant (`k.sharma@one-fm.com`) so the AMP token is issued to the real task assignee even though `RECIPIENT` now differs from it; updated the email's summary table (Sprint AI-017, Story Points 3, Epic, PR/Research Required, Reported By) to match WI-001663's real field values.
- `one_fm/patches.txt`: retagged the patch line's comment so it re-executes on the next `bench migrate` (Frappe's Patch Log treats the full line, comment included, as the patch's identity — retagging is the supported way to force a re-run of unchanged patch code, per existing precedent in this file).

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
N/A (no UI change) — rendered AMP HTML was validated locally with `amphtml-validator --html_format AMP4EMAIL` (PASS) rather than visually screenshotted.

## Areas affected and ensured
- `one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py`
- `one_fm/patches.txt`
- No doctype, permission, or hook changes.

## Is there any existing behavior change of other features due to this code change?
No. This is a single one-time data-migration patch scoped to sending one notification email; it doesn't alter any doctype, controller, or shared code path.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

(Real, live production WI-001663 Work Item + BPMN Process Instance/Active Task data, provided by the requester.)

## Was child table created?
No child table created.
    - [ ] is attachment required?
        did you test attachment
        N/A

## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?
        N/A

## Is patch required?
- [x] Yes
- [ ] No
    ## Was the patch test?
    Yes — locally verified: `build_email_actions`/`generate_action_token` round-trips correctly (token decodes to the expected `instance_name`, `task_id`, and `user`), and the rendered AMP HTML passes `amphtml-validator --html_format AMP4EMAIL`. The referenced `BPMN Process Instance`/`BPMN Active Task` only exist on production (confirmed absent on the local dev site, as expected), so the actual send will be exercised live via `bench migrate` on production.

## Which browser(s) did you use for testing?
  - [ ] Chrome
  - [ ] Safari
  - [ ] Firefox

N/A — backend-only patch, no browser UI involved. Email rendering was verified via HTML/AMP validation tooling, not manual browser testing.
