### PR TITLE
WI-002032: record the Penalty Serial No on Penalty And Investigation

### DIFF
--- a/one_fm/legal/doctype/penalty_and_investigation/penalty_and_investigation.json
+++ b/one_fm/legal/doctype/penalty_and_investigation/penalty_and_investigation.json
@@ -9,7 +9,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-07-30 22:05:00.000000",
+ "modified": "2026-08-13 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Legal",
  "name": "Penalty And Investigation",
@@ -275,6 +275,12 @@
    "read_only": 1
   },
   {
+   "fieldname": "penalty_serial_no",
+   "label": "Penalty Serial No",
+   "fieldtype": "Data",
+   "allow_on_submit": 1
+  },
+  {
    "fieldname": "employee_response",
    "label": "Employee Response",
    "fieldtype": "Select",
@@ -476,6 +482,7 @@
   "penalty_name",
   "penalty_status",
   "created_by",
+  "penalty_serial_no",
   "employee_response",
   "refusal_proof",
   "penalty",


### PR DESCRIPTION
Adds the `penalty_serial_no` field the BA site defines: a plain Data field, `allow_on_submit`, sitting after Created By.

The serial the penalty carries on paper had nowhere to live on the record, so the monthly report and the departmental email had no way to quote it back. #6691's report has a Serial No. column and #6692's email table has one too — this is where both get it from.

Nothing generates it. The number comes from the physical penalty document, so inventing a series here would produce a second, competing identity alongside the record's own `PEN-MM-YYYY-####` name. The reporter's spreadsheet confirms this: that column holds hand-assigned numbers (1890, 513, …), 9,497 distinct across 9,813 rows.

**Base of the chain** — #6691 and #6692 stack on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)