### PR TITLE
Update AMP recipient addresses for sender registration

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -540,7 +540,7 @@ one_fm.patches.v15_0.seed_app_services
 one_fm.patches.v15_0.set_candidate_title_fields
 one_fm.patches.v15_0.update_attendance_check
 one_fm.patches.v15_0.update_employee_and_user_references
-one_fm.patches.v15_0.send_work_item_notify_assignee_demo_email #2026-08-13
+one_fm.patches.v15_0.send_work_item_notify_assignee_demo_email #2026-08-18 rerun for AMP sender-registration addresses
 one_fm.patches.v15_0.mark_present_auto_attendance_missed_checkin_jul13
 one_fm.patches.v15_0.add_employee_schedule_suspension_workflow #2026-07-24
 one_fm.patches.v15_0.add_accommodation_leave_movement_assignment_rules #2026-07-30

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -540,7 +540,7 @@ one_fm.patches.v15_0.seed_app_services
 one_fm.patches.v15_0.set_candidate_title_fields
 one_fm.patches.v15_0.update_attendance_check
 one_fm.patches.v15_0.update_employee_and_user_references
-one_fm.patches.v15_0.send_work_item_notify_assignee_demo_email #2026-08-18 rerun for AMP sender-registration addresses
+one_fm.patches.v15_0.send_work_item_notify_assignee_demo_email #2026-08-18
 one_fm.patches.v15_0.mark_present_auto_attendance_missed_checkin_jul13
 one_fm.patches.v15_0.add_employee_schedule_suspension_workflow #2026-07-24
 one_fm.patches.v15_0.add_accommodation_leave_movement_assignment_rules #2026-07-30

--- a/one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py
+++ b/one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py
@@ -2,7 +2,14 @@ import frappe
 from frappe import _
 
 SENDER = "notifications@one-fm.com"
-RECIPIENT = "notifications@one-fm.com"
+# AMP for Email sender-registration addresses (per
+# https://amp.dev/documentation/guides-and-tutorials/start/email_sender_distribution)
+# — Gmail and Yahoo/Verizon Media require a production-ready AMP email sent
+# directly to these addresses as part of allowlisting one-fm.com as a sender.
+RECIPIENTS = [
+	"ampforemail.whitelisting@gmail.com",
+	"ampverification@yahoo.com",
+]
 
 # Real, live BPMN Process Instance task for WI-001663's "Start Work" step —
 # not a synthetic demo. Confirmed via both the instance's `workflow_state`
@@ -17,20 +24,19 @@ WORK_ITEM_ID = "WI-001663"
 WORK_ITEM_TITLE = "Refactor AI Model, AI Provider and AI Model pricing doctype"
 
 # The task's real assignee — the token must be issued for this user (not
-# RECIPIENT) since handle_amp_action checks it against the task's actual
-# assignment. RECIPIENT is only where this copy of the email is delivered
-# for inspection (notifications@one-fm.com itself, to verify the MIME/CORS
-# mechanics) — not who's expected to click it.
+# RECIPIENTS) since handle_amp_action checks it against the task's actual
+# assignment. RECIPIENTS is only where this AMP submission is delivered for
+# Gmail's/Yahoo's allowlisting review — not who's expected to click it.
 ASSIGNEE_USER = "k.sharma@one-fm.com"
 
 
 def execute():
 	"""One-time trigger: send a real "Start Work" notification email — tied
 	to the actual live BPMN task for WI-001663 — from
-	notifications@one-fm.com to notifications@one-fm.com itself (a
-	self-addressed copy, to inspect the MIME structure and CORS headers
-	directly via "Show original" before pointing this at a real assignee),
-	through the actual production sending pipeline.
+	notifications@one-fm.com to Gmail's and Yahoo/Verizon Media's AMP for
+	Email sender-registration addresses, as the "production-ready AMP email"
+	submission required by their allowlisting process, through the actual
+	production sending pipeline.
 
 	The email's "Start Work" action is a genuine one-click AMP action tied
 	to a real, live BPMN Process Instance task — not a static registry
@@ -45,7 +51,8 @@ def execute():
 	calls `complete_task` on the real Process Instance, genuinely advancing
 	it — a deliberate, confirmed side effect for this specific task, for
 	whoever actually clicks it (the token is issued to ASSIGNEE_USER, not
-	RECIPIENT).
+	RECIPIENTS — so a reviewer at Gmail/Yahoo clicking "Start Work" during
+	their allowlisting review would genuinely complete this production task).
 
 	This runs automatically, once, the first time `bench migrate` executes
 	on any site with this patch present (Frappe's Patch Log ensures it
@@ -131,7 +138,7 @@ def send():
 
 	frappe.flags.amp_html = amp_html
 	email_queue = frappe.sendmail(
-		recipients=[RECIPIENT],
+		recipients=RECIPIENTS,
 		sender=SENDER,
 		subject=title,
 		message=html_body,


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
The one-time data patch `send_work_item_notify_assignee_demo_email.py` is required to send a
"production-ready AMP email" to Gmail's and Yahoo/Verizon Media's official AMP-for-Email
sender-registration addresses, per amp.dev's sender distribution guide
(https://amp.dev/documentation/guides-and-tutorials/start/email_sender_distribution), in order to
get `one-fm.com` allowlisted as an AMP email sender. The patch was instead sending the email to
`notifications@one-fm.com` itself (a self-addressed MIME/CORS inspection copy), so it would never
have satisfied Gmail/Yahoo's registration requirement.

## Analysis and design (optional)
N/A

## Solution description
- Replaced the single `RECIPIENT = "notifications@one-fm.com"` constant with
  `RECIPIENTS = ["ampforemail.whitelisting@gmail.com", "ampverification@yahoo.com"]`
  (the two addresses amp.dev's sender-registration doc requires).
- Updated `frappe.sendmail(recipients=[RECIPIENT], ...)` to `recipients=RECIPIENTS`.
- Updated inline comments/docstring to describe the email as the AMP sender-registration
  submission rather than a self-addressed test copy, and to call out that the BPMN action
  token in the email is still live — a Gmail/Yahoo reviewer clicking "Start Work" would
  genuinely complete the real production task for WI-001663.
- No other logic changed: sender, BPMN instance/task IDs, and email body are untouched.

## Is there a business logic within a doctype?
- [ ] Yes
- [x] No

## Output screenshots (optional)
N/A — no UI change, backend-only patch.

## Areas affected and ensured
- `one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py` only — a one-time
  `bench migrate` patch. No doctype, schema, or UI changes.

## Is there any existing behavior change of other features due to this code change?
No. This only changes who receives the one-time AMP registration email; it does not
change any other patch, doctype, or runtime behavior.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

(Uses the existing live BPMN Process Instance `orj9cj8ajr` / task `bb085897-1b90-488a-836a-846672b4aacd` for WI-001663.)

## Was child table created?
N/A — no child table involved.
    - [ ] is attachment required?

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [x] Yes
- [ ] No
    Was the patch tested? Not yet — this patch is designed to run once via `bench migrate`
    and send through production's SMTP relay/registered IP (required for Google Workspace
    to accept it), so it hasn't been run yet. Recommend confirming the Email Queue entry
    after the next production migrate.

## Which browser(s) did you use for testing?
- [ ] Chrome
- [ ] Safari
- [ ] Firefox

N/A — no UI/browser involved in this change.