### PR TITLE
fix: return the real error text from mobile API responses

### DIFF
--- a/one_fm/api/v1/face_recognition.py
+++ b/one_fm/api/v1/face_recognition.py
@@ -234,8 +234,8 @@ def _fmt_clock(value) -> str:
     return value.strftime("%I:%M %p").lstrip("0")
 
 
-def get_checkin_windows(employee: str) -> list:
-    """Today's shifts with their check-in boundaries (WI-001777).
+def get_checkin_windows(employee: str, include_previous_day: bool = False) -> list:
+    """Today's shifts with their check-in and check-out boundaries (WI-001777).
 
     Deliberately separate from ``one_fm.utils.get_current_shift``, whose query only
     returns a shift once its window is already OPEN. Five callers depend on that to
@@ -243,14 +243,19 @@ def get_checkin_windows(employee: str) -> list:
     that says when the next window opens needs to see the whole day.
 
     Boundaries come from the Shift Type, not from any assumed hour:
-      opens_at      = start - begin_check_in_before_shift_start_time
-      late_after    = start + late_entry_grace_period   (flagged late, still allowed)
-      blocked_after = start + working_hours_threshold_for_absent
+      opens_at        = start - begin_check_in_before_shift_start_time
+      late_after      = start + late_entry_grace_period   (flagged late, still allowed)
+      blocked_after   = start + working_hours_threshold_for_absent
+      checkout_closes = end + allow_check_out_after_shift_end_time
+
+    ``include_previous_day`` also returns yesterday's shifts, which an overnight
+    check-out still belongs to after midnight.
     """
     ShiftAssignment = frappe.qb.DocType("Shift Assignment")
     ShiftType = frappe.qb.DocType("Shift Type")
 
     today = getdate()
+    earliest = add_days(today, -1) if include_previous_day else today
     rows = (
         frappe.qb.from_(ShiftAssignment)
         .join(ShiftType)
@@ -262,12 +267,13 @@ def get_checkin_windows(employee: str) -> list:
             ShiftType.begin_check_in_before_shift_start_time.as_("opens_before"),
             ShiftType.late_entry_grace_period.as_("late_grace"),
             ShiftType.working_hours_threshold_for_absent.as_("absent_after_hours"),
+            ShiftType.allow_check_out_after_shift_end_time.as_("checkout_grace"),
         )
         .where(
             (ShiftAssignment.employee == employee)
             & (ShiftAssignment.status == "Active")
             & (ShiftAssignment.docstatus == 1)
-            & (ShiftAssignment.start_datetime >= today)
+            & (ShiftAssignment.start_datetime >= earliest)
             & (ShiftAssignment.start_datetime < add_days(today, 1))
         )
         .orderby(ShiftAssignment.start_datetime)
@@ -281,10 +287,16 @@ def get_checkin_windows(employee: str) -> list:
             frappe._dict(
                 shift_assignment=row.name,
                 start=row.start_datetime,
+                end=row.end_datetime,
                 opens_at=row.start_datetime - timedelta(minutes=cint(row.opens_before)),
                 late_after=row.start_datetime + timedelta(minutes=cint(row.late_grace)),
                 blocked_after=row.start_datetime
                 + timedelta(hours=flt(row.absent_after_hours)),
+                checkout_closes_at=(
+                    row.end_datetime + timedelta(minutes=cint(row.checkout_grace))
+                    if row.end_datetime
+                    else None
+                ),
             )
         )
 
@@ -331,6 +343,46 @@ def get_checkin_window_message(employee: str) -> str:
             "Check-In Unavailable: Your scheduled shift starts at {0}. "
             "Check-in opens at {1}."
         ).format(_fmt_clock(upcoming[0].start), _fmt_clock(upcoming[0].opens_at))
+
+    return ""
+
+
+def has_open_checkin(shift_assignment: str) -> bool:
+    """True when the employee checked IN for this shift and never checked OUT.
+
+    Distinguishes "could not check in" from "could not check out" - both arrive at the
+    same dead end in ``get_site_location`` once the shift's window has passed, but only
+    one of them is what the employee is actually trying to do.
+    """
+    last_log = frappe.get_all(
+        "Employee Checkin",
+        filters={"shift_assignment": shift_assignment},
+        fields=["log_type"],
+        order_by="time desc",
+        limit_page_length=1,
+    )
+    return bool(last_log) and last_log[0].log_type == "IN"
+
+
+def get_checkout_window_message(employee: str) -> str:
+    """Why check-out is unavailable right now, in words an employee can act on.
+
+    An employee who is still checked IN after the check-out window closed used to be
+    told their *check-in* window had closed - true, but not the thing they were trying
+    to do, and it left the open IN looking like their own mistake. Returns an empty
+    string unless there really is an unclosed check-in past its deadline, so the
+    check-in banner keeps speaking for every other case.
+    """
+    now = now_datetime()
+    for window in get_checkin_windows(employee, include_previous_day=True):
+        if not window.checkout_closes_at or now <= window.checkout_closes_at:
+            continue
+        if not has_open_checkin(window.shift_assignment):
+            continue
+        return _(
+            "Check-Out Window Closed: Your shift ended at {0} and check-out was allowed "
+            "until {1}. Please contact your Site Supervisor to record your check-out."
+        ).format(_fmt_clock(window.end), _fmt_clock(window.checkout_closes_at))
 
     return ""
 
@@ -478,6 +530,13 @@ def get_site_location(employee_id: str = None, shift: str = None,latitude: float
             elif site:
                 return response("Resource Not Found", 404, None, "No site location set for {site}".format(site=site))
 
+            # Neither a location nor a site left this branch without a response at all,
+            # so the app received an empty body and showed its generic "unexpected
+            # error" with nothing logged to explain it. Always say something.
+            return response("Resource Not Found", 404, None,
+                            _("No check-in location is configured for your shift. "
+                              "Please contact your Site Supervisor."))
+
         else:
             if employee.shift_working:
                 if has_day_off(employee.name, date):
@@ -495,6 +554,13 @@ def get_site_location(employee_id: str = None, shift: str = None,latitude: float
             status, message = is_holiday(employee=employee, date=date)
             if status:
                 return response("Resource Not Found", 404, None, message)
+
+            # An unclosed check-in past its deadline is a check-OUT problem; say so
+            # before the check-in banner, which would otherwise blame a window the
+            # employee already used successfully.
+            checkout_message = get_checkout_window_message(employee.name)
+            if checkout_message:
+                return response("Resource Not Found", 404, None, checkout_message)
 
             # WI-001777: the employee may well have a shift today whose check-in
             # window is simply not open - get_current_shift only returns a shift once

--- a/one_fm/api/v1/utils.py
+++ b/one_fm/api/v1/utils.py
@@ -20,7 +20,11 @@ def response(message, status_code, data=None, error=None):
         if data:
             frappe.local.response["data"] = data
         elif error:
-            frappe.local.response["error"] = error
+            # The app renders this slot verbatim. An Exception object is not JSON
+            # serialisable, so passing one through - as every `except` branch here does -
+            # loses the sentence and the client falls back to "An unexpected error
+            # occurred". Coerce so the reason always reaches the employee.
+            frappe.local.response["error"] = error if isinstance(error, str) else cstr(error)
         return
     except Exception as e:
         frappe.log_error(title="API Response", message=frappe.get_traceback())

--- a/one_fm/tests/test_checkin_window_banner.py
+++ b/one_fm/tests/test_checkin_window_banner.py
@@ -20,19 +20,24 @@ from one_fm.api.v1.face_recognition import (
 	_fmt_clock,
 	get_checkin_window_message,
 	get_checkin_windows,
+	get_checkout_window_message,
 	get_site_location,
 )
+from one_fm.api.v1.utils import response
 from one_fm.overrides.employee import NOT_RETURNED_FROM_LEAVE
 
 
-def _window(start, opens_before=60, late_grace=15, absent_after=4.0):
+def _window(start, opens_before=60, late_grace=15, absent_after=4.0, end=None, checkout_grace=120):
 	start = get_datetime(start)
+	end = get_datetime(end) if end else None
 	return frappe._dict(
 		shift_assignment="TEST-SA",
 		start=start,
+		end=end,
 		opens_at=start - timedelta(minutes=opens_before),
 		late_after=start + timedelta(minutes=late_grace),
 		blocked_after=start + timedelta(hours=absent_after),
+		checkout_closes_at=end + timedelta(minutes=checkout_grace) if end else None,
 	)
 
 
@@ -137,6 +142,91 @@ class TestWindowsFromShiftType(FrappeTestCase):
 
 	def test_an_employee_with_no_assignment_today_has_no_windows(self):
 		self.assertEqual(get_checkin_windows("_no_such_employee"), [])
+
+
+class TestCheckoutWindowMessage(FrappeTestCase):
+	"""An unclosed check-in past its deadline must be named as a check-OUT problem."""
+
+	def _message_at(self, now, windows, open_checkin=True):
+		with patch(
+			"one_fm.api.v1.face_recognition.get_checkin_windows", return_value=windows
+		), patch(
+			"one_fm.api.v1.face_recognition.now_datetime", return_value=get_datetime(now)
+		), patch(
+			"one_fm.api.v1.face_recognition.has_open_checkin", return_value=open_checkin
+		):
+			return get_checkout_window_message("EMP-TEST")
+
+	def test_it_quotes_the_shift_end_and_the_deadline(self):
+		# The 360 Foodhall case: assignment says 05:00-17:00, check-out allowed until
+		# 19:00, employee still on site at 19:50 with an open IN.
+		msg = self._message_at(
+			"2026-08-16 19:50:00",
+			[_window("2026-08-16 05:00:00", end="2026-08-16 17:00:00")],
+		)
+		self.assertIn("Check-Out Window Closed", msg)
+		self.assertIn("5:00 PM", msg)  # when the shift ended
+		self.assertIn("7:00 PM", msg)  # when check-out stopped being accepted
+		self.assertIn("Site Supervisor", msg)
+
+	def test_a_closed_shift_with_no_open_checkin_says_nothing(self):
+		# Never checked in, or already checked out - this is not a check-out problem,
+		# so the check-in banner keeps speaking.
+		self.assertEqual(
+			self._message_at(
+				"2026-08-16 19:50:00",
+				[_window("2026-08-16 05:00:00", end="2026-08-16 17:00:00")],
+				open_checkin=False,
+			),
+			"",
+		)
+
+	def test_inside_the_grace_period_says_nothing(self):
+		# 18:30 is still within end + 120 minutes, so check-out is genuinely allowed.
+		self.assertEqual(
+			self._message_at(
+				"2026-08-16 18:30:00",
+				[_window("2026-08-16 05:00:00", end="2026-08-16 17:00:00")],
+			),
+			"",
+		)
+
+	def test_no_shift_today_says_nothing(self):
+		self.assertEqual(self._message_at("2026-08-16 19:50:00", []), "")
+
+	def test_an_assignment_without_an_end_is_skipped(self):
+		# No end_datetime means no deadline to have missed.
+		self.assertEqual(
+			self._message_at("2026-08-16 19:50:00", [_window("2026-08-16 05:00:00")]), ""
+		)
+
+
+class TestEveryPathAnswers(FrappeTestCase):
+	"""No branch may return without setting a response - that is the generic toast."""
+
+	def test_get_site_location_always_returns_a_message(self):
+		source = frappe.read_file(
+			frappe.get_app_path("one_fm", "api", "v1", "face_recognition.py")
+		)
+		# The shift branch used to fall off the end when a shift had neither a
+		# resolved location nor a site, leaving frappe.local.response untouched.
+		self.assertIn("No check-in location is configured for your shift", source)
+
+
+class TestResponseErrorIsReadable(FrappeTestCase):
+	"""The app renders the error slot verbatim, so it has to be a sentence."""
+
+	def test_an_exception_is_coerced_to_its_message(self):
+		# Passing the Exception object itself is what produced the app's generic
+		# "An unexpected error occurred" - the slot could not be serialised.
+		response("Internal Server Error", 500, None, ValueError("shift lookup failed"))
+		self.assertEqual(frappe.local.response.get("error"), "shift lookup failed")
+
+	def test_a_string_is_left_alone(self):
+		response("Resource Not Found", 404, None, "Check-Out Window Closed: ...")
+		self.assertEqual(
+			frappe.local.response.get("error"), "Check-Out Window Closed: ..."
+		)
 
 
 class TestNotReturnedFromLeaveBlocker(FrappeTestCase):


### PR DESCRIPTION
fix: return the real error text from mobile API responses
Every `except` branch in the v1 check-in API calls response() with the raw Exception object. That slot is serialised into the JSON body, so a non-serialisable value loses the sentence entirely and the mobile app falls back to "An unexpected error occurred" - leaving employees and support with no idea why a check-in was refused.

- coerce a non-string error to its message before it reaches the response

feat: tell employees when the check-out window has closed
An employee still checked IN after the check-out deadline reached the same dead end as one who never checked in, and was told their *check-in* window had closed - true, but not what they were trying to do. Seen on the 360 Foodhall Summer Camp roster, where the shift assignment carries the base shift's hours and check-out is refused every evening.

- carry `end` and `checkout_closes_at` on each check-in window, derived from allow_check_out_after_shift_end_time
- let get_checkin_windows() also look at yesterday, which an overnight check-out after midnight still belongs to
- add has_open_checkin() and get_checkout_window_message(), consulted ahead of the check-in banner in get_site_location()
- answer with a message when a shift resolves to neither a location nor a site; that branch previously returned nothing at all, which the app showed as a generic error with nothing logged to explain it
- cover the new messages, the grace period and the response coercion