### PR TITLE
fix: clear stale OJT link when a trainee is re-rostered

### DIFF
--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -1074,12 +1074,17 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
 			shift = VALUES(shift),
 			project = VALUES(project),
 			site = VALUES(site),
-			reference_doctype = IF(employee_availability = 'Client Event', NULL, reference_doctype),
-			reference_docname = IF(employee_availability = 'Client Event', NULL, reference_docname),
+			reference_doctype = IF(employee_availability IN ('Client Event', 'On-the-job Training'), NULL, reference_doctype),
+			reference_docname = IF(employee_availability IN ('Client Event', 'On-the-job Training'), NULL, reference_docname),
 			client_event = IF(employee_availability = 'Client Event', NULL, client_event),
 			event_staff = IF(employee_availability = 'Client Event', NULL, event_staff),
 			event_location = IF(employee_availability = 'Client Event', NULL, event_location),
 			is_event_schedule = IF(employee_availability = 'Client Event', 0, is_event_schedule),
+			/* Clear the OJT link when a training row is re-rostered onto a real Working post.
+			   A stale link makes the row invisible to the Roster Post Actions fill checker.
+			   Must stay ABOVE the employee_availability assignment below: MariaDB evaluates
+			   ON DUPLICATE KEY UPDATE left to right, so this still sees the pre-update value. */
+			on_the_job_training = IF(employee_availability = 'On-the-job Training', NULL, on_the_job_training),
 			shift_type = VALUES(shift_type),
 			day_off_ot = VALUES(day_off_ot),
 			employee_availability = "Working",
@@ -2375,6 +2380,7 @@ def dayoff(employees, client_day_off=0, selected_dates=0, selected_reliever=None
 				event_staff = "",
 				event_location = "",
 				is_event_schedule = 0,
+				on_the_job_training = NULL,
 				employee_availability = "{employee_availability}"
 			"""
 			frappe.db.sql(query_main)

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -1074,17 +1074,21 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
 			shift = VALUES(shift),
 			project = VALUES(project),
 			site = VALUES(site),
-			reference_doctype = IF(employee_availability IN ('Client Event', 'On-the-job Training'), NULL, reference_doctype),
-			reference_docname = IF(employee_availability IN ('Client Event', 'On-the-job Training'), NULL, reference_docname),
+			/* reference_docname is assigned before reference_doctype: MariaDB evaluates this
+			   list left to right, so the docname guard has to read reference_doctype while it
+			   still holds the pre-update value. The Client Event guard is unchanged; the OJT
+			   branch keys on reference_doctype so a Shift Request reference is never touched. */
+			reference_docname = IF(employee_availability = 'Client Event' OR reference_doctype = 'On the Job Training', NULL, reference_docname),
+			reference_doctype = IF(employee_availability = 'Client Event' OR reference_doctype = 'On the Job Training', NULL, reference_doctype),
 			client_event = IF(employee_availability = 'Client Event', NULL, client_event),
 			event_staff = IF(employee_availability = 'Client Event', NULL, event_staff),
 			event_location = IF(employee_availability = 'Client Event', NULL, event_location),
 			is_event_schedule = IF(employee_availability = 'Client Event', 0, is_event_schedule),
-			/* Clear the OJT link when a training row is re-rostered onto a real Working post.
-			   A stale link makes the row invisible to the Roster Post Actions fill checker.
-			   Must stay ABOVE the employee_availability assignment below: MariaDB evaluates
-			   ON DUPLICATE KEY UPDATE left to right, so this still sees the pre-update value. */
-			on_the_job_training = IF(employee_availability = 'On-the-job Training', NULL, on_the_job_training),
+			/* Every row this statement touches becomes "Working" below, and a Working schedule
+			   must never carry an OJT link: it would be dropped by the Roster Post Actions fill
+			   checker, which reads the post as short-staffed and raises a "not filled" document
+			   every day. Unconditional, so it also self-heals rows left stale by earlier writes. */
+			on_the_job_training = NULL,
 			shift_type = VALUES(shift_type),
 			day_off_ot = VALUES(day_off_ot),
 			employee_availability = "Working",

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -599,3 +599,4 @@ one_fm.patches.v15_0.update_penalty_assignment_rules_process_task_based
 one_fm.patches.v15_0.update_visa_request_workflow_and_rules
 one_fm.patches.v15_0.add_leave_application_resumption_contact_fields #1
 one_fm.patches.v15_0.approve_attendance_check_jul11_2026 #2026-08-16
+one_fm.patches.v15_0.clear_stale_ojt_link_on_working_schedules #2026-08-16

--- a/one_fm/patches/v15_0/clear_stale_ojt_link_on_working_schedules.py
+++ b/one_fm/patches/v15_0/clear_stale_ojt_link_on_working_schedules.py
@@ -1,0 +1,91 @@
+# one_fm/patches/v15_0/clear_stale_ojt_link_on_working_schedules.py
+import frappe
+
+
+def execute():
+	"""Clear the stale On the Job Training link left on Working Employee Schedules.
+
+	An Employee Schedule created by an On the Job Training record carries
+	``employee_availability = "On-the-job Training"`` plus ``on_the_job_training``,
+	``reference_doctype`` and ``reference_docname`` pointing at that OJT. When a
+	supervisor later re-rosters the trainee onto a real post, the roster bulk
+	write (``one_fm/one_fm/page/roster/roster.py``, the
+	``INSERT ... ON DUPLICATE KEY UPDATE`` in ``extreme_schedule``) flipped
+	availability to "Working" and rewrote the role/shift/site but left the OJT
+	fields behind. Being raw SQL, it also bypassed
+	``EmployeeSchedule.validate_ojt_change``.
+
+	That stale link makes the row invisible to the daily post-fill checker
+	(``create_roster_post_actions``), whose employee-schedule query drops any row
+	with ``on_the_job_training`` set. The post is fully rostered but reported one
+	short, and a Roster Post Actions "not filled" document is raised every day
+	for it — e.g. OPR-RPA-2026-34757.
+
+	The roster upsert now clears these fields going forward; this patch cleans up
+	the rows written before that fix.
+
+	Two deliberate limits on what gets touched:
+
+	* Only rows whose availability is "Working". A genuine trainee row still
+	  reads "On-the-job Training" and must keep its link.
+	* Only rows dated today or later. The checker only ever looks from tomorrow
+	  to the end of next month, so clearing past rows buys nothing operationally
+	  while rewriting historical roster records that OJT reporting may read. At
+	  the time of writing that is 8 rows forward against 242 in the past, spread
+	  over every month since 2025-11 — which is also why the roster.py fix, not
+	  this cleanup, is the actual remedy.
+	"""
+	stale = frappe.db.sql(
+		"""
+		SELECT name
+		FROM `tabEmployee Schedule`
+		WHERE employee_availability = 'Working'
+		AND date >= CURDATE()
+		AND (
+			(on_the_job_training IS NOT NULL AND on_the_job_training != '')
+			OR reference_doctype = 'On the Job Training'
+		)
+		""",
+		as_dict=True,
+	)
+	if not stale:
+		return
+
+	names = [row["name"] for row in stale]
+
+	# Plain UPDATE rather than a document save: these rows are only being
+	# cleaned of a dangling link, and re-running the Employee Schedule
+	# controller would re-fire roster validations (day-off quotas, leave
+	# overlap, shift intersection) against unrelated data — and
+	# validate_ojt_change would throw on exactly the rows being repaired.
+	#
+	# reference_docname is assigned before reference_doctype on purpose: MySQL
+	# evaluates a SET list left to right, so clearing the doctype first would
+	# make the docname guard read NULL and never match.
+	frappe.db.sql(
+		"""
+		UPDATE `tabEmployee Schedule`
+		SET on_the_job_training = NULL,
+			reference_docname = IF(reference_doctype = 'On the Job Training', NULL, reference_docname),
+			reference_doctype = IF(reference_doctype = 'On the Job Training', NULL, reference_doctype)
+		WHERE name IN %(names)s
+		""",
+		{"names": names},
+	)
+
+	# Keep the Shift Assignment mirror of the field in step. It is fetched from
+	# employee_schedule.on_the_job_training, so a stale value survives there too.
+	frappe.db.sql(
+		"""
+		UPDATE `tabShift Assignment`
+		SET custom_on_the_job_training = NULL
+		WHERE employee_schedule IN %(names)s
+		AND custom_on_the_job_training IS NOT NULL
+		AND custom_on_the_job_training != ''
+		""",
+		{"names": names},
+	)
+
+	frappe.db.commit()
+
+	print(f"Cleared stale OJT link on {len(names)} Employee Schedule rows")


### PR DESCRIPTION
fix: clear stale OJT link when a trainee is re-rostered
An Employee Schedule created by an On the Job Training record carries employee_availability "On-the-job Training" plus on_the_job_training, reference_doctype and reference_docname pointing at that OJT. The roster bulk write flipped availability to "Working" and rewrote role/shift/site but left those OJT fields behind, and being raw SQL it also bypassed EmployeeSchedule.validate_ojt_change.

The stale link makes the row invisible to the daily post-fill checker (create_roster_post_actions), whose employee-schedule query drops any row with on_the_job_training set. A fully rostered post is then reported one short and raises a "not filled" Roster Post Actions document every day — e.g. OPR-RPA-2026-34757, where 8 posts had 8 Working schedules but only 7 were counted.

- clear on_the_job_training in extreme_schedule when the row being overwritten was an OJT row, and extend the reference_doctype and reference_docname guards to cover it alongside Client Event
- keep the assignment above employee_availability = "Working": MariaDB evaluates ON DUPLICATE KEY UPDATE left to right, so it must read the pre-update value
- clear on_the_job_training in dayoff, which already cleared the reference fields but left the link for a later re-roster to inherit

fix: patch stale OJT links left on Working employee schedules
Clean up the rows written before the roster upsert learned to clear the OJT trail. Without this, the Roster Post Actions checker keeps under-counting already-rostered posts on schedules created earlier.

Scope is deliberately narrow on two axes:

- only employee_availability = "Working"; a genuine trainee row still reads "On-the-job Training" and must keep its link
- only date >= CURDATE(); the checker never looks further back than tomorrow, so clearing past rows buys nothing operationally while rewriting roster history that OJT reporting may read

<img width="917" height="579" alt="Screenshot 2026-08-17 at 1 14 54 PM" src="https://github.com/user-attachments/assets/1ee4b492-c3ea-4b1a-9a0c-03db820d36de" />
