### PR TITLE
fix: drop patches.txt entries whose patch files no longer exist

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -564,8 +564,6 @@ one_fm.patches.v15_0.add_vehicle_max_passenger_capacity #2026-08-11 WI-002000
 
 
 
-one_fm.patches.v15_0.backfill_checkin_geolocation_for_employees #2026-08-02
-one_fm.patches.v15_0.fix_checkin_metadata_and_timeline #2026-08-02
 
 
 


### PR DESCRIPTION
`bench migrate` on one-fm.com currently fails on every run with two `ModuleNotFoundError`s:

```
No module named 'one_fm.patches.v15_0.backfill_checkin_geolocation_for_employees'
No module named 'one_fm.patches.v15_0.fix_checkin_metadata_and_timeline'
```

## Cause

Commit `7dcac0f13` — *"Revert 'feat: add checkin metadata, timeline, and rename correction patch'"*, 2026-08-16 — deleted both patch files:

```
one_fm/patches/v15_0/backfill_checkin_geolocation_for_employees.py  | 181 ---
one_fm/patches/v15_0/fix_checkin_metadata_and_timeline.py           | 221 ---
```

but did not touch `patches.txt`. The two entries stayed registered, so the patch handler still tries to import modules that aren't there. This is not intermittent — it fails on every migrate and will keep doing so until the entries go.

## Change

Removes the two stale lines. Nothing else. The files are already gone, so neither patch can have any remaining effect, and there is no behaviour to restore or undo.

## Checks

- Swept every `one_fm.patches.*` entry in `patches.txt` against the filesystem. These two were the only ones missing a module; after the change, zero remain.
- `one_fm.patches.v15_0.backfill_checkin_geolocation_from_device_id #2026-07-12` (line 480) is a **different** patch with a similar name. It still has its file and is deliberately untouched.

## Note

This is the last of the three checkin patches from 2026-08-02/04 to be cleaned up. The third, `set_checkin_modified_by_administrator`, was removed in #6713 (already merged) — that one still had its file, so both the file and the entry went together there.

The remaining `configure_agency_process_completion_values` failure in the same migrate log is unrelated to this PR. It fails on a broken link in `CCP001`; the hardening that would let it skip such records already exists on `staging` (commit `a644a0620`) and simply hasn't reached `version-15` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
