### PR TITLE
fix: make nirmala day off repair patch safe to migrate

### DIFF
--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -298,9 +298,11 @@ def mark_single_attendance(emp, att_date, roster_type="Basic"):
 
 
 def mark_for_shift_assignment(employee, att_date, roster_type='Basic'):
+    # att_date may arrive as a str (whitelisted call / patch), a date, a datetime or a
+    # pandas Timestamp (mark_bulk_attendance). getdate normalises all of them to a date.
     shift_assignment = frappe.db.get_value("Shift Assignment", {
         'employee':employee,
-        'start_date':att_date.date(),
+        'start_date':getdate(att_date),
         'roster_type':roster_type,
         'docstatus':1
         }, ["*"], as_dict=1

--- a/one_fm/patches/v15_0/fix_nirmala_day_off_client_event_conflict.py
+++ b/one_fm/patches/v15_0/fix_nirmala_day_off_client_event_conflict.py
@@ -19,6 +19,12 @@ DATE = "2026-06-15"
 
 
 def execute():
+	# One-off data repair: skip silently on any site that does not have this employee
+	# (fresh/CI sites), so migrate never fails on missing data.
+	if not frappe.db.exists("Employee", EMPLOYEE):
+		print(f"Employee {EMPLOYEE} not found on this site; skipping repair.")
+		return
+
 	schedules = frappe.get_all(
 		"Employee Schedule",
 		filters={"employee": EMPLOYEE, "date": DATE},
@@ -80,8 +86,14 @@ def execute():
 	# Re-run the standard single-attendance marker, which honours the Day Off schedule.
 	from one_fm.overrides.attendance import mark_single_attendance
 
-	mark_single_attendance(EMPLOYEE, DATE, roster_type="Basic")
-	frappe.db.commit()
+	try:
+		mark_single_attendance(EMPLOYEE, DATE, roster_type="Basic")
+		frappe.db.commit()
+	except Exception:
+		# A data-repair patch must never block migrate; report and continue.
+		frappe.db.rollback()
+		print(f"Could not re-mark attendance for {EMPLOYEE} on {DATE}:")
+		print(frappe.get_traceback())
 
 	att = frappe.db.get_value(
 		"Attendance",


### PR DESCRIPTION
fix: make nirmala day off repair patch safe to migrate
The one-off repair for HR-EMP-03989 assumed the employee and her attendance data exist, so it could abort bench migrate on fresh or CI sites and on any unexpected failure during re-marking.

- return early when the employee does not exist on the site
- catch and report failures from mark_single_attendance instead of letting them break the migration

fix: normalise att_date in mark_for_shift_assignment
mark_for_shift_assignment called att_date.date(), which only works when the caller passes a datetime or pandas Timestamp. The whitelisted mark_single_attendance entry point, remark_absent_for_employees, mark_overtime_attendance and data patches all pass a date string, which raised AttributeError: 'str' object has no attribute 'date'.

- use getdate(att_date) so str, date, datetime and Timestamp inputs all resolve to a date
- behaviour is unchanged for the existing datetime callers