### PR TITLE
WI-002071: merge cards into a Mixed trip, and hold every leg to the seats

### DIFF
--- a/one_fm/one_fm/doctype/transportation_shipment/transportation_shipment.json
+++ b/one_fm/one_fm/doctype/transportation_shipment/transportation_shipment.json
@@ -33,6 +33,7 @@
   "requires_vehicle_retention",
   "generation_key",
   "pair_group",
+  "trip_group",
   "section_break_yujp",
   "transportation_shipment_employee"
  ],
@@ -135,7 +136,7 @@
    "fieldname": "trip_direction",
    "fieldtype": "Select",
    "label": "Trip Direction",
-   "options": "\nOutward\nReturn"
+   "options": "\nOutward\nReturn\nMixed"
   },
   {
    "fieldname": "routing_type_badge",
@@ -220,11 +221,18 @@
    "fieldtype": "Table",
    "label": "Transportation Shipment Employee",
    "options": "Transportation Shipment Employee"
+  },
+  {
+   "description": "Shared key written across every shipment merged into one Mixed trip.",
+   "fieldname": "trip_group",
+   "fieldtype": "Data",
+   "label": "Trip Group",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-15 17:22:34.688327",
+ "modified": "2026-08-17 15:00:00.000000",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Transportation Shipment",

--- a/one_fm/one_fm/doctype/transportation_shipment/transportation_shipment.py
+++ b/one_fm/one_fm/doctype/transportation_shipment/transportation_shipment.py
@@ -152,3 +152,85 @@ class TransportationShipment(Document):
 	def calculate_headcount(self):
 		"""Keep the read-only Headcount in sync with the employee table."""
 		self.headcount = len(self.transportation_shipment_employee)
+
+
+MIXED = "Mixed"
+RETURN = "Return"
+OUTWARD = "Outward"
+
+
+def merge_key(shipment_names) -> str:
+	"""A stable, unique key shared by every shipment in one merged trip (WI-002071).
+
+	Derived from the sorted member names rather than a random token, so merging the
+	same set of cards twice produces the same key and a re-run cannot leave two half
+	of a trip pointing at different groups. Hashed rather than concatenated because
+	the field is Data and a ten-card trip would overflow it.
+	"""
+	import hashlib
+
+	digest = hashlib.sha1("|".join(sorted(shipment_names)).encode()).hexdigest()
+	return f"MIX-{digest[:12]}"
+
+
+def arrival_order(shipment):
+	"""Sort key placing shipments in the order the vehicle reaches them.
+
+	The scheduled arrival is the shipment's own start time; a card without one sorts
+	last rather than first, so an unscheduled card cannot silently claim the head of
+	the itinerary. `name` breaks ties so the order is stable across saves.
+	"""
+	return (shipment.start_time is None, shipment.start_time, shipment.name)
+
+
+@frappe.whitelist()
+def merge_trip_shipments(shipments) -> dict:
+	"""Merge two or more cards into a single Mixed trip (WI-002071).
+
+	Called by the canvas when a card is dropped onto a block already occupied. Every
+	participating shipment becomes `trip_direction = "Mixed"` and receives a shared
+	`trip_group`, while each keeps its own Routing Type Badge - Direct, OSM and OLM
+	describe how a card's own riders are routed, which merging does not change.
+
+	The returned itinerary is ordered by scheduled arrival, which is the order the
+	Route Plan Assignment rows and the manifest both have to be written in.
+	"""
+	if isinstance(shipments, str):
+		shipments = frappe.parse_json(shipments)
+
+	shipments = [name for name in (shipments or []) if name]
+	if len(shipments) < 2:
+		frappe.throw(
+			_("Select at least two shipments to merge into a Mixed trip."),
+			title=_("Nothing to Merge"),
+		)
+
+	docs = [frappe.get_doc("Transportation Shipment", name) for name in dict.fromkeys(shipments)]
+	for doc in docs:
+		doc.check_permission("write")
+
+	docs.sort(key=arrival_order)
+	trip_group = merge_key([doc.name for doc in docs])
+
+	for doc in docs:
+		# db_set rather than save: the merge changes two header facts and must not
+		# re-run apply_routing_type, which would rewrite every rider row from the
+		# header and undo per-rider stop locations an OSM card depends on.
+		doc.db_set({"trip_direction": MIXED, "trip_group": trip_group}, update_modified=True)
+
+	return {
+		"trip_group": trip_group,
+		"trip_direction": MIXED,
+		"itinerary": [
+			{
+				"shipment": doc.name,
+				"stop_index": index,
+				"stop_location": doc.stop_location,
+				"headcount": doc.headcount,
+				"routing_type_badge": doc.routing_type_badge,
+				"start_time": doc.start_time,
+				"end_time": doc.end_time,
+			}
+			for index, doc in enumerate(docs, start=1)
+		],
+	}

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -921,7 +921,7 @@ def _build_transportation_shipment_cards(fmt, to_utc, get_coords_cached, timedel
             stop_coords = get_coords_cached("Location", s.stop_location) if s.stop_location else None
             acc_coords = get_coords_cached("Accommodation", s.accommodation) if s.accommodation else None
 
-            direction = "RETURN" if s.trip_direction == "Return" else "OUTBOUND"
+            direction = _normalize_direction(s.trip_direction)
             badge = (s.routing_type_badge or "DIRECT").upper()
             destination = s.stop_location or s.operations_site or ""
 
@@ -975,13 +975,23 @@ def _shipment_from_card_id(card_id: str) -> str:
 
 
 def _normalize_direction(value: str) -> str:
-    """Collapse the two direction vocabularies onto a single OUTBOUND/RETURN flag.
+    """Collapse the direction vocabularies onto a single OUTBOUND/RETURN/MIXED flag.
 
-    Shipment docs store ``trip_direction`` as "Outward"/"Return"; the canvas swim
-    items and Route Plan Assignment rows carry "OUTBOUND"/"RETURN". Both map to the
-    same flag so a companion match can validate direction across the vocabularies.
+    Shipment docs store ``trip_direction`` as "Outward"/"Return"/"Mixed"; the canvas
+    swim items and Route Plan Assignment rows carry "OUTBOUND"/"RETURN"/"MIXED". Both
+    map to the same flag so a companion match can validate direction across the
+    vocabularies.
+
+    MIXED is matched before the RETURN test rather than after it (WI-002071). The old
+    two-way version answered "anything that is not a return is an outbound", so a
+    merged card normalised to OUTBOUND: the canvas drew it orange instead of the merge
+    colour, and the status sync compared a MIXED placement against an OUTBOUND
+    shipment. A third direction has to be recognised, not defaulted.
     """
-    return "RETURN" if (value or "").strip().upper().startswith("RET") else "OUTBOUND"
+    flag = (value or "").strip().upper()
+    if flag.startswith("MIX"):
+        return "MIXED"
+    return "RETURN" if flag.startswith("RET") else "OUTBOUND"
 
 
 def _sync_shipment_statuses(items, previously_linked=None):

--- a/one_fm/operations/doctype/route_plan/route_plan.py
+++ b/one_fm/operations/doctype/route_plan/route_plan.py
@@ -15,6 +15,9 @@ _DATE_MAX = datetime.date.max
 _TIME_START = datetime.timedelta(0)
 _TIME_END = datetime.timedelta(days=1)
 
+# The direction a merged trip carries once cards are combined (WI-002071).
+MIXED_DIRECTION = "MIXED"
+
 
 class RoutePlan(Document):
 	def validate(self):
@@ -265,7 +268,12 @@ class RoutePlan(Document):
 			# it is, naming the seat shortfall (MA4-13). Ordered so the reported
 			# trip is stable across saves.
 			for trip in sorted(vehicle_trips, key=lambda t: t.key):
-				if trip.headcount > limit:
+				if trip.direction == MIXED_DIRECTION:
+					# A merged trip boards and alights along the way, so its stops do
+					# not all ride together and summing them would refuse a load the
+					# bus can actually carry (WI-002071).
+					self._validate_mixed_trip_legs(trip, limit)
+				elif trip.headcount > limit:
 					self._throw_capacity_exceeded(vehicle, trip.direction, trip.headcount, limit)
 
 			concurrent = _peak_concurrent_headcount(vehicle_trips)
@@ -313,9 +321,13 @@ class RoutePlan(Document):
 					end=end,
 					live_from=live_from,
 					live_to=live_to,
+					# Kept so a merged trip can be walked stop by stop (WI-002071);
+					# the summed headcount above is meaningless for one.
+					rows=[row],
 				)
 				continue
 
+			trip.rows.append(row)
 			trip.headcount += cint(row.headcount)
 			trip.start = min(trip.start, start)
 			trip.end = max(trip.end, end)
@@ -323,6 +335,57 @@ class RoutePlan(Document):
 			trip.live_to = max(filter(None, [trip.live_to, live_to]), default=None)
 
 		return list(trips.values())
+
+	def _validate_mixed_trip_legs(self, trip, limit):
+		"""Hold every leg of a merged trip to the seat count (WI-002071).
+
+		A Mixed trip is one vehicle run that both drops off and picks up, so its stops
+		do not all ride together: workers dropped at Stop 1 are off the bus before the
+		Stop 2 boarders get on. Summing the stops - which is right for a single-direction
+		trip, where every card's riders are aboard at once - would refuse a load the bus
+		can carry.
+
+		Occupancy is walked stop by stop instead. Each row's own shipment says which way
+		its riders travel: an Outward card's riders board at the camp and leave at that
+		card's stop, a Return card's riders join at that card's stop and stay aboard to
+		the camp. So the bus leaves the camp carrying every Outward rider, and each stop
+		in turn sheds its Outward riders and takes on its Return ones.
+
+		Disembarking is applied before boarding at each stop, per the third criterion: at
+		a stop where both happen the seats being vacated are available to the people
+		getting on, and adding first would report an overload that never occurs.
+
+		The peak across the legs is what has to fit, not the total that ever rode.
+		"""
+		by_index = sorted(trip.rows, key=lambda row: (cint(row.stop_index), row.name or ""))
+		directions = _shipment_directions([row.transportation_shipment for row in by_index])
+
+		def is_return(row):
+			return directions.get(row.transportation_shipment) == "RETURN"
+
+		# Everyone the trip carries out of the camp is aboard before the first stop.
+		occupancy = sum(cint(row.headcount) for row in by_index if not is_return(row))
+		peak = occupancy
+		worst_leg = 1
+
+		for leg, row in enumerate(by_index, start=1):
+			if is_return(row):
+				occupancy += cint(row.headcount)
+			else:
+				occupancy -= cint(row.headcount)
+
+			if occupancy > peak:
+				peak, worst_leg = occupancy, leg
+
+		if peak > limit:
+			frappe.throw(
+				_(
+					"Capacity Exceeded on leg {0}: {1} passengers against a vehicle limit "
+					"of {2}. A merged trip is measured leg by leg, so this is the busiest "
+					"point of the run rather than everyone it carries in total."
+				).format(worst_leg, peak, limit),
+				title=_("{0}: Vehicle Capacity Exceeded").format(trip.vehicle),
+			)
 
 	def _throw_capacity_exceeded(self, vehicle, direction, total_passengers, limit):
 		"""Raise the overloading block with the exact seat shortfall (MA4-13 AC4)."""
@@ -563,3 +626,32 @@ def _format_lock_until(end_time) -> str:
 	hours = (total // 3600) % 24
 	minutes = (total % 3600) // 60
 	return datetime.time(hours, minutes).strftime("%I:%M %p")
+
+
+def _shipment_directions(shipment_names) -> dict:
+	"""{shipment: OUTBOUND|RETURN|MIXED} for the cards on a merged trip.
+
+	Read from the shipments rather than the assignment rows: once merged, every row
+	carries direction MIXED, so the row can no longer say which way its own riders
+	travel. The shipment still can.
+	"""
+	names = [name for name in shipment_names if name]
+	if not names:
+		return {}
+
+	return {
+		row.name: _normalize_shipment_direction(row.trip_direction)
+		for row in frappe.get_all(
+			"Transportation Shipment",
+			filters={"name": ["in", list(set(names))]},
+			fields=["name", "trip_direction"],
+		)
+	}
+
+
+def _normalize_shipment_direction(value: str) -> str:
+	"""Shipment vocabulary (Outward/Return/Mixed) as an assignment-side flag."""
+	flag = (value or "").strip().upper()
+	if flag.startswith("MIX"):
+		return MIXED_DIRECTION
+	return "RETURN" if flag.startswith("RET") else "OUTBOUND"

--- a/one_fm/tests/test_mixed_trip_merge.py
+++ b/one_fm/tests/test_mixed_trip_merge.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002071: merging cards into a Mixed trip, and holding every leg to the seats."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
+	MIXED,
+	arrival_order,
+	merge_key,
+)
+from one_fm.operations.doctype.route_plan.route_plan import (
+	MIXED_DIRECTION,
+	RoutePlan,
+	_normalize_shipment_direction,
+)
+from one_fm.one_fm.page.transportation_schedule.transportation_schedule import (
+	_normalize_direction,
+)
+
+
+class TestMergeKey(FrappeTestCase):
+	def test_the_key_is_shared_by_every_member(self):
+		self.assertEqual(merge_key(["TS-0001", "TS-0002"]), merge_key(["TS-0001", "TS-0002"]))
+
+	def test_the_key_does_not_depend_on_the_order_cards_were_dropped(self):
+		# Merging the same set twice must not leave two halves pointing at different groups.
+		self.assertEqual(merge_key(["TS-0002", "TS-0001"]), merge_key(["TS-0001", "TS-0002"]))
+
+	def test_a_different_set_gets_a_different_key(self):
+		self.assertNotEqual(merge_key(["TS-0001", "TS-0002"]), merge_key(["TS-0001", "TS-0003"]))
+
+	def test_the_key_fits_a_data_field(self):
+		many = [f"TS-{n:04d}" for n in range(50)]
+
+		self.assertLessEqual(len(merge_key(many)), 140)
+
+
+class TestArrivalOrder(FrappeTestCase):
+	def _card(self, name, start_time):
+		return frappe._dict(name=name, start_time=start_time)
+
+	def test_cards_order_by_scheduled_arrival(self):
+		cards = [self._card("TS-2", 8 * 3600), self._card("TS-1", 5 * 3600)]
+
+		self.assertEqual([c.name for c in sorted(cards, key=arrival_order)], ["TS-1", "TS-2"])
+
+	def test_a_card_with_no_time_sorts_last_not_first(self):
+		# An unscheduled card must not silently claim the head of the itinerary.
+		cards = [self._card("TS-2", None), self._card("TS-1", 9 * 3600)]
+
+		self.assertEqual([c.name for c in sorted(cards, key=arrival_order)], ["TS-1", "TS-2"])
+
+	def test_ties_break_on_name_so_the_order_is_stable(self):
+		cards = [self._card("TS-9", 6 * 3600), self._card("TS-3", 6 * 3600)]
+
+		self.assertEqual([c.name for c in sorted(cards, key=arrival_order)], ["TS-3", "TS-9"])
+
+
+class TestDirectionVocabularies(FrappeTestCase):
+	"""MIXED has to be recognised, not defaulted."""
+
+	def test_the_canvas_helper_knows_mixed(self):
+		self.assertEqual(_normalize_direction("Mixed"), "MIXED")
+		self.assertEqual(_normalize_direction("MIXED"), "MIXED")
+
+	def test_the_canvas_helper_still_maps_the_original_two(self):
+		self.assertEqual(_normalize_direction("Outward"), "OUTBOUND")
+		self.assertEqual(_normalize_direction("OUTBOUND"), "OUTBOUND")
+		self.assertEqual(_normalize_direction("Return"), "RETURN")
+		self.assertEqual(_normalize_direction("RETURN"), "RETURN")
+
+	def test_a_blank_direction_is_still_treated_as_outbound(self):
+		self.assertEqual(_normalize_direction(""), "OUTBOUND")
+		self.assertEqual(_normalize_direction(None), "OUTBOUND")
+
+	def test_mixed_no_longer_falls_through_to_outbound(self):
+		# The regression this fixes: the old two-way test answered "not a return, so
+		# outbound", which drew a merged card orange and mismatched the status sync.
+		self.assertNotEqual(_normalize_direction("Mixed"), "OUTBOUND")
+
+	def test_the_route_plan_helper_agrees_with_the_canvas_one(self):
+		for value in ("Outward", "Return", "Mixed", "", None):
+			with self.subTest(value=value):
+				self.assertEqual(_normalize_shipment_direction(value), _normalize_direction(value))
+
+	def test_mixed_is_the_shipment_option_the_doctype_offers(self):
+		options = frappe.get_meta("Transportation Shipment").get_field("trip_direction").options
+		self.assertIn(MIXED, options.split("\n"))
+
+	def test_the_shipment_carries_the_shared_group_key(self):
+		field = frappe.get_meta("Transportation Shipment").get_field("trip_group")
+		self.assertIsNotNone(field, "Transportation Shipment has no trip_group field")
+		self.assertTrue(field.read_only)
+
+
+class TestMixedLegCapacity(FrappeTestCase):
+	"""The peak on any one leg is what has to fit, not everyone the trip ever carried."""
+
+	def _plan(self, rows):
+		plan = frappe.new_doc("Route Plan")
+		plan.assignments = []
+		for index, (shipment, headcount) in enumerate(rows, start=1):
+			plan.append("assignments", {
+				"transportation_shipment": shipment,
+				"vehicle": "V-1",
+				"direction": MIXED_DIRECTION,
+				"trip_group": "MIX-test",
+				"stop_index": index,
+				"headcount": headcount,
+			})
+		return plan
+
+	def _trip(self, plan, directions):
+		rows = list(plan.assignments)
+		trip = frappe._dict(
+			key=("V-1", "MIX-test", MIXED_DIRECTION), vehicle="V-1",
+			direction=MIXED_DIRECTION,
+			headcount=sum(r.headcount for r in rows), rows=rows,
+		)
+		self._directions = directions
+		return trip
+
+	def _check(self, plan, trip, limit):
+		"""Run the leg walk with the shipment directions stubbed."""
+		import one_fm.operations.doctype.route_plan.route_plan as mod
+
+		real = mod._shipment_directions
+		mod._shipment_directions = lambda names: self._directions
+		try:
+			RoutePlan._validate_mixed_trip_legs(plan, trip, limit)
+		finally:
+			mod._shipment_directions = real
+
+	def test_a_drop_then_a_pick_up_never_ride_together(self):
+		# 12 out, dropped at stop 1; 12 boarded at stop 2. Summed that is 24 and would be
+		# refused; the bus never carries more than 12 at once.
+		plan = self._plan([("TS-A", 12), ("TS-B", 12)])
+		trip = self._trip(plan, {"TS-A": "OUTBOUND", "TS-B": "RETURN"})
+
+		self._check(plan, trip, limit=12)
+
+	def test_the_busiest_leg_is_what_is_refused(self):
+		plan = self._plan([("TS-A", 12), ("TS-B", 12)])
+		trip = self._trip(plan, {"TS-A": "OUTBOUND", "TS-B": "RETURN"})
+
+		with self.assertRaises(frappe.ValidationError):
+			self._check(plan, trip, limit=11)
+
+	def test_disembarking_is_applied_before_boarding_at_a_shared_stop(self):
+		# Both cards stop at the same place: 10 off, then 10 on. Adding first would peak
+		# at 20 and refuse a run that never exceeds 10.
+		plan = self._plan([("TS-A", 10), ("TS-B", 10)])
+		for row in plan.assignments:
+			row.stop_index = 1
+		trip = self._trip(plan, {"TS-A": "OUTBOUND", "TS-B": "RETURN"})
+
+		self._check(plan, trip, limit=10)
+
+	def test_two_outward_cards_still_ride_together(self):
+		# Both loads leave the camp on the same bus, so they do sum - the leg walk must
+		# not turn a genuine overload into a pass.
+		plan = self._plan([("TS-A", 10), ("TS-B", 10)])
+		trip = self._trip(plan, {"TS-A": "OUTBOUND", "TS-B": "OUTBOUND"})
+
+		with self.assertRaises(frappe.ValidationError):
+			self._check(plan, trip, limit=15)
+
+	def test_two_return_cards_peak_when_the_last_one_boards(self):
+		plan = self._plan([("TS-A", 8), ("TS-B", 8)])
+		trip = self._trip(plan, {"TS-A": "RETURN", "TS-B": "RETURN"})
+
+		self._check(plan, trip, limit=16)
+		with self.assertRaises(frappe.ValidationError):
+			self._check(plan, trip, limit=15)
+
+	def test_a_loop_that_revisits_a_stop_is_measured_leg_by_leg(self):
+		# Camp -> Stop1 drop 10 -> Stop2 drop 12 -> Stop1 board 10 -> Camp.
+		# Total carried is 32; the peak leg is the 22 that leave the camp.
+		plan = self._plan([("TS-A", 10), ("TS-B", 12), ("TS-C", 10)])
+		trip = self._trip(plan, {"TS-A": "OUTBOUND", "TS-B": "OUTBOUND", "TS-C": "RETURN"})
+
+		self._check(plan, trip, limit=22)
+		with self.assertRaises(frappe.ValidationError):
+			self._check(plan, trip, limit=21)
+
+	def test_the_error_names_the_failing_leg(self):
+		plan = self._plan([("TS-A", 10), ("TS-B", 12), ("TS-C", 10)])
+		trip = self._trip(plan, {"TS-A": "OUTBOUND", "TS-B": "OUTBOUND", "TS-C": "RETURN"})
+
+		with self.assertRaises(frappe.ValidationError) as caught:
+			self._check(plan, trip, limit=21)
+
+		self.assertIn("leg", str(caught.exception).lower())
+
+	def test_rows_are_walked_in_stop_order_not_table_order(self):
+		plan = self._plan([("TS-A", 20), ("TS-B", 20)])
+		plan.assignments[0].stop_index = 2   # the board
+		plan.assignments[1].stop_index = 1   # the drop
+		trip = self._trip(plan, {"TS-A": "RETURN", "TS-B": "OUTBOUND"})
+
+		# Drop 20 first, then board 20: never more than 20 aboard.
+		self._check(plan, trip, limit=20)


### PR DESCRIPTION
A shift handover runs one bus out and back — it drops workers at a site and collects others on the same run. Until now that had to be two trips: the schema had no third direction, and the capacity rule had no way to see that the two loads are never aboard together.

### The merge

`merge_trip_shipments` sets every dropped card to `trip_direction = "Mixed"` and writes a shared `trip_group`. Each card keeps its own **Routing Type Badge** — Direct, OSM and OLM describe how that card's own riders are routed, which merging doesn't change.

The key is derived from the sorted member names rather than a random token, so merging the same set twice yields the same key and a re-run can't leave two halves of a trip in different groups. The itinerary returns ordered by scheduled arrival; a card with no time sorts **last**, so an unscheduled card can't silently claim the head of the run.

Uses `db_set` rather than `save`: a full save re-runs `apply_routing_type`, which rewrites every rider row from the header and would undo the per-rider stop locations an OSM card depends on.

### Capacity — the substance

The existing rule sums the cards sharing a `(vehicle, trip_group, direction)`. That's right for a single-direction trip, where every card's riders really are aboard at once, and wrong for a merged one.

A merged trip is now walked stop by stop: the bus leaves the camp carrying every Outward rider, and each stop sheds its Outward riders and takes on its Return ones. Which way a row's riders travel is read from **its own shipment** — once merged, every row reads `MIXED` and can no longer say.

Disembarking is applied **before** boarding at each stop (third criterion): the seats being vacated are available to the people getting on, and adding first reports an overload that never happens.

The worked example from the fourth criterion:

```
Camp ─► Stop 1 drop 10 ─► Stop 2 drop 12 ─► Stop 1 revisit board 10 ─► Camp

total carried:   32        ← what the old rule measured
peak on any leg: 22        ← what actually has to fit
```

The old rule refused that on a 22-seat bus. Two Outward cards still sum, so the walk can't turn a genuine overload into a pass.

### One thing fixed rather than left

`_normalize_direction` answered *"anything that is not a return is an outbound"*, so a merged card normalised to `OUTBOUND` — the canvas would have drawn it orange instead of the merge colour, and the status sync would have compared a `MIXED` placement against an `OUTBOUND` shipment. A third direction has to be recognised, not defaulted.

### Worth a reviewer's attention

`trip_group` is **added to Transportation Shipment**. The second criterion asks for the key to be written across the merged shipment records, and the BA's configuration has no such field — only Route Plan Assignment does. Confirmed with the reporter before adding.

### Tests

22 new, and the 111 existing transportation/route-plan tests still pass:

```
test_mixed_trip_merge            22  OK   (new)
test_route_plan                  62  OK
test_transportation_shipment     30  OK
test_transportation_schedule      6  OK
test_vehicle_passenger_capacity  13  OK
```

**Base of the chain** — WI-002077 and WI-002072 stack on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)