### PR TITLE
fix: register the Shift Preview patch where Frappe actually reads it (WI-001834)

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -585,3 +585,4 @@ one_fm.patches.v15_0.add_embassy_attestation_rates_to_hr_settings #2026-08-12 WI
 one_fm.patches.v15_0.add_pcc_attestation_doctype #2026-08-12 WI-002028
 one_fm.patches.v15_0.add_pcc_attestation_workflow_and_rules #2026-08-12 WI-002029
 one_fm.patches.v15_0.add_pcc_processing_fees_to_hr_settings #2026-08-12 WI-002026
+one_fm.patches.v15_0.add_shift_request_shift_preview #2026-08-12 WI-001834

--- a/one_fm/tests/test_shift_request_preview.py
+++ b/one_fm/tests/test_shift_request_preview.py
@@ -2,6 +2,8 @@
 # See license.txt
 """WI-001834: the Shift Preview an approver reads, and what gets created from it."""
 
+import pathlib
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days
@@ -201,3 +203,43 @@ class TestShiftRequestPreview(FrappeTestCase):
 		request = frappe._dict({"shift_type": self.default_type})
 
 		self.assertEqual(shift_type_on(request, A_FRIDAY), self.default_type)
+
+
+class TestThePatchIsActuallyRegistered(FrappeTestCase):
+	"""The regression that took Shift Request down on staging.
+
+	The patch that creates `custom_shift_preview` was listed only in a stray
+	`patches.txt` at the repo root, which Frappe never reads - it reads
+	`one_fm/patches.txt`. So the patch never ran, the Custom Field was never created, and
+	`doc.append("custom_shift_preview", ...)` raised AttributeError on every save of a
+	request whose range covers an override day.
+
+	The field assertions above pass on a site where the patch has been run by hand, so they
+	could not see this. This one checks the registration itself.
+	"""
+
+	def setUp(self):
+		self.patches = pathlib.Path(frappe.get_app_path("one_fm", "patches.txt")).read_text()
+
+	def test_the_shift_preview_patch_is_listed(self):
+		self.assertIn("one_fm.patches.v15_0.add_shift_request_shift_preview", self.patches)
+
+	def test_it_runs_after_the_model_sync(self):
+		# The Table field's options point at the Shift Preview child DocType, which only
+		# exists once the model sync has run. Registered pre_model_sync, create_custom_fields
+		# fails on the link and leaves the section break behind without the grid - which is
+		# exactly the half-created state staging was found in.
+		post = self.patches.split("[post_model_sync]", 1)
+		self.assertEqual(len(post), 2, "patches.txt has no [post_model_sync] section")
+		self.assertIn("one_fm.patches.v15_0.add_shift_request_shift_preview", post[1])
+
+	def test_there_is_no_stray_patches_file_at_the_repo_root(self):
+		# It has been re-introduced three times this sprint. Frappe ignores it, so anything
+		# landing there is silently never applied.
+		root = pathlib.Path(frappe.get_app_path("one_fm")).parent / "patches.txt"
+
+		self.assertFalse(root.exists(), f"{root} is not read by Frappe - move its entries into one_fm/patches.txt")
+
+	def test_the_child_doctype_the_grid_points_at_exists(self):
+		self.assertTrue(frappe.db.exists("DocType", "Shift Preview"))
+		self.assertTrue(frappe.get_meta("Shift Preview").istable)

--- a/patches.txt
+++ b/patches.txt
@@ -1,1 +1,0 @@
-one_fm.patches.v15_0.add_shift_request_shift_preview #2026-08-12 WI-001834


### PR DESCRIPTION
## What broke

Saving a Shift Request whose range covers an override day fails on `staging`:

```
File "apps/one_fm/one_fm/overrides/shift_request.py", line 125, in build_shift_preview
    doc.append("custom_shift_preview", row)
AttributeError: 'NoneType' object has no attribute 'options'
```

`meta.get_field("custom_shift_preview")` returns `None` — the Custom Field was never created.

## Why

The patch that creates it was listed **only** in a `patches.txt` at the repo root. Frappe reads `one_fm/patches.txt`; nothing reads the root file. Confirmed on the site:

| check | result |
|---|---|
| `Patch Log` for `add_shift_request_shift_preview` | absent — never ran |
| `Custom Field` `custom_section_break_z4s37` | present |
| `Custom Field` `custom_shift_preview` | **missing** |
| `DocType` `Shift Preview` | present |

The section break exists without the grid because an older `shift_request` patch calls `create_custom_fields(get_shift_request_custom_fields())` over the whole set in list order, created the section break, then failed on the grid — whose `options` point at the `Shift Preview` child DocType.

## Fix

- Entry moved into `one_fm/patches.txt`, under `[post_model_sync]` so the child DocType exists before the Table field's link is validated.
- Stray root `patches.txt` deleted. It has been re-introduced three times this sprint and silently swallows every entry placed in it.

## Tests

`one_fm.tests.test_shift_request_preview` currently reports **10 errors on staging** — the same `AttributeError`. The existing assertions could not catch this because they pass on any site where the field happens to exist.

Four added tests check the registration instead: the patch is listed, it is listed after the model sync, the child DocType exists, and there is no `patches.txt` at the repo root. These 4 pass now; the other 10 pass once `bench migrate` has run the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)