### PR TITLE
Restore WI-001838: penalty tiers assign through Process Tasks

### DIFF
--- a/one_fm/custom/assignment_rule/penalty_and_investigation_general_manager.json
+++ b/one_fm/custom/assignment_rule/penalty_and_investigation_general_manager.json
@@ -8,7 +8,7 @@
   "assign_condition": "workflow_state == \"Pending General Manager\"",
   "unassign_condition": "workflow_state != \"Pending General Manager\"",
   "close_condition": "",
-  "rule": "Based on Field",
+  "rule": "Based on Process Task",
   "field": "owner",
   "doctype": "Assignment Rule",
   "users": [],

--- a/one_fm/custom/assignment_rule/penalty_and_investigation_hr_administrator.json
+++ b/one_fm/custom/assignment_rule/penalty_and_investigation_hr_administrator.json
@@ -8,7 +8,7 @@
   "assign_condition": "workflow_state == \"Pending HR Administrator\"",
   "unassign_condition": "workflow_state != \"Pending HR Administrator\"",
   "close_condition": "",
-  "rule": "Based on Field",
+  "rule": "Based on Process Task",
   "field": "owner",
   "doctype": "Assignment Rule",
   "users": [],

--- a/one_fm/custom/assignment_rule/penalty_and_investigation_legal_manager.json
+++ b/one_fm/custom/assignment_rule/penalty_and_investigation_legal_manager.json
@@ -8,7 +8,7 @@
   "assign_condition": "workflow_state == \"Pending Legal Manager\"",
   "unassign_condition": "workflow_state != \"Pending Legal Manager\"",
   "close_condition": "",
-  "rule": "Based on Field",
+  "rule": "Based on Process Task",
   "field": "owner",
   "doctype": "Assignment Rule",
   "users": [],

--- a/one_fm/custom/assignment_rule/penalty_and_investigation_payroll_officer.json
+++ b/one_fm/custom/assignment_rule/penalty_and_investigation_payroll_officer.json
@@ -8,7 +8,7 @@
   "assign_condition": "workflow_state == \"Pending Payroll Officer\"",
   "unassign_condition": "workflow_state != \"Pending Payroll Officer\"",
   "close_condition": "",
-  "rule": "Based on Field",
+  "rule": "Based on Process Task",
   "field": "owner",
   "doctype": "Assignment Rule",
   "assignment_days": [

--- a/one_fm/tests/test_penalty_assignment_rules.py
+++ b/one_fm/tests/test_penalty_assignment_rules.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2026, ONE FM and contributors
 # See license.txt
-"""Tests for the Penalty And Investigation assignment rules (WI-001798).
+"""Tests for the Penalty And Investigation assignment rules (WI-001798, WI-001838).
 
-One rule per waiting state of the WI-001796 workflow, shipped as supplied: "Based on
-Field" on `owner`, assigning on workflow_state and closing when it moves on.
+One rule per waiting state of the WI-001796 workflow, assigning on workflow_state and
+closing when it moves on. WI-001838 changed how they pick the assignee: "Based on
+Process Task" instead of "Based on Field" on `owner`, so the process owner can hand a
+tier to someone else from the Process Task without a code change.
 """
 
 import frappe
@@ -30,6 +32,16 @@ RULES = {
 	),
 }
 
+# The Process Task each rule now takes its assignee from (WI-001838).
+PROCESS_NAME = "Penalty"
+
+TASKS = {
+	"Penalty and Investigation-HR Administrator": "Assigning HR Administrator",
+	"Penalty and Investigation-Legal Manager": "Assigning Legal Manager",
+	"Penalty and Investigation-General Manager": "Assigning General Manager",
+	"Penalty and Investigation-Payroll Officer": "Assigning Payroll Officer",
+}
+
 WORKFLOW = "Penalty & Investigation"
 
 FIELDS = (
@@ -37,6 +49,15 @@ FIELDS = (
 	"is_assignment_rule_with_workflow", "assign_condition", "close_condition",
 	"rule", "field",
 )
+
+
+def _conditions(rule):
+	"""Every condition the rule actually carries, skipping the ones left empty."""
+	return [
+		c
+		for c in (rule.assign_condition, rule.unassign_condition, rule.close_condition)
+		if c
+	]
 
 
 def _rule(name):
@@ -63,26 +84,75 @@ class TestRulesMatchWhatWasSupplied(FrappeTestCase):
 					msg=f"{name}.{field}",
 				)
 
-	def test_they_select_the_assignee_from_a_field(self):
+	def test_they_select_the_assignee_from_a_process_task(self):
 		for name in RULES:
-			rule = _rule(name)
-			self.assertEqual(rule.rule, "Based on Field", msg=name)
-			self.assertEqual(rule.field, "owner", msg=name)
-
-	def test_the_field_they_assign_on_exists(self):
-		# Assigning on a missing field silently assigns to nobody.
-		meta = frappe.get_meta("Penalty And Investigation")
-		for name in RULES:
-			field = _rule(name).field
-			self.assertTrue(
-				field in frappe.model.default_fields or meta.has_field(field), msg=field
-			)
+			self.assertEqual(_rule(name).rule, "Based on Process Task", msg=name)
 
 	def test_they_are_enabled_and_cover_every_day(self):
 		for name in RULES:
 			rule = _rule(name)
 			self.assertFalse(rule.disabled, msg=name)
 			self.assertEqual(len(rule.assignment_days), 7, msg=name)
+
+
+class TestTheProcessTaskTheyAssignThrough(FrappeTestCase):
+	"""WI-001838. `get_user_based_on_process_task` reads one field - the linked task's
+	`employee_user` - and returns it with no fallback, so an unlinked rule or a task
+	whose employee has no user assigns nobody and the penalty just sits there.
+	"""
+
+	def test_every_rule_is_linked_to_a_process_task(self):
+		for name in RULES:
+			self.assertTrue(_rule(name).custom_routine_task, msg=name)
+
+	def test_the_linked_task_exists_and_is_the_one_for_that_tier(self):
+		for name, task in TASKS.items():
+			linked = _rule(name).custom_routine_task
+			self.assertTrue(frappe.db.exists("Process Task", linked), msg=name)
+			self.assertEqual(
+				frappe.db.get_value("Process Task", linked, ["process_name", "task"]),
+				(PROCESS_NAME, task),
+				msg=name,
+			)
+
+	def test_no_two_tiers_share_a_task(self):
+		# Two rules on one task means both tiers land on the same person, which is the
+		# owner-assignment problem WI-001838 set out to remove.
+		linked = [_rule(name).custom_routine_task for name in RULES]
+		self.assertEqual(len(set(linked)), len(linked), msg=linked)
+
+	def test_the_task_resolves_to_a_user_who_can_be_assigned(self):
+		for name in RULES:
+			user = frappe.db.get_value(
+				"Process Task", _rule(name).custom_routine_task, "employee_user"
+			)
+			# A disabled user is not asserted against: assign_to still writes the ToDo and
+			# only skips the notification, so it is a data question for the process owner,
+			# not something this rule can get wrong.
+			self.assertTrue(user, msg=f"{name}: task names no employee_user")
+			self.assertTrue(frappe.db.exists("User", user), msg=f"{name}: {user}")
+
+	def test_the_rule_hands_back_that_user(self):
+		# The path the framework takes when a penalty enters the waiting state. The
+		# selection ignores the document now, so the tier's assignee no longer depends on
+		# who raised the penalty - which is the whole point of the change.
+		for name, state in ((n, s) for n, (_f, s) in RULES.items()):
+			rule = _rule(name)
+			expected = frappe.db.get_value(
+				"Process Task", rule.custom_routine_task, "employee_user"
+			)
+			doc = frappe._dict(
+				doctype="Penalty And Investigation", workflow_state=state, owner="Administrator"
+			)
+			self.assertEqual(rule.get_user(doc), expected, msg=name)
+			self.assertNotEqual(rule.get_user(doc), doc.owner, msg=name)
+
+	def test_the_linked_task_is_active(self):
+		for name in RULES:
+			self.assertTrue(
+				frappe.db.get_value("Process Task", _rule(name).custom_routine_task, "is_active"),
+				msg=name,
+			)
 
 
 class TestConditionsMatchTheWorkflow(FrappeTestCase):
@@ -105,10 +175,12 @@ class TestConditionsMatchTheWorkflow(FrappeTestCase):
 		self.assertEqual(waiting - covered, set(), msg="a waiting state has no rule")
 
 	def test_each_rule_names_its_own_state(self):
+		# The supplied definition leaves close_condition empty and does the work in
+		# unassign_condition, which is the one AssignmentRule.apply_unassign evaluates.
 		for name, (_json_file, state) in RULES.items():
 			rule = _rule(name)
 			self.assertIn(f'== "{state}"', rule.assign_condition, msg=name)
-			self.assertIn(f'!= "{state}"', rule.close_condition, msg=name)
+			self.assertIn(f'!= "{state}"', rule.unassign_condition, msg=name)
 
 	def test_the_notification_only_renders_fields_the_penalty_has(self):
 		meta = frappe.get_meta("Penalty And Investigation")
@@ -133,7 +205,7 @@ class TestConditionsActuallyEvaluate(FrappeTestCase):
 		states = [d.state for d in frappe.get_doc("Workflow", WORKFLOW).states]
 		for name in RULES:
 			rule = _rule(name)
-			for condition in (rule.assign_condition, rule.close_condition or ""):
+			for condition in _conditions(rule):
 				if not condition:
 					continue
 				for state in states + [None, ""]:
@@ -147,18 +219,18 @@ class TestConditionsActuallyEvaluate(FrappeTestCase):
 		# which is handed {"doc": ...}, but a NameError here.
 		for name in RULES:
 			rule = _rule(name)
-			for condition in (rule.assign_condition, rule.close_condition or ""):
+			for condition in _conditions(rule):
 				self.assertNotIn("doc.", condition, msg=name)
 
-	def test_each_rule_assigns_on_its_own_state_and_closes_on_the_others(self):
+	def test_each_rule_assigns_on_its_own_state_and_releases_on_the_others(self):
 		states = [d.state for d in frappe.get_doc("Workflow", WORKFLOW).states]
 		for name, (_json_file, own_state) in RULES.items():
 			rule = _rule(name)
 			self.assertTrue(self._eval(rule.assign_condition, own_state), msg=name)
-			self.assertFalse(self._eval(rule.close_condition, own_state), msg=name)
+			self.assertFalse(self._eval(rule.unassign_condition, own_state), msg=name)
 			for other in set(states) - {own_state}:
 				self.assertFalse(self._eval(rule.assign_condition, other), msg=f"{name} on {other}")
-				self.assertTrue(self._eval(rule.close_condition, other), msg=f"{name} on {other}")
+				self.assertTrue(self._eval(rule.unassign_condition, other), msg=f"{name} on {other}")
 
 
 class TestAssignmentDays(FrappeTestCase):


### PR DESCRIPTION
Re-lands **WI-001838** on `version-15`. Companion to one_bpmn #539 — same root cause, same 8 August cleanup run.

## Why this is missing

The 8 August cleanup (`sprint_29th-4th`) reverted WI-001838 while it was not Done. That revert reached `test-production` and `version-15` but **never `staging`**, so staging kept the code. WI-001838 has since become **Done**, so the 5th–11th August release should have re-landed it — but merging `test-production` into the sprint branch silently re-applied the old revert.

**This is not a regression.** `version-15` never had this code, so production has lost nothing; the release simply failed to deliver work that was ready.

## Approach

`git revert 7af9fdd5b` off `version-15`, not a cherry-pick of the original — the three-way merge preserves everything that has landed on these files since. Every touched file is now **byte-identical to `staging`**, verified with `git diff upstream/staging HEAD`.

## What comes back

- 4 assignment rules — `penalty_and_investigation_{general_manager,hr_administrator,legal_manager,payroll_officer}.json` — flip from `"rule": "Based on Field"` back to `"rule": "Based on Process Task"`
- `test_penalty_assignment_rules.py` — +114 lines: `TestTheProcessTaskTheyAssignThrough`, `_conditions()`, and six tests

Worth noting: `get_user_based_on_process_task` **is** already on `version-15` (in `__init__.py` and `overrides/assignment_rule.py`), so the helper shipped — but the four rules were still routing on `Based on Field`, meaning the feature was inert. This is a behavioural fix, not just test coverage.

5 files, +97/-25. One conflict in `patches.txt`: the revert wanted to re-add `update_penalty_assignment_rules_process_task_based` and `update_visa_request_workflow_and_rules`, both of which the release had already restored further down the file. Resolved by keeping the existing entries — no duplicates (verified).

Fix upstream too: these reverts need applying to `staging`, or the code returns next sprint and the merge drops it again.