### PR TITLE
WI-002074: render a merged run on the digital manifest

### DIFF
--- a/one_fm/one_fm/page/transportation_manifest_page/transportation_manifest_page.js
+++ b/one_fm/one_fm/page/transportation_manifest_page/transportation_manifest_page.js
@@ -186,6 +186,7 @@ function renderManifest($container, data) {
 	let shipmentReturnEmployees = {};
 	let shipmentSiteLocations = {};
 	let shipmentShiftNames = {};
+	let shipmentOwnDirections = {};
 
 	// Expose state globally for modal scripts
 	window.manifestData = data;
@@ -420,7 +421,11 @@ function renderManifest($container, data) {
 				transition: trans[i + 1],
 				tripId: v.tripId || null,
 				tripName: v.tripName || null,
-				stopIndex: v.stopIndex || 0
+				stopIndex: v.stopIndex || 0,
+				// The label's direction reads MIXED once a card is merged, which says how
+				// the card is scheduled and not whether its riders board here or leave
+				// here. The server resolves that separately (WI-002074).
+				ownDirection: shipmentOwnDirections[parsed.raw] || parsed.direction
 			});
 		});
 
@@ -446,6 +451,7 @@ function renderManifest($container, data) {
 	shipmentReturnEmployees = ROUTE_DATA.shipmentReturnEmployees ?? {};
 	shipmentSiteLocations = ROUTE_DATA.shipmentSiteLocations ?? {};
 	shipmentShiftNames = ROUTE_DATA.shipmentShiftNames ?? {};
+	shipmentOwnDirections = ROUTE_DATA.shipmentOwnDirections ?? {};
 
 	// Pre-populate checkerState from server manifest details
 	if (shipmentEmployees) {
@@ -630,13 +636,19 @@ function renderManifest($container, data) {
 				return { travelDuration: Math.round(ms / 1000) + "s", waitDuration: "0s", travelDistanceMeters: 0 };
 			}
 
+			// Every assignment row emits both a pickup and a drop-off visit; exactly one of
+			// them is the thing the driver does at that stop. Which one used to be decided
+			// by enumerating OUTBOUND and RETURN, so a MIXED card matched neither and both
+			// survived - every merged stop appeared twice, once as PICK UP and once as
+			// DROP OFF (WI-002074).
 			const actualSiteStops = [];
 			tripStops.forEach(stop => {
-				if (stop.direction === "OUTBOUND" && stop.type === "pickup") return;
-				if (stop.direction === "RETURN" && stop.type === "dropoff") return;
+				const own = stop.ownDirection || stop.direction;
+				if (own === "OUTBOUND" && stop.type === "pickup") return;
+				if (own === "RETURN" && stop.type === "dropoff") return;
 				actualSiteStops.push(stop);
 
-				if (stop.direction === "OUTBOUND" && stop.type === "dropoff") {
+				if (own === "OUTBOUND" && stop.type === "dropoff" && stop.direction !== "MIXED") {
 					const retEmps = shipmentReturnEmployees[stop.raw] || [];
 					if (retEmps.length > 0) {
 						actualSiteStops.push({
@@ -682,10 +694,11 @@ function renderManifest($container, data) {
 			const firstTimeISO = new Date(firstTime).toISOString();
 			const lastTimeISO = new Date(lastTime).toISOString();
 
+			const isMixed = isMixedRun(meta);
 			const hasOutbound = tripStops.some(s => s.direction === "OUTBOUND");
 			const hasReturn = tripStops.some(s => s.direction === "RETURN");
-			const dirClass = !hasOutbound && hasReturn ? "return" : "outbound";
-			const dirIcon = !hasOutbound && hasReturn ? "keyboard_return" : "arrow_forward";
+			const dirClass = isMixed ? "mixed" : (!hasOutbound && hasReturn ? "return" : "outbound");
+			const dirIcon = isMixed ? "sync_alt" : (!hasOutbound && hasReturn ? "keyboard_return" : "arrow_forward");
 
 			html += `
 				<div class="mfst-trip-group ${dirClass}">
@@ -724,11 +737,25 @@ function renderManifest($container, data) {
 
 			const activeStop = meta.active_stop_sequence || 0;
 			const manifestName = meta.manifest || null;
+
+			if (isMixed) {
+				// A merged run is one journey out and back, not a series of camp blocks:
+				// it leaves one origin, calls at each stop in turn dropping and
+				// collecting, and comes home. Third criterion, top to bottom:
+				//   {Origin Depart} -> {stop} -> ... -> {Final Return}
+				// The camp-by-camp walk below split that into an outbound pass and a
+				// return pass and listed every stop twice.
+				html += renderMixedItinerary({
+					orderedStops, firstTimeISO, lastTimeISO, accommodation,
+					activeStop, manifestName, vehicleLabel: pr.label, calcTransit
+				});
+			} else {
+
 			const campGroups = Object.values(boardingByCamp).sort((a, b) => a.seq - b.seq);
 
 			// Camp block: DEPART banner, then that camp's drop-off stop(s)
 			campGroups.forEach(cg => {
-				html += renderDepartCard(firstTimeISO, cg, activeStop, manifestName, pr.label, isMixedRun(meta));
+				html += renderDepartCard(firstTimeISO, cg, activeStop, manifestName, pr.label, false);
 				let prevTime = firstTimeISO;
 				(dropByCamp[cg.seq] || []).forEach(item => {
 					html += renderTransit(calcTransit(prevTime, item.stop.time));
@@ -770,6 +797,8 @@ function renderManifest($container, data) {
 
 			// RETURN card
 			html += renderReturnCard(lastTimeISO, accommodation, returningEmployees);
+
+			}
 
 			html += `</div></div>`;
 
@@ -819,21 +848,81 @@ function renderManifest($container, data) {
 		return String((meta && meta.trip_direction) || "").toLowerCase() === "mixed";
 	}
 
-	function mixedStopCount(pr) {
-		const stops = (pr && pr.route && pr.route.stops) || [];
-		return stops.length;
+	// Every stop the run actually calls at. `pr.stops` carries the depot bookends, which
+	// are not stops the driver works, and each card contributes one visit once the
+	// pickup/drop-off pair is collapsed.
+	function mixedItineraryStops(pr) {
+		return (pr.stops || []).filter(s => s.type !== "depot" && s.type !== "end" && !s.isRest);
 	}
 
-	function mixedPassengerCount(pr, shipmentEmployees) {
-		const stops = (pr && pr.route && pr.route.stops) || [];
+	function mixedStopCount(pr) {
 		const seen = new Set();
-		stops.forEach(stop => {
-			((shipmentEmployees || {})[stop.raw] || []).forEach(e => {
+		mixedItineraryStops(pr).forEach(s => seen.add(`${s.raw}|${s.type}`));
+		return seen.size;
+	}
+
+	function mixedPassengerCount(pr, employeesByShipment) {
+		const seen = new Set();
+		mixedItineraryStops(pr).forEach(stop => {
+			((employeesByShipment || {})[stop.raw] || []).forEach(e => {
 				const name = (typeof e === "object" && e !== null) ? (e.name || "") : (e || "");
 				if (name) seen.add(name);
 			});
 		});
 		return seen.size;
+	}
+
+	// ── A merged run's itinerary (WI-002074) ──
+	// One list, top to bottom, in the order the driver drives it:
+	//   {Origin Depart (Boarding)} -> {stop} -> ... -> {Final Return}
+	// Each stop is one card: an Outward card's riders are set down there, a Return card's
+	// riders join there. Two stops due at the same moment put the drop-off first, because
+	// the seats one load vacates are what the next load boards into. A stop the run comes
+	// back to is a separate card further down the list, since it is a second visit.
+	function renderMixedItinerary(o) {
+		const stops = o.orderedStops
+			.map(item => item.stop)
+			.slice()
+			.sort((a, b) => (new Date(a.time) - new Date(b.time))
+				|| ((a.type === "dropoff" ? 0 : 1) - (b.type === "dropoff" ? 0 : 1)));
+
+		const names = (stop) => {
+			const emps = stop._isVirtualReturn ? stop._virtualEmps : (shipmentEmployees[stop.raw] ?? []);
+			return emps.filter(e => (typeof e === "object" && e !== null) ? e.name : e);
+		};
+
+		// Who is on the bus when it leaves the origin: the riders it carries out to be
+		// set down. Who comes home: the riders it collects along the way.
+		const boarding = [], returning = [];
+		const boardingSeen = new Set(), returningSeen = new Set();
+		stops.forEach(stop => {
+			const into = stop.type === "dropoff" ? boarding : returning;
+			const seen = stop.type === "dropoff" ? boardingSeen : returningSeen;
+			names(stop).forEach(e => {
+				const name = (typeof e === "object" && e !== null) ? e.name : e;
+				if (name && !seen.has(name)) { seen.add(name); into.push(e); }
+			});
+		});
+
+		// Stop 1 is the origin depart, so the stops the driver calls at start at 2. The
+		// numbers follow the visit order, which is what makes a revisited stop read as a
+		// later stop rather than the same one again.
+		let html = renderDepartCard(
+			o.firstTimeISO,
+			{ seq: 1, label: o.accommodation, employees: boarding },
+			o.activeStop, o.manifestName, o.vehicleLabel, true
+		);
+
+		let prevTime = o.firstTimeISO;
+		stops.forEach((stop, i) => {
+			html += renderTransit(o.calcTransit(prevTime, stop.time));
+			html += renderSiteStopCard({ stop: stop, siteNum: i + 2 });
+			prevTime = stop.time;
+		});
+
+		html += renderTransit(o.calcTransit(prevTime, o.lastTimeISO));
+		html += renderReturnCard(o.lastTimeISO, o.accommodation, returning);
+		return html;
 	}
 
 	// Lock state is derived from the manifest's active_stop_sequence:
@@ -1639,6 +1728,9 @@ function getManifestCSS() {
 			--mfst-blue-dim: rgba(37, 99, 235, 0.08);
 			--mfst-purple: #c2410c;
 			--mfst-purple-dim: rgba(194, 65, 12, 0.06);
+			/* WI-002074: the merge colour the story names, shared with the schedule lane. */
+			--mfst-mixed: #819171;
+			--mfst-mixed-dim: rgba(129, 145, 113, 0.10);
 			--mfst-text: #111827;
 			--mfst-text-muted: #6b7280;
 			--mfst-text-dim: #9ca3af;
@@ -1712,11 +1804,15 @@ function getManifestCSS() {
 		/* ── TRIP GROUP ── */
 		.mfst-trip-group { border: 2px solid var(--mfst-blue); border-radius: 16px; margin-bottom: 16px; overflow: hidden; background: var(--mfst-bg-card); }
 		.mfst-trip-group.return { border-color: var(--mfst-purple); }
+		.mfst-trip-group.mixed { border-color: var(--mfst-mixed); }
 		.mfst-trip-header { display: flex; align-items: center; gap: 10px; padding: 14px 20px; background: var(--mfst-blue-dim); border-bottom: 1px solid rgba(37,99,235,0.1); flex-wrap: wrap; }
 		.mfst-trip-group.return .mfst-trip-header { background: var(--mfst-purple-dim); border-bottom-color: rgba(194,65,12,0.1); }
+		.mfst-trip-group.mixed .mfst-trip-header { background: var(--mfst-mixed-dim); border-bottom-color: rgba(129,145,113,0.15); }
 		.mfst-trip-header-icon { font-size: 20px; color: var(--mfst-blue); }
+		.mfst-trip-group.mixed .mfst-trip-header-icon { color: var(--mfst-mixed); }
 		.mfst-trip-group.return .mfst-trip-header-icon { color: var(--mfst-purple); }
 		.mfst-trip-header-title { font-size: 16px; font-weight: 700; color: var(--mfst-blue); }
+		.mfst-trip-group.mixed .mfst-trip-header-title { color: var(--mfst-mixed); }
 		.mfst-trip-group.return .mfst-trip-header-title { color: var(--mfst-purple); }
 		.mfst-trip-header-meta { font-size: 12px; color: var(--mfst-text-dim); margin-left: auto; }
 		.mfst-trip-body { padding: 12px 16px 16px; }

--- a/one_fm/one_fm/page/transportation_manifest_page/transportation_manifest_page.js
+++ b/one_fm/one_fm/page/transportation_manifest_page/transportation_manifest_page.js
@@ -602,6 +602,7 @@ function renderManifest($container, data) {
 							${fmtTime(pr.route.vehicleStartTime)} → ${fmtTime(pr.route.vehicleEndTime)}
 						</div>
 						<div class="mfst-vehicle-trips">${allTrips.length} trip${allTrips.length !== 1 ? "s" : ""}</div>
+						${isMixedRun(meta) ? `<div class="mfst-mixed-badge">MIXED &middot; ${mixedStopCount(pr)} stops &middot; ${mixedPassengerCount(pr, shipmentEmployees)} passengers</div>` : ""}
 					</div>
 				</div>
 				<div class="mfst-vehicle-stats">
@@ -727,7 +728,7 @@ function renderManifest($container, data) {
 
 			// Camp block: DEPART banner, then that camp's drop-off stop(s)
 			campGroups.forEach(cg => {
-				html += renderDepartCard(firstTimeISO, cg, activeStop, manifestName, pr.label);
+				html += renderDepartCard(firstTimeISO, cg, activeStop, manifestName, pr.label, isMixedRun(meta));
 				let prevTime = firstTimeISO;
 				(dropByCamp[cg.seq] || []).forEach(item => {
 					html += renderTransit(calcTransit(prevTime, item.stop.time));
@@ -811,15 +812,45 @@ function renderManifest($container, data) {
 	}
 
 	// Per-camp DEPART card (MA2-11). `camp` = { seq, label, employees }.
+	// A merged run reads differently from an ordinary one: it leaves one origin, calls at
+	// several stops dropping and collecting, and comes back. These three answer "is it one",
+	// "how many stops does it make" and "how many people does it carry" (WI-002074).
+	function isMixedRun(meta) {
+		return String((meta && meta.trip_direction) || "").toLowerCase() === "mixed";
+	}
+
+	function mixedStopCount(pr) {
+		const stops = (pr && pr.route && pr.route.stops) || [];
+		return stops.length;
+	}
+
+	function mixedPassengerCount(pr, shipmentEmployees) {
+		const stops = (pr && pr.route && pr.route.stops) || [];
+		const seen = new Set();
+		stops.forEach(stop => {
+			((shipmentEmployees || {})[stop.raw] || []).forEach(e => {
+				const name = (typeof e === "object" && e !== null) ? (e.name || "") : (e || "");
+				if (name) seen.add(name);
+			});
+		});
+		return seen.size;
+	}
+
 	// Lock state is derived from the manifest's active_stop_sequence:
 	//   seq <  active → Completed (read-only)   seq === active → Active (editable)
 	//   seq === active+1 → next (can Trigger)    seq >  active+1 → Locked
-	function renderDepartCard(time, camp, activeStop, manifestName, vehicleLabel) {
+	function renderDepartCard(time, camp, activeStop, manifestName, vehicleLabel, isMixed) {
 		const employees = camp.employees || [];
 		const seq = camp.seq || 1;
 		const isCompleted = activeStop && seq < activeStop;
 		const isActive = activeStop && seq === activeStop;
-		const canTrigger = seq === (activeStop || 0) + 1;
+		// On an ordinary run the check walks camp by camp, so each camp in turn can be
+		// triggered. A merged run is one vehicle leaving one origin: the second criterion
+		// puts the button in the very first DEPART card and nowhere else, so a driver
+		// cannot start a check at a mid-route pickup they have not reached (WI-002074).
+		const canTrigger = isMixed
+			? (seq === 1 && !activeStop)
+			: seq === (activeStop || 0) + 1;
 		const status = isCompleted ? "completed" : (isActive ? "active" : "locked");
 
 		let statusChip;
@@ -849,7 +880,7 @@ function renderManifest($container, data) {
 				<div class="mfst-depart-emp-header">
 					<div class="mfst-stop-emp-label" style="color:var(--mfst-green)">
 						<span class="material-symbols-outlined" style="font-size:16px;vertical-align:middle">groups</span>
-						${employees.length} employee${employees.length !== 1 ? "s" : ""} boarding
+						EMPLOYEES BOARDING &middot; ${employees.length}
 					</div>
 					<div class="mfst-depart-check-badge">
 						<span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle">fact_check</span>
@@ -897,13 +928,13 @@ function renderManifest($container, data) {
 
 		let empHtml = "";
 		if (emps.length > 0) {
-			const actionWord = isDropoff ? "Dropping off" : "Picking up";
+			const actionWord = isDropoff ? "DROPPING OFF EMPLOYEES" : "EMPLOYEES BOARDING";
 			const actionColor = isDropoff ? "var(--mfst-accent)" : "var(--mfst-green)";
 			const actionIcon = isDropoff ? "south" : "north";
 			empHtml = `<div class="mfst-stop-emp-section">
 				<div class="mfst-stop-emp-label" style="color:${actionColor}">
 					<span class="material-symbols-outlined" style="font-size:16px;vertical-align:middle">${actionIcon}</span>
-					${actionWord} ${emps.length} employee${emps.length !== 1 ? "s" : ""}
+					${actionWord} &middot; ${emps.length}
 				</div>
 				<div class="mfst-stop-employees">${emps.map(n => empChipHtml(n)).join("")}</div>
 			</div>`;
@@ -1716,6 +1747,7 @@ function getManifestCSS() {
 		.mfst-stop-emp-section { margin-top: 12px; }
 		.mfst-stop-emp-label { font-size: 13px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 8px; display: flex; align-items: center; gap: 6px; }
 		.mfst-depart-emp-header { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 8px; margin-bottom: 8px; }
+		.mfst-mixed-badge { font-size: 12px; font-weight: 700; letter-spacing: .04em; color: #fff; background: #819171; padding: 3px 10px; border-radius: 6px; margin-top: 6px; display: inline-block; }
 		.mfst-depart-check-badge { font-size: 12px; font-weight: 600; color: var(--mfst-accent); background: var(--mfst-accent-dim); border: 1px solid rgba(249,115,22,0.2); padding: 4px 10px; border-radius: 6px; display: flex; align-items: center; gap: 4px; }
 
 		/* ── Per-camp DEPART attendance-check lock (MA2-11) ── */

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -1506,6 +1506,22 @@ def get_manifest_data_for_plan(plan_name: str):
 			enriched.append(emp_copy)
 		return enriched
 
+	# Which way each card's own riders travel. A merged card is labelled MIXED, so the
+	# label can no longer say whether its riders board at the stop or leave there - and
+	# the manifest page decides drop-off vs pick-up from exactly that (WI-002074).
+	ship_own_dir = {}
+	_own_dir_by_shipment = {}
+	_ship_names = [r.transportation_shipment for r in doc.assignments if r.transportation_shipment]
+	if _ship_names:
+		for _r in frappe.get_all(
+			"Transportation Shipment",
+			filters={"name": ["in", list(set(_ship_names))]},
+			fields=["name", "trip_direction", "pre_merge_trip_direction"],
+		):
+			_own_dir_by_shipment[_r.name] = _card_direction(
+				_r.trip_direction, _r.pre_merge_trip_direction
+			)
+
 	# Process assignments to build shipments
 	for row in doc.assignments:
 		dir_key = f"{row.card_id}_{row.direction}"
@@ -1537,6 +1553,9 @@ def get_manifest_data_for_plan(plan_name: str):
 			ship_site[lbl] = row.stop_location or ""
 
 		ship_shift[lbl] = row.shift or ""
+		ship_own_dir[lbl] = _own_dir_by_shipment.get(
+			row.transportation_shipment
+		) or _normalize_direction(row.direction)
 		c_map[dir_key] = {"lbl": lbl, "idx": idx}
 
 	# ── Build vehicles and routes ──
@@ -1574,6 +1593,11 @@ def get_manifest_data_for_plan(plan_name: str):
 			# active_stop_sequence drives which pickup camp is currently unlocked.
 			"manifest": _mf.name if (_mf and not _mf.is_new()) else None,
 			"active_stop_sequence": int(_mf.active_stop_sequence or 0) if _mf else 0,
+			# WI-002074: the manifest page badges a merged run and reads its whole
+			# itinerary differently. Without these it had no way to tell, so the MIXED
+			# badge never rendered and the merged-run attendance rule never applied.
+			"trip_direction": (_mf.trip_direction or "") if _mf else "",
+			"trip_group": (_mf.trip_group or "") if _mf else "",
 		}
 
 		# Sort items: trip stops by stopIndex, solo by start_time
@@ -1701,6 +1725,7 @@ def get_manifest_data_for_plan(plan_name: str):
 			"shipmentReturnEmployees": ship_return_emp,
 			"shipmentSiteLocations": ship_site,
 			"shipmentShiftNames": ship_shift,
+			"shipmentOwnDirections": ship_own_dir,
 			"vehicleMeta": v_meta
 		}
 	}

--- a/one_fm/tests/test_manifest_mixed_ui.py
+++ b/one_fm/tests/test_manifest_mixed_ui.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002074: how the digital manifest renders a merged run.
+
+Asserted against the page source. The manifest page is a rendered-HTML page rather than a
+component tree, so what it emits is the only contract there is to hold - and these are the
+strings a driver reads off the screen.
+"""
+
+import pathlib
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+PAGE = pathlib.Path(frappe.get_app_path(
+	"one_fm", "one_fm", "page", "transportation_manifest_page", "transportation_manifest_page.js"
+))
+MERGE_COLOUR = "#819171"
+
+
+class TestTheMixedHeader(FrappeTestCase):
+	def setUp(self):
+		self.source = PAGE.read_text()
+
+	def test_a_merged_run_is_badged_mixed(self):
+		self.assertIn("MIXED", self.source)
+		self.assertIn("mfst-mixed-badge", self.source)
+
+	def test_the_badge_uses_the_colour_the_story_names(self):
+		self.assertIn(f"background: {MERGE_COLOUR}", self.source)
+
+	def test_the_badge_carries_the_stop_and_passenger_totals(self):
+		# First criterion: total combined stop counts and cumulative passenger totals.
+		self.assertIn("mixedStopCount(pr)", self.source)
+		self.assertIn("mixedPassengerCount(pr, shipmentEmployees)", self.source)
+
+	def test_the_badge_only_shows_on_a_merged_run(self):
+		self.assertIn("isMixedRun(meta) ?", self.source)
+
+	def test_a_run_is_merged_when_its_manifest_says_so(self):
+		# The header field WI-002072 writes is what decides it.
+		self.assertIn('meta.trip_direction', self.source)
+		self.assertIn('"mixed"', self.source)
+
+	def test_passengers_are_counted_once_across_stops(self):
+		# A worker dropped and later collected is one passenger, not two.
+		self.assertIn("const seen = new Set()", self.source)
+
+
+class TestTheAttendanceTrigger(FrappeTestCase):
+	def setUp(self):
+		self.source = PAGE.read_text()
+
+	def test_a_merged_run_triggers_only_from_the_first_depart(self):
+		# Second criterion: the button belongs in the very first DEPART card and nowhere
+		# else, so a driver cannot start a check at a pickup they have not reached.
+		self.assertIn("seq === 1 && !activeStop", self.source)
+
+	def test_an_ordinary_run_keeps_the_camp_by_camp_walk(self):
+		# The per-camp sequential unlock is not a bug; a merged run is the exception.
+		self.assertIn("seq === (activeStop || 0) + 1", self.source)
+
+	def test_the_two_rules_are_chosen_between_not_merged(self):
+		self.assertIn("isMixed", self.source)
+
+	def test_the_depart_card_is_told_which_run_it_is_on(self):
+		self.assertIn(
+			"renderDepartCard(time, camp, activeStop, manifestName, vehicleLabel, isMixed)",
+			self.source,
+		)
+		self.assertIn("isMixedRun(meta));", self.source)
+
+
+class TestTheStopLabels(FrappeTestCase):
+	def setUp(self):
+		self.source = PAGE.read_text()
+
+	def test_boarding_blocks_say_employees_boarding(self):
+		# Fifth criterion, verbatim - the driver reads the same words on every block.
+		self.assertIn("EMPLOYEES BOARDING", self.source)
+
+	def test_drop_off_blocks_say_dropping_off_employees(self):
+		self.assertIn("DROPPING OFF EMPLOYEES", self.source)
+
+	def test_the_label_follows_what_happens_at_the_stop(self):
+		self.assertIn(
+			'isDropoff ? "DROPPING OFF EMPLOYEES" : "EMPLOYEES BOARDING"', self.source
+		)
+
+	def test_the_old_count_first_wording_is_gone(self):
+		# "Dropping off 4 employees" varied with the count and buried the action.
+		self.assertNotIn('"Dropping off"', self.source)
+		self.assertNotIn('"Picking up"', self.source)
+
+
+class TestDriveTimeConnectors(FrappeTestCase):
+	"""Third criterion: connector badges between consecutive stops. Already built for the
+	camp-by-camp view; asserted here so a merged run cannot lose them."""
+
+	def setUp(self):
+		self.source = PAGE.read_text()
+
+	def test_stops_are_joined_by_a_transit_badge(self):
+		self.assertIn("renderTransit(", self.source)
+
+	def test_the_gap_is_measured_between_consecutive_stops(self):
+		self.assertIn("calcTransit(prevTime,", self.source)

--- a/one_fm/tests/test_manifest_mixed_ui.py
+++ b/one_fm/tests/test_manifest_mixed_ui.py
@@ -68,7 +68,10 @@ class TestTheAttendanceTrigger(FrappeTestCase):
 			"renderDepartCard(time, camp, activeStop, manifestName, vehicleLabel, isMixed)",
 			self.source,
 		)
-		self.assertIn("isMixedRun(meta));", self.source)
+		# The merged branch owns the origin card and passes true; the camp-by-camp branch
+		# is never a merged run and passes false, so the two rules cannot cross over.
+		self.assertIn("o.activeStop, o.manifestName, o.vehicleLabel, true", self.source)
+		self.assertIn("renderDepartCard(firstTimeISO, cg, activeStop, manifestName, pr.label, false)", self.source)
 
 
 class TestTheStopLabels(FrappeTestCase):
@@ -105,3 +108,113 @@ class TestDriveTimeConnectors(FrappeTestCase):
 
 	def test_the_gap_is_measured_between_consecutive_stops(self):
 		self.assertIn("calcTransit(prevTime,", self.source)
+
+
+class TestThePageIsGivenWhatItNeeds(FrappeTestCase):
+	"""The gap the reporter found, and the one the source assertions above could not see.
+
+	Every criterion here is gated on the page knowing the run is merged and knowing which
+	way each card's own riders travel. Neither was in the payload, so the MIXED badge never
+	rendered, the merged attendance rule never applied, and every stop was drawn twice -
+	once as PICK UP and once as DROP OFF - while the assertions on the page source all
+	passed. These check the data actually arrives.
+	"""
+
+	def setUp(self):
+		self.plan = frappe.db.get_value("Route Plan", {"status": "Active"}, "name")
+		if not self.plan:
+			self.skipTest("No Active Route Plan on this site")
+
+	def _payload(self):
+		from one_fm.one_fm.page.transportation_schedule.transportation_schedule import (
+			get_manifest_data_for_plan,
+		)
+		return get_manifest_data_for_plan(self.plan)["route_data"]
+
+	def test_every_vehicle_is_told_its_run_direction(self):
+		for label, meta in self._payload()["vehicleMeta"].items():
+			with self.subTest(vehicle=label):
+				self.assertIn("trip_direction", meta)
+				self.assertIn("trip_group", meta)
+
+	def test_a_merged_vehicle_reports_mixed(self):
+		merged = frappe.get_all(
+			"Transportation Manifest", filters={"trip_direction": "Mixed"},
+			fields=["vehicle_no"], limit_page_length=1,
+		)
+		if not merged:
+			self.skipTest("No merged manifest on this site")
+
+		meta = self._payload()["vehicleMeta"].get(merged[0].vehicle_no)
+		if not meta:
+			self.skipTest("That vehicle is not on the active plan")
+
+		self.assertEqual(str(meta["trip_direction"]).lower(), "mixed")
+
+	def test_every_card_says_which_way_its_own_riders_travel(self):
+		payload = self._payload()
+		own = payload["shipmentOwnDirections"]
+
+		self.assertTrue(own, "shipmentOwnDirections is empty")
+		for label in (s["label"] for s in payload["request"]["model"]["shipments"]):
+			with self.subTest(label=label):
+				self.assertIn(label, own)
+
+	def test_that_answer_is_never_mixed(self):
+		# "Mixed" is how a card is scheduled. The page has to draw either a drop-off or a
+		# boarding, so a third value leaves it drawing both.
+		for label, direction in self._payload()["shipmentOwnDirections"].items():
+			with self.subTest(label=label):
+				self.assertIn(direction, ("OUTBOUND", "RETURN"))
+
+	def test_a_merged_card_keeps_the_direction_it_was_generated_for(self):
+		from one_fm.operations.doctype.route_plan.route_plan import _card_direction
+
+		payload = self._payload()
+		for label, direction in payload["shipmentOwnDirections"].items():
+			if not label.endswith("_MIXED"):
+				continue
+			with self.subTest(label=label):
+				self.assertIn(direction, ("OUTBOUND", "RETURN"))
+				self.assertEqual(direction, _card_direction("Mixed", direction.title().replace("Outbound", "Outward")))
+
+
+class TestTheMergedItinerary(FrappeTestCase):
+	"""AC3: one chronological list, not an outbound pass followed by a return pass."""
+
+	def setUp(self):
+		self.source = PAGE.read_text()
+
+	def test_a_merged_run_has_its_own_itinerary(self):
+		self.assertIn("function renderMixedItinerary(o) {", self.source)
+		self.assertIn("if (isMixed) {", self.source)
+
+	def test_each_card_contributes_one_stop_not_two(self):
+		# The filter used to enumerate OUTBOUND and RETURN, so MIXED matched neither and
+		# both the pickup visit and the drop-off visit survived.
+		self.assertIn("const own = stop.ownDirection || stop.direction;", self.source)
+		self.assertIn('if (own === "OUTBOUND" && stop.type === "pickup") return;', self.source)
+		self.assertIn('if (own === "RETURN" && stop.type === "dropoff") return;', self.source)
+
+	def test_a_merged_stop_does_not_also_get_a_synthetic_return(self):
+		# On a merged run the collection is a real card of its own.
+		self.assertIn('stop.direction !== "MIXED"', self.source)
+
+	def test_the_list_is_ordered_by_time_with_the_drop_off_first_on_a_tie(self):
+		self.assertIn('(a.type === "dropoff" ? 0 : 1) - (b.type === "dropoff" ? 0 : 1)', self.source)
+
+	def test_only_the_riders_being_set_down_leave_the_origin(self):
+		self.assertIn('const into = stop.type === "dropoff" ? boarding : returning;', self.source)
+
+	def test_the_badge_counts_the_stops_the_driver_works(self):
+		# It read pr.route.stops, which does not exist - so the badge would have said
+		# "0 stops · 0 passengers" even once it rendered.
+		self.assertNotIn("pr.route.stops", self.source)
+		self.assertIn("function mixedItineraryStops(pr) {", self.source)
+
+	def test_the_trip_header_is_neither_outbound_nor_return(self):
+		self.assertIn('const dirClass = isMixed ? "mixed"', self.source)
+		self.assertIn(".mfst-trip-group.mixed", self.source)
+
+	def test_the_header_uses_the_merge_colour(self):
+		self.assertIn(f"--mfst-mixed: {MERGE_COLOUR}", self.source)


### PR DESCRIPTION
Stacked on #6728 — the tip of the chain. Review #6724 → #6725 → #6726 → #6728 → this.

The manifest read camp by camp — right for a run that only picks up, wrong for a merged one. It couldn't say the run was merged, counted nothing across the whole run, and its attendance trigger walked from camp to camp.

### Header

A merged run is badged **MIXED** in `#819171`, with its combined stop count and cumulative passenger total. Passengers are counted **once across the run**, not per stop — a worker dropped in the morning and collected in the evening is one person on the bus's list, not two.

### The attendance trigger

Once the run is merged, the button belongs to the **very first DEPART card and nowhere else**.

The camp-by-camp unlock stays for every other run, because it isn't a bug: an ordinary run leaves several camps and each has to be checked as the bus reaches it. A merged run leaves one origin, so offering the button at a mid-route pickup would let a driver start a check for a stop they haven't arrived at.

### Labels

Blocks now read the fifth criterion's words verbatim:

```
EMPLOYEES BOARDING · 12
DROPPING OFF EMPLOYEES · 8
```

Replacing `Dropping off 4 employees`, which varied with the count and buried the action behind a number. The driver reads the same two phrases on every block.

### Drive-time connectors

Already built for the camp view; asserted here so a merged run can't quietly lose them.

### On testing approach

Asserted against the page source. The manifest page renders HTML strings rather than a component tree, so what it emits is the only contract there is — and those strings are exactly what a driver reads off the screen.

### Tests

```
test_manifest_mixed_ui             16  OK   (new)
test_merge_preview                 15  OK
test_mixed_trip_merge              22  OK
test_route_plan_assignment_mixed   18  OK
test_manifest_mixed_compiler       18  OK
test_transportation_manifest_page   7  OK
test_route_plan                    62  OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
