### PR TITLE
WI-002077: write a merged trip's direction, group and stop order onto the assignment rows

### DIFF
--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -1104,13 +1104,14 @@ def save_assignments(plan_name: str, swim_items: str, assigned_cards: str):
 
     # Clear existing assignments and rebuild
     doc.assignments = []
-    for item in items:
+    directions = _shipment_direction_flags(items)
+    for item in _with_stop_indexes(items):
         shipment = _shipment_from_card_id(item.get("cardId", ""))
         doc.append("assignments", {
             "card_id":                 item.get("cardId", ""),
             "transportation_shipment": shipment,
             "vehicle":                 item.get("vehicleId", ""),
-            "direction":               item.get("direction", ""),
+            "direction":               _assignment_direction(item, directions.get(shipment)),
             "stop_index":              item.get("stopIndex", 0),
             "trip_group":              item.get("tripId", ""),
             "trip_name":               item.get("tripName", ""),
@@ -1121,6 +1122,8 @@ def save_assignments(plan_name: str, swim_items: str, assigned_cards: str):
             "shift":                   item.get("_shift", ""),
             "accommodation":           item.get("_accommodation", ""),
             "stop_location":           item.get("_stopLocation", ""),
+            "transit_minutes":         item.get("transitMinutes") or 0,
+            "buffer_minutes":          item.get("bufferMinutes") or 0,
         })
 
     doc.save(ignore_permissions=False)
@@ -1884,3 +1887,77 @@ def process_rambo_replacement(original_employee: str, replacement_employee: str,
         "notified": False,
         "message": "Replacement processed. No supervisor found for this shift to notify."
     }
+
+
+def _shipment_direction_flags(items) -> dict:
+    """{shipment: OUTBOUND|RETURN|MIXED} for every card being saved (WI-002077).
+
+    Read in one query rather than per row: a full month's canvas is hundreds of items.
+    """
+    names = {
+        _shipment_from_card_id(item.get("cardId", ""))
+        for item in items
+        if _shipment_from_card_id(item.get("cardId", ""))
+    }
+    if not names:
+        return {}
+
+    return {
+        row.name: _normalize_direction(row.trip_direction)
+        for row in frappe.get_all(
+            "Transportation Shipment",
+            filters={"name": ["in", list(names)]},
+            fields=["name", "trip_direction"],
+        )
+    }
+
+
+def _assignment_direction(item, shipment_direction: str) -> str:
+    """The direction a row is written with (WI-002077).
+
+    Taken from the card's own Transportation Shipment rather than from whatever the
+    canvas sent, which is what "auto-fetched from the Transportation Shipment card"
+    asks for. The two sides use different vocabularies - the shipment says Outward,
+    the assignment says OUTBOUND - so this is a mapping and not a fetch_from; declaring
+    one would write "Outward" into a Select that does not offer it.
+
+    A merged card carries MIXED, so every row of one merged trip agrees on it without
+    the canvas having to say so.
+
+    Falls back to the canvas value when the shipment cannot be read - a row placed by
+    hand with no shipment link still has a direction worth keeping.
+    """
+    if shipment_direction:
+        return shipment_direction
+
+    return _normalize_direction(item.get("direction", ""))
+
+
+def _with_stop_indexes(items):
+    """Number the stops of each merged trip 1, 2, 3... in chronological order (WI-002077).
+
+    A merged trip's rows have to carry an explicit position, because the manifest and the
+    per-leg capacity walk both read the run in stop order and neither can infer it from
+    table order. The canvas sends stopIndex for the multi-stop cards it already sequences;
+    a trip merged by dropping one card onto another has no index yet, so the order is
+    derived from the start times the modal produced.
+
+    Only rows sharing a trip_group are numbered. A standalone card is its own trip and its
+    index is left exactly as the canvas sent it.
+    """
+    grouped = {}
+    for item in items:
+        group = item.get("tripId")
+        if group:
+            grouped.setdefault(group, []).append(item)
+
+    for members in grouped.values():
+        if len(members) < 2:
+            continue
+        # Sorted on the start the modal computed; a member with no start sorts last so it
+        # cannot silently take the head of the run.
+        ordered = sorted(members, key=lambda i: (not i.get("start"), i.get("start") or "", i.get("cardId", "")))
+        for position, member in enumerate(ordered, start=1):
+            member["stopIndex"] = position
+
+    return items

--- a/one_fm/operations/doctype/route_plan_assignment/route_plan_assignment.json
+++ b/one_fm/operations/doctype/route_plan_assignment/route_plan_assignment.json
@@ -22,7 +22,9 @@
     "stop_location",
     "section_break_times",
     "start_time",
-    "end_time"
+    "end_time",
+    "transit_minutes",
+    "buffer_minutes"
   ],
   "fields": [
     {
@@ -51,7 +53,7 @@
       "fieldname": "direction",
       "fieldtype": "Select",
       "label": "Direction",
-      "options": "\nOUTBOUND\nRETURN",
+      "options": "\nOUTBOUND\nRETURN\nMIXED",
       "reqd": 1,
       "in_list_view": 1
     },
@@ -129,12 +131,24 @@
       "fieldtype": "Data",
       "label": "End Time",
       "description": "ISO timestamp of block end on timeline. Date part = multi-day lock lifespan end; time part = daily trip end."
+    },
+    {
+      "fieldname": "transit_minutes",
+      "fieldtype": "Int",
+      "label": "Transit Minutes",
+      "description": "Driving time from the previous stop, as set in the Merge Trip modal."
+    },
+    {
+      "fieldname": "buffer_minutes",
+      "fieldtype": "Int",
+      "label": "Buffer Minutes",
+      "description": "Waiting time at this stop before departing for the next one."
     }
   ],
   "index_web_pages_for_search": 0,
   "istable": 1,
   "links": [],
-  "modified": "2026-05-04 10:00:00.000000",
+  "modified": "2026-08-17 16:00:00.000000",
   "modified_by": "Administrator",
   "module": "Operations",
   "name": "Route Plan Assignment",

--- a/one_fm/tests/test_route_plan_assignment_mixed.py
+++ b/one_fm/tests/test_route_plan_assignment_mixed.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002077: what a Route Plan Assignment row stores for a merged trip."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.one_fm.page.transportation_schedule.transportation_schedule import (
+	_assignment_direction,
+	_with_stop_indexes,
+)
+
+
+class TestAssignmentSchema(FrappeTestCase):
+	def test_direction_offers_mixed(self):
+		options = frappe.get_meta("Route Plan Assignment").get_field("direction").options
+
+		self.assertEqual(options.split("\n"), ["", "OUTBOUND", "RETURN", "MIXED"])
+
+	def test_the_row_can_hold_the_shared_group_key(self):
+		self.assertIsNotNone(frappe.get_meta("Route Plan Assignment").get_field("trip_group"))
+
+	def test_the_row_can_hold_an_explicit_stop_position(self):
+		field = frappe.get_meta("Route Plan Assignment").get_field("stop_index")
+
+		self.assertIsNotNone(field)
+		self.assertEqual(field.fieldtype, "Int")
+
+	def test_the_modal_s_timings_have_somewhere_to_live(self):
+		meta = frappe.get_meta("Route Plan Assignment")
+
+		for fieldname in ("transit_minutes", "buffer_minutes"):
+			with self.subTest(fieldname=fieldname):
+				field = meta.get_field(fieldname)
+				self.assertIsNotNone(field, f"{fieldname} is missing")
+				self.assertEqual(field.fieldtype, "Int")
+
+
+class TestDirectionComesFromTheShipment(FrappeTestCase):
+	"""The row's direction is the card's own, not whatever the canvas sent."""
+
+	def test_a_merged_card_writes_mixed(self):
+		self.assertEqual(_assignment_direction({"direction": "OUTBOUND"}, "MIXED"), "MIXED")
+
+	def test_the_shipment_wins_over_the_canvas(self):
+		# A card dropped in the wrong lane must not be recorded travelling the wrong way.
+		self.assertEqual(_assignment_direction({"direction": "OUTBOUND"}, "RETURN"), "RETURN")
+
+	def test_the_two_original_directions_still_map(self):
+		self.assertEqual(_assignment_direction({}, "OUTBOUND"), "OUTBOUND")
+		self.assertEqual(_assignment_direction({}, "RETURN"), "RETURN")
+
+	def test_a_row_with_no_shipment_keeps_the_canvas_direction(self):
+		self.assertEqual(_assignment_direction({"direction": "RETURN"}, None), "RETURN")
+		self.assertEqual(_assignment_direction({"direction": "MIXED"}, None), "MIXED")
+
+	def test_a_row_with_neither_falls_back_to_outbound(self):
+		self.assertEqual(_assignment_direction({}, None), "OUTBOUND")
+
+	def test_the_shipment_vocabulary_is_translated_not_copied(self):
+		# "Outward" is not a value the assignment Select offers; writing it would be
+		# rejected. The mapping is why this is not a fetch_from.
+		options = frappe.get_meta("Route Plan Assignment").get_field("direction").options.split("\n")
+
+		self.assertNotIn("Outward", options)
+		self.assertIn("OUTBOUND", options)
+
+
+class TestStopIndexing(FrappeTestCase):
+	def _item(self, card, group, start, stop_index=0):
+		return {"cardId": card, "tripId": group, "start": start, "stopIndex": stop_index}
+
+	def test_merged_rows_are_numbered_in_chronological_order(self):
+		items = [
+			self._item("c-2", "MIX-1", "2026-08-20 14:00:00"),
+			self._item("c-1", "MIX-1", "2026-08-20 06:00:00"),
+			self._item("c-3", "MIX-1", "2026-08-20 18:00:00"),
+		]
+
+		by_card = {i["cardId"]: i["stopIndex"] for i in _with_stop_indexes(items)}
+
+		self.assertEqual(by_card, {"c-1": 1, "c-2": 2, "c-3": 3})
+
+	def test_the_positions_are_contiguous_from_one(self):
+		items = [self._item(f"c-{n}", "MIX-1", f"2026-08-20 0{n}:00:00") for n in range(1, 5)]
+
+		indexes = sorted(i["stopIndex"] for i in _with_stop_indexes(items))
+
+		self.assertEqual(indexes, [1, 2, 3, 4])
+
+	def test_every_row_of_one_trip_shares_the_group_key(self):
+		items = [
+			self._item("c-1", "MIX-1", "2026-08-20 06:00:00"),
+			self._item("c-2", "MIX-1", "2026-08-20 14:00:00"),
+		]
+
+		self.assertEqual({i["tripId"] for i in _with_stop_indexes(items)}, {"MIX-1"})
+
+	def test_two_trips_are_numbered_independently(self):
+		items = [
+			self._item("a-1", "MIX-A", "2026-08-20 06:00:00"),
+			self._item("a-2", "MIX-A", "2026-08-20 14:00:00"),
+			self._item("b-1", "MIX-B", "2026-08-20 07:00:00"),
+			self._item("b-2", "MIX-B", "2026-08-20 15:00:00"),
+		]
+
+		by_card = {i["cardId"]: i["stopIndex"] for i in _with_stop_indexes(items)}
+
+		self.assertEqual(by_card, {"a-1": 1, "a-2": 2, "b-1": 1, "b-2": 2})
+
+	def test_a_standalone_card_keeps_the_index_the_canvas_sent(self):
+		# One card is its own trip; the canvas already sequences multi-stop runs.
+		items = [self._item("solo", "MIX-solo", "2026-08-20 06:00:00", stop_index=7)]
+
+		self.assertEqual(_with_stop_indexes(items)[0]["stopIndex"], 7)
+
+	def test_an_ungrouped_card_is_left_alone(self):
+		items = [{"cardId": "loose", "tripId": "", "start": "2026-08-20 06:00:00", "stopIndex": 4}]
+
+		self.assertEqual(_with_stop_indexes(items)[0]["stopIndex"], 4)
+
+	def test_a_member_with_no_start_sorts_last(self):
+		items = [
+			self._item("c-late", "MIX-1", None),
+			self._item("c-first", "MIX-1", "2026-08-20 06:00:00"),
+		]
+
+		by_card = {i["cardId"]: i["stopIndex"] for i in _with_stop_indexes(items)}
+
+		self.assertEqual(by_card, {"c-first": 1, "c-late": 2})
+
+	def test_the_order_is_stable_when_two_stops_share_a_time(self):
+		items = [
+			self._item("c-b", "MIX-1", "2026-08-20 06:00:00"),
+			self._item("c-a", "MIX-1", "2026-08-20 06:00:00"),
+		]
+
+		by_card = {i["cardId"]: i["stopIndex"] for i in _with_stop_indexes(items)}
+
+		self.assertEqual(by_card, {"c-a": 1, "c-b": 2})


### PR DESCRIPTION
Stacked on #6724 — review that first.

The canvas wrote whatever direction the drop happened to carry, so a merged card had nowhere to record that it *was* one, and a merged trip's rows had no explicit position in the run. Both the manifest and the per-leg capacity walk read a trip in stop order, and neither can infer it from table order.

### Direction comes from the shipment

Taken from the card's own Transportation Shipment — what *"auto-fetched from the Transportation Shipment card"* asks for. It's a **mapping, not a `fetch_from`**, because the two sides speak different vocabularies:

```
Transportation Shipment      Route Plan Assignment
  Outward            ───►      OUTBOUND
  Return             ───►      RETURN
  Mixed              ───►      MIXED
```

Declaring a `fetch_from` would write `"Outward"` into a Select that doesn't offer it. Confirmed with the reporter that both vocabularies stay as the BA configured them.

Taking it from the shipment also settles a card dropped into the wrong lane: the row records the way its riders **actually travel**, not the lane someone dropped it in. A row with no shipment link keeps the canvas value, since a hand-placed row still has a direction worth keeping.

### Stop ordering

Merged rows are numbered `1, 2, 3…` in the order the modal scheduled them. Only rows sharing a `trip_group` are numbered — a standalone card is its own trip and keeps the index the canvas gave it.

Two ordering guards: a member with **no start time sorts last**, so an unscheduled stop can't take the head of the run; and ties break on card id, so numbering doesn't shuffle between saves.

### transit_minutes / buffer_minutes

Added to the row. WI-002078's Merge Trip modal lets the operator adjust driving time and the wait at each stop, and the derived start/end times alone can't be turned back into the two numbers that produced them. Storing them keeps the operator's figures recoverable on reopen — as you asked. The BA's config has neither field.

### Tests

```
test_route_plan_assignment_mixed  18  OK   (new)
test_mixed_trip_merge             22  OK
test_route_plan                   62  OK
test_transportation_schedule       6  OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
