### PR TITLE
Restore WI-001686: Attendance as a Connection on Event Staff

### DIFF
--- a/one_fm/custom/custom_field/attendance.py
+++ b/one_fm/custom/custom_field/attendance.py
@@ -85,6 +85,19 @@ def get_attendance_custom_fields():
                 "read_only": 1
             },
             {
+                # WI-001686: what makes Attendance a Connection on Event Staff. Read from
+                # the Shift Assignment, the same hop custom_client_event above takes -
+                # Client Event has no Event Staff to fetch, it is the far end of a
+                # one-to-many.
+                "fieldname": "custom_event_staff",
+                "fieldtype": "Link",
+                "insert_after": "custom_client_event",
+                "label": "Event Staff",
+                "options": "Event Staff",
+                "fetch_from": "shift_assignment.event_staff",
+                "read_only": 1
+            },
+            {
                 "fieldname": "shift_assignment",
                 "fieldtype": "Link",
                 "insert_after": "section_break_17",

--- a/one_fm/one_fm/doctype/event_staff/event_staff.js
+++ b/one_fm/one_fm/doctype/event_staff/event_staff.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on("Event Staff", {
 	// Frontend replace warnings have been removed as backend handles roster overlap directly.
-  
+
 	client_event(frm) {
 		if (frm.doc.client_event) {
 			frappe.db.get_value("Client Event", frm.doc.client_event,

--- a/one_fm/one_fm/doctype/event_staff/event_staff.json
+++ b/one_fm/one_fm/doctype/event_staff/event_staff.json
@@ -182,6 +182,10 @@
   {
    "link_doctype": "Shift Assignment",
    "link_fieldname": "event_staff"
+  },
+  {
+   "link_doctype": "Attendance",
+   "link_fieldname": "custom_event_staff"
   }
  ],
  "modified": "2026-03-16 10:01:08.807734",

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -547,6 +547,7 @@ one_fm.patches.v15_0.add_employee_schedule_suspension_workflow #2026-07-24
 one_fm.patches.v15_0.add_accommodation_leave_movement_assignment_rules #2026-07-30
 one_fm.patches.v15_0.add_employee_site_supervisor_fields #2026-07-30
 one_fm.patches.v15_0.add_vehicle_list_view_columns #2026-07-30
+one_fm.patches.v15_0.add_attendance_event_staff_field #2026-08-01
 one_fm.patches.v15_0.migrate_penalty_applied_level #2026-07-30
 one_fm.patches.v15_0.rename_penalty_fields_to_ba_layout #2026-08-02
 one_fm.patches.v15_0.add_penalty_and_investigation_assignment_rules #2026-08-01 rerun for payroll officer


### PR DESCRIPTION
Re-lands **WI-001686** on `version-15`. Companion to one_bpmn #539 — same root cause, same 8 August cleanup run.

## Why this is missing

The 8 August cleanup (`sprint_29th-4th`) reverted WI-001686 while it was not Done. That revert reached `test-production` and `version-15` but **never `staging`**, so staging kept the code. WI-001686 has since become **Done**, so the 5th–11th August release should have re-landed it — but merging `test-production` into the sprint branch silently re-applied the old revert.

**This is not a regression.** `version-15` never had this code, so production has lost nothing; the release simply failed to deliver work that was ready.

## Approach

`git revert 665b24629` off `version-15`, not a cherry-pick of the original — the three-way merge preserves everything that has landed on these files since. Every touched file is now **byte-identical to `staging`**, verified with `git diff upstream/staging HEAD`.

## What comes back

- `custom/custom_field/attendance.py` — the `custom_event_staff` Custom Field: Link to `Event Staff`, `insert_after: custom_client_event`, `fetch_from: shift_assignment.event_staff`, `read_only: 1`
- `event_staff.json` / `event_staff.js` — the connections wiring
- `patches.txt` — the `add_attendance_event_staff_field` entry

**This one is urgent.** The release already restored the patch file `add_attendance_event_staff_field.py` and left its `patches.txt` entry in place on `version-15`, but not the Custom Field definition the patch targets. So the next production migrate runs that patch against a field that does not exist. This PR closes that gap.

4 files, +20/-2. One whitespace-only conflict in `event_staff.js` (trailing spaces vs a blank line), resolved to the restored state.

> The 1 August revert `f9061fc87` also touched this work item, but undoing the 8 August one alone brings all three files to parity with `staging`, so it is deliberately **not** reverted here.

Fix upstream too: these reverts need applying to `staging`, or the code returns next sprint and the merge drops it again.