### PR TITLE
Revert "WI-001687: Shift dropdown for OT slots shows all active shifts" (#6541)

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -2987,20 +2987,14 @@ function change_ot_schedule(page) {
 				"label": "Shift", "fieldname": "shift", "fieldtype": "Link", "options": "Operations Shift", "reqd": 1, onchange: function () {
 					let name = d.get_value("shift");
 					if (name) {
-						frappe.db.get_value("Operations Shift", name, ["site", "project", "double_shift_ot_allowed"])
+						frappe.db.get_value("Operations Shift", name, ["site", "project"])
 							.then(res => {
-								let { site, project, double_shift_ot_allowed } = res.message;
+								let { site, project } = res.message;
 								d.set_value("site", site);
 								d.set_value("project", project);
-								// WI-001687: non-blocking warning when the chosen shift disallows Double Shift OT.
-								if (!cint(double_shift_ot_allowed)) {
-									frappe.show_alert({ message: __("Warning: The selected shift does not allow Double Shift OT. A Double Shift OT Checker will be generated."), indicator: "orange" }, 7);
-								}
 							});
 					}
 				}, get_query: function () {
-					// WI-001687: show ALL active shifts for an OT slot; non-DSOT shifts are
-					// allowed with a soft warning and tracked via a checker rather than blocked.
 					return {
 						"filters": { "status": "Active" },
 						"page_length": 9999

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -852,14 +852,10 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
 	operations_shift_doc = frappe.get_doc("Operations Shift", shift, ignore_permissions=True)
 	operations_role_doc = frappe.get_doc("Operations Role", operations_role, ignore_permissions=True)
 	day_off_ot = cint(day_off_ot)
-	# roster_type is driven solely by whether the OT (second-shift) dialog was used.
-	# day_off_ot is an independent flag: a Day Off OT first shift is still "Basic".
-	roster_type = "Over-Time" if otRoster == "true" else "Basic"
-
-	# WI-001687: OT scheduling is no longer blocked for shifts without
-	# 'Double Shift OT Allowed'. Selection is unrestricted (a soft warning is
-	# shown client-side); non-compliant OT is tracked via the Roster Double
-	# Shift OT Checker (WI-001688) rather than blocked here.
+	if otRoster == "false":
+		roster_type = "Basic"
+	elif otRoster == "true" or day_off_ot == 1:
+		roster_type = "Over-Time"
 
 	# check for end date
 	if end_date:


### PR DESCRIPTION
Reverts #6541. Not meant to be on production yet. **This is the revert that fixes the user-facing error.**

## Why

`double_shift_ot_allowed` was defined on **Operations Shift** by WI-001425 (#6413), and that PR was reverted out of `version-15` on 21 Jul by `86989678c` — which deleted the field from `operations_shift.json`. WI-001687 merged on 28 Jul still queries it:

```js
frappe.db.get_value("Operations Shift", name, ["site", "project", "double_shift_ot_allowed"])
```

`frappe.client.get_value` validates every fieldname against the DocType meta, the field is not there, so every shift selection in the **Schedule/Change OT** dialog throws:

```
frappe.exceptions.DataError: Field not permitted in query: double_shift_ot_allowed
```

This PR is one of three reverts that back the feature out of `version-15`.

## Scope

Reverts merge commit `08aa6329b` only — two hunks in `roster.js` (the field in the `get_value` call, the soft-warning alert, two comments) and one in `roster.py`. Nothing else touched, no conflicts.

Note this restores the pre-WI-001687 `roster_type` logic in `extreme_schedule`:

```python
if otRoster == "false":
	roster_type = "Basic"
elif otRoster == "true" or day_off_ot == 1:
	roster_type = "Over-Time"
```

i.e. the Day-Off-OT/`roster_type` decoupling goes back too, since it arrived with this PR. The `get_query` filter is unchanged either way (`{"status": "Active"}`) — WI-001687 only added a comment above it, because the `double_shift_ot_allowed: 1` filter from #6413 was already gone.

## Verification

With all three reverts applied, `grep -rn "double_shift_ot_allowed\|roster_double_shift_ot_checker" one_fm/` returns nothing, and `roster.py` / `hooks.py` / `roster.js` all pass a syntax check. Reverting #6413 on top is a **no-op** — `86989678c` already removed all of it; it only looked un-reverted because this PR re-introduced one of its `roster.py` hunks.

## Suggested merge order

#6721 (WI-001689) → #6722 (WI-001688) → this one. Any order works for the error itself; this is the only one that stops the user-facing throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)