### PR TITLE
Restore WI-001654: Take Action opens the roster pre-filtered

### DIFF
--- a/one_fm/operations/doctype/roster_day_off_checker/roster_day_off_checker.js
+++ b/one_fm/operations/doctype/roster_day_off_checker/roster_day_off_checker.js
@@ -4,8 +4,42 @@
 frappe.ui.form.on('Roster Day Off Checker', {
     refresh: function(frm) {
         add_make_cdo_button(frm);
+        add_take_action_button(frm);
     }
 });
+
+// WI-001654: open the roster already filtered to this employee's allocation, so a
+// supervisor can correct the day off schedule without rebuilding the filters by hand.
+function add_take_action_button(frm) {
+    if (!frm.is_new()) {
+        frm.add_custom_button(__('Take Action'), function() {
+            open_filtered_roster(frm);
+        }).addClass('btn-primary');
+    }
+}
+
+function open_filtered_roster(frm) {
+    frappe.call({
+        method: 'one_fm.operations.doctype.roster_day_off_checker.roster_day_off_checker.get_take_action_data',
+        args: { checker: frm.doc.name },
+        freeze: true,
+        freeze_message: __('Opening roster...'),
+        callback: function(r) {
+            if (!r.message || !r.message.path) {
+                frappe.msgprint(__('Unable to determine the roster filters for this record.'));
+                return;
+            }
+
+            // Same handling as the Roster Client Day Off Checker: build the URL from the
+            // returned params, dropping any the server could not resolve.
+            let url = new URL(r.message.path, window.location.origin);
+            Object.entries(r.message.params || {}).forEach(function([key, value]) {
+                if (value) url.searchParams.set(key, value);
+            });
+            window.open(url.toString(), '_blank');
+        }
+    });
+}
 
 function add_make_cdo_button(frm) {
     if (!frm.doc.__islocal && 

--- a/one_fm/operations/doctype/roster_day_off_checker/roster_day_off_checker.py
+++ b/one_fm/operations/doctype/roster_day_off_checker/roster_day_off_checker.py
@@ -788,3 +788,48 @@ def update_attendance_to_cdo(employee, attendance_date):
             'error': True,
             'message': f'Failed to update attendance: {str(e)}'
         }
+
+@frappe.whitelist()
+def get_take_action_data(checker: str) -> dict:
+	"""
+	Redirect path and roster filters for the Take Action button (WI-001654).
+
+	Returns the same {path, params} shape as the Roster Client Day Off Checker's
+	equivalent, so the client handling is identical.
+
+	The checker stores the employee's allocations as plain text (project_allocation,
+	site_allocation, shift_allocation) and carries no operations role, so anything
+	missing is resolved from the Employee record - which is also where the role lives.
+	"""
+	doc = frappe.get_doc("Roster Day Off Checker", checker)
+	doc.check_permission("read")
+
+	employee = (
+		frappe.db.get_value(
+			"Employee",
+			doc.employee,
+			["project", "site", "shift", "custom_operations_role_allocation", "employee_id", "employee_name"],
+			as_dict=True,
+		)
+		or frappe._dict()
+	)
+
+	# The roster reads these off the query string in setup_preset_filters(); year and
+	# month drive which month the calendar opens on.
+	date = getdate(doc.date) if doc.date else getdate(nowdate())
+
+	return {
+		"path": "/app/roster",
+		"params": {
+			"main_view": "roster",
+			"sub_view": "roster",
+			"employee_id": doc.employee_id or employee.employee_id,
+			"employee_name": doc.employee_name or employee.employee_name,
+			"project": doc.project_allocation or employee.project,
+			"site": doc.site_allocation or employee.site,
+			"shift": doc.shift_allocation or employee.shift,
+			"operations_role": employee.custom_operations_role_allocation,
+			"year": str(date.year),
+			"month": str(date.month),
+		},
+	}

--- a/one_fm/operations/doctype/roster_day_off_checker/test_roster_day_off_checker.py
+++ b/one_fm/operations/doctype/roster_day_off_checker/test_roster_day_off_checker.py
@@ -1,13 +1,30 @@
 # Copyright (c) 2022, ONE FM and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import getdate
 
 from one_fm.operations.doctype.roster_day_off_checker.roster_day_off_checker import (
 	calculate_expected_days_off,
+	get_take_action_data,
 	is_exit_before_month_midpoint,
 )
+
+MODULE = "one_fm.operations.doctype.roster_day_off_checker.roster_day_off_checker"
+
+
+class StubChecker(frappe._dict):
+	"""Stand-in for the checker document.
+
+	A module-level class rather than a _dict carrying a lambda: Frappe pickles values it
+	caches, and a locally defined lambda cannot be pickled.
+	"""
+
+	def check_permission(self, *args, **kwargs):
+		return None
 
 
 class TestRosterDayOffChecker(FrappeTestCase):
@@ -104,3 +121,107 @@ class TestCalculateExpectedDaysOff(FrappeTestCase):
 		# 20 applicable / 30 days * 4 = 2.666...
 		self.assertAlmostEqual(calculate_expected_days_off(20, 30, 4), 20 / 30 * 4)
 		self.assertEqual(round(calculate_expected_days_off(20, 30, 4)), 3)
+
+
+
+class TestTakeActionData(FrappeTestCase):
+	"""
+	WI-001654: Take Action opens the roster pre-filtered by employee, project, site, shift
+	and role. The checker document and Employee lookup are stubbed so the filter
+	resolution is tested without Employee/Operations fixtures.
+	"""
+
+	def _checker(self, **overrides):
+		doc = StubChecker(
+			{
+				"name": "OPR-RDOC-TEST",
+				"employee": "EMP-TEST-0001",
+				"employee_id": "EMPID-1",
+				"employee_name": "Test Worker",
+				"project_allocation": "Project A",
+				"site_allocation": "Site A",
+				"shift_allocation": "Shift A",
+				"date": "2026-07-11",
+			}
+		)
+		doc.update(overrides)
+		return doc
+
+	def _employee(self, **overrides):
+		employee = frappe._dict(
+			{
+				"project": "Employee Project",
+				"site": "Employee Site",
+				"shift": "Employee Shift",
+				"custom_operations_role_allocation": "Role A",
+				"employee_id": "EMPID-FALLBACK",
+				"employee_name": "Fallback Name",
+			}
+		)
+		employee.update(overrides)
+		return employee
+
+	def _run(self, checker=None, employee="default"):
+		employee_value = self._employee() if employee == "default" else employee
+		with patch(f"{MODULE}.frappe.get_doc", return_value=checker or self._checker()):
+			with patch(f"{MODULE}.frappe.db.get_value", return_value=employee_value):
+				return get_take_action_data("OPR-RDOC-TEST")
+
+	def test_every_filter_the_ac_asks_for_is_returned(self):
+		params = self._run()["params"]
+
+		# AC: Employee Name & ID, Project, Site, Shift, Role
+		self.assertEqual(params["employee_id"], "EMPID-1")
+		self.assertEqual(params["employee_name"], "Test Worker")
+		self.assertEqual(params["project"], "Project A")
+		self.assertEqual(params["site"], "Site A")
+		self.assertEqual(params["shift"], "Shift A")
+		self.assertEqual(params["operations_role"], "Role A")
+
+	def test_redirects_to_the_roster(self):
+		result = self._run()
+
+		self.assertEqual(result["path"], "/app/roster")
+		# These two open the right view; the rest are read as page filters.
+		self.assertEqual(result["params"]["main_view"], "roster")
+		self.assertEqual(result["params"]["sub_view"], "roster")
+
+	def test_calendar_opens_on_the_checker_month(self):
+		params = self._run()["params"]
+
+		self.assertEqual(params["year"], "2026")
+		self.assertEqual(params["month"], "7")
+
+	def test_allocations_fall_back_to_the_employee_record(self):
+		# The checker stores allocations as free text and they can be blank. The Employee
+		# record is the fallback, and is the only source for the operations role.
+		checker = self._checker(project_allocation="", site_allocation=None, shift_allocation="")
+		params = self._run(checker=checker)["params"]
+
+		self.assertEqual(params["project"], "Employee Project")
+		self.assertEqual(params["site"], "Employee Site")
+		self.assertEqual(params["shift"], "Employee Shift")
+		self.assertEqual(params["operations_role"], "Role A")
+
+	def test_employee_identity_falls_back_too(self):
+		checker = self._checker(employee_id="", employee_name="")
+		params = self._run(checker=checker)["params"]
+
+		self.assertEqual(params["employee_id"], "EMPID-FALLBACK")
+		self.assertEqual(params["employee_name"], "Fallback Name")
+
+	def test_missing_employee_record_does_not_raise(self):
+		# get_value returns None when the Employee is gone. The button should still open
+		# the roster with whatever the checker itself holds rather than erroring.
+		params = self._run(employee=None)["params"]
+
+		self.assertEqual(params["project"], "Project A")
+		self.assertIsNone(params["operations_role"])
+
+	def test_no_date_falls_back_to_today(self):
+		checker = self._checker(date=None)
+		params = self._run(checker=checker)["params"]
+
+		today = getdate(frappe.utils.nowdate())
+		self.assertEqual(params["year"], str(today.year))
+		self.assertEqual(params["month"], str(today.month))


### PR DESCRIPTION
Re-lands **WI-001654** on `version-15`. Companion to one_bpmn #539 — same root cause, same 8 August cleanup run.

## Why this is missing

The 8 August cleanup (`sprint_29th-4th`) reverted WI-001654 while it was not Done. That revert reached `test-production` and `version-15` but **never `staging`**, so staging kept the code. WI-001654 has since become **Done**, so the 5th–11th August release should have re-landed it — but merging `test-production` into the sprint branch silently re-applied the old revert.

**This is not a regression.** `version-15` never had this code, so production has lost nothing; the release simply failed to deliver work that was ready.

## Approach

`git revert a7076cccd` off `version-15`, not a cherry-pick of the original — the three-way merge preserves everything that has landed on these files since. Every touched file is now **byte-identical to `staging`**, verified with `git diff upstream/staging HEAD`.

## What comes back

- `roster_day_off_checker.py` — `get_take_action_data(checker)`, the whitelisted method returning the `/app/roster` redirect path plus employee / project / site / shift / operations-role / year / month filters
- `roster_day_off_checker.js` — `add_take_action_button(frm)` and `open_filtered_roster(frm)`
- `test_roster_day_off_checker.py` — 121 lines of coverage

3 files, +201/-1. Clean revert, no conflicts. `py_compile` and `node --check` pass.

Fix upstream too: these reverts need applying to `staging`, or the code returns next sprint and the merge drops it again.