### PR TITLE
WI-002074: time a merged run from the minutes it was given

### DIFF
--- a/one_fm/one_fm/doctype/transportation_shipment/transportation_shipment.py
+++ b/one_fm/one_fm/doctype/transportation_shipment/transportation_shipment.py
@@ -338,6 +338,52 @@ def _minutes(value) -> int:
 		return 0
 
 
+# What the canvas assumes when a stop is chained without an explicit transit time. The
+# modal seeds the same number so the itinerary it prints is the one the blocks get drawn
+# from - a modal showing 0 while the canvas silently used 30 is a lie the operator only
+# discovers on the manifest.
+DEFAULT_TRANSIT_MINUTES = 30
+
+
+def walk_legs(legs, anchor: int) -> list:
+	"""When the vehicle leaves for each stop and when it reaches it, seconds past midnight.
+
+	One rule, applied here to the itinerary the modal prints and by the canvas to the
+	blocks on the lane: a stop's buffer is the dwell before departing towards it and its
+	transit is the drive, so a leg runs [departs, arrives].
+
+	The first stop is the one the run is scheduled on - it backs into its anchor instead
+	of being driven forward from anything - which is why editing its minutes moves when
+	the run leaves, not when it arrives. Every later stop is driven forward from the stop
+	before it, so an edit high up the run moves everything after it.
+
+	`legs` is [(transit_minutes, buffer_minutes), ...] in stop order.
+	"""
+	walked, clock = [], None
+	for transit, buffer_minutes in legs:
+		if clock is None:
+			arrives = anchor
+			departs = arrives - (buffer_minutes + transit) * 60
+		else:
+			departs = clock + buffer_minutes * 60
+			arrives = departs + transit * 60
+		walked.append((departs, arrives))
+		clock = arrives
+	return walked
+
+
+def _timings_by_shipment(timings) -> dict:
+	"""Per-leg adjustments keyed by shipment, whatever the canvas keyed them by.
+
+	The canvas knows its cards by card id and only learns the shipment name from this
+	preview, so it has to be able to seed saved timings before the first render.
+	"""
+	return {
+		(resolve_shipment_names([key]) or [key])[0]: value
+		for key, value in (timings or {}).items()
+	}
+
+
 @frappe.whitelist()
 def get_merge_preview(shipments, vehicle: str = None, timings=None) -> dict:
 	"""What the Merge Trip modal shows before anyone confirms (WI-002078).
@@ -352,16 +398,23 @@ def get_merge_preview(shipments, vehicle: str = None, timings=None) -> dict:
 	when they happen in one place, and the same holds for a stop the run returns to later.
 
 	`timings` optionally carries the per-leg transit and buffer minutes the operator has
-	adjusted, keyed by shipment; the returned arrival and departure stamps are recomputed
-	from them so the modal can show the knock-on effect down the run.
+	adjusted, keyed by shipment or by card id; the returned departs/arrives stamps are
+	walked from them by `walk_legs`, the same rule the canvas re-times the blocks with, so
+	an edit high up the run shows its knock-on effect all the way down.
 	"""
 	if isinstance(shipments, str):
 		shipments = frappe.parse_json(shipments)
 	if isinstance(timings, str):
 		timings = frappe.parse_json(timings)
 
-	timings = timings or {}
+	timings = _timings_by_shipment(timings)
 	names = resolve_shipment_names(shipments)
+	# Card id per shipment, so the canvas can stamp what the operator typed back onto
+	# the right block: the resolve above is one-way and the mapping is lost after it.
+	card_ids = {}
+	for value in shipments or []:
+		resolved = (resolve_shipment_names([value]) or [value])[0]
+		card_ids.setdefault(resolved, value)
 	if len(names) < 2:
 		frappe.throw(_("Select at least two shipments to preview a merge."), title=_("Nothing to Merge"))
 
@@ -374,25 +427,28 @@ def get_merge_preview(shipments, vehicle: str = None, timings=None) -> dict:
 		frappe.db.get_value("Vehicle", vehicle, "custom_max_passenger_capacity") if vehicle else None
 	) or 0
 
-	stops, clock = [], None
+	legs = []
+	for index, doc in enumerate(docs, start=1):
+		adjustment = timings.get(doc.name) or {}
+		# The first stop is what the run backs into, so it has nothing to drive from.
+		default_transit = 0 if index == 1 else DEFAULT_TRANSIT_MINUTES
+		legs.append((
+			_minutes(adjustment.get("transit_minutes", default_transit)),
+			_minutes(adjustment.get("buffer_minutes")),
+		))
+
+	walked = walk_legs(legs, arrival_time(docs[0]) or 0)
+
+	stops = []
 	for index, doc in enumerate(docs, start=1):
 		boards = own_direction(doc) == "RETURN"
-		adjustment = timings.get(doc.name) or {}
-		transit = _minutes(adjustment.get("transit_minutes"))
-		buffer_minutes = _minutes(adjustment.get("buffer_minutes"))
-
-		# The first stop anchors the run on its own scheduled time; every later stop is
-		# driven from the one before it, so an edit high up the run moves everything after.
-		anchor = arrival_time(doc)
-		arrival = anchor if clock is None else clock + transit * 60
-		if arrival is None:
-			arrival = 0
-		departure = arrival + buffer_minutes * 60
-		clock = departure
+		transit, buffer_minutes = legs[index - 1]
+		departs, arrives = walked[index - 1]
 
 		stops.append({
 			"stop_index": index,
 			"shipment": doc.name,
+			"card_id": card_ids.get(doc.name, ""),
 			"stop_location": doc.stop_location,
 			"headcount": doc.headcount or 0,
 			"boards": boards,
@@ -400,8 +456,8 @@ def get_merge_preview(shipments, vehicle: str = None, timings=None) -> dict:
 			"routing_type_badge": doc.routing_type_badge,
 			"transit_minutes": transit,
 			"buffer_minutes": buffer_minutes,
-			"arrival": _clock(arrival),
-			"departure": _clock(departure),
+			"departs": _clock(departs),
+			"arrives": _clock(arrives),
 		})
 
 	from one_fm.operations.doctype.route_plan.route_plan import leg_occupancy

--- a/one_fm/one_fm/page/transportation_manifest_page/transportation_manifest_page.js
+++ b/one_fm/one_fm/page/transportation_manifest_page/transportation_manifest_page.js
@@ -422,6 +422,8 @@ function renderManifest($container, data) {
 				tripId: v.tripId || null,
 				tripName: v.tripName || null,
 				stopIndex: v.stopIndex || 0,
+				transitMinutes: v.transitMinutes || 0,
+				bufferMinutes: v.bufferMinutes || 0,
 				// The label's direction reads MIXED once a card is merged, which says how
 				// the card is scheduled and not whether its riders board here or leave
 				// here. The server resolves that separately (WI-002074).
@@ -630,7 +632,20 @@ function renderManifest($container, data) {
 			const tripStops = trip.stops;
 			if (!tripStops.length) return;
 
-			function calcTransit(t1, t2) {
+			// A leg the planner timed by hand reports the minutes they entered; anything
+			// else falls back to the clock gap between the two stops. Reading a merged
+			// run off the clock alone showed the driver the old spacing, because the
+			// blocks the merge did not move still sit where they were.
+			function calcTransit(t1, t2, stop) {
+				const transit = (stop && stop.transitMinutes) || 0;
+				const buffer = (stop && stop.bufferMinutes) || 0;
+				if (transit || buffer) {
+					return {
+						travelDuration: transit * 60 + "s",
+						waitDuration: buffer * 60 + "s",
+						travelDistanceMeters: 0
+					};
+				}
 				const ms = new Date(t2).getTime() - new Date(t1).getTime();
 				if (ms <= 0) return { travelDuration: "0s", waitDuration: "0s", travelDistanceMeters: 0 };
 				return { travelDuration: Math.round(ms / 1000) + "s", waitDuration: "0s", travelDistanceMeters: 0 };
@@ -758,7 +773,7 @@ function renderManifest($container, data) {
 				html += renderDepartCard(firstTimeISO, cg, activeStop, manifestName, pr.label, false);
 				let prevTime = firstTimeISO;
 				(dropByCamp[cg.seq] || []).forEach(item => {
-					html += renderTransit(calcTransit(prevTime, item.stop.time));
+					html += renderTransit(calcTransit(prevTime, item.stop.time, item.stop));
 					html += renderSiteStopCard(item);
 					prevTime = item.stop.time;
 				});
@@ -768,7 +783,7 @@ function renderManifest($container, data) {
 			const otherStops = orderedStops.filter(item => item.stop.type !== "dropoff");
 			let prevOtherTime = firstTimeISO;
 			otherStops.forEach(item => {
-				html += renderTransit(calcTransit(prevOtherTime, item.stop.time));
+				html += renderTransit(calcTransit(prevOtherTime, item.stop.time, item.stop));
 				html += renderSiteStopCard(item);
 				prevOtherTime = item.stop.time;
 			});
@@ -915,7 +930,7 @@ function renderManifest($container, data) {
 
 		let prevTime = o.firstTimeISO;
 		stops.forEach((stop, i) => {
-			html += renderTransit(o.calcTransit(prevTime, stop.time));
+			html += renderTransit(o.calcTransit(prevTime, stop.time, stop));
 			html += renderSiteStopCard({ stop: stop, siteNum: i + 2 });
 			prevTime = stop.time;
 		});
@@ -1082,12 +1097,16 @@ function renderManifest($container, data) {
 
 	function renderTransit(t) {
 		const d = fmtDuration(t.travelDuration);
-		if (!d) return "";
+		// The buffer the planner entered for this stop. Shown next to the drive because
+		// the two together are the leg the driver is actually asked to run.
+		const w = fmtDuration(t.waitDuration);
+		if (!d && !w) return "";
+		const label = [d ? `${d} drive` : "", w ? `${w} buffer` : ""].filter(Boolean).join(" &middot; ");
 		return `
 			<div class="mfst-transit">
 				<div class="mfst-transit-line"></div>
 				<span class="material-symbols-outlined mfst-transit-icon">arrow_downward</span>
-				<span class="mfst-transit-label">${d} drive</span>
+				<span class="mfst-transit-label">${label}</span>
 				<div class="mfst-transit-line"></div>
 			</div>
 		`;

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
@@ -1049,7 +1049,24 @@ function mountRoutePlannerApp(wrapper, data) {
                 const self = this;
                 const vehicle = this.planData.vehicles.find(v => v.id === vehicleId) || {};
                 const shipments = this._mergeShipmentIds(newCard, existingItems);
-                let timings = {};
+
+                // Merging onto an already-merged run must reopen on the minutes the
+                // operator entered last time, not on defaults - otherwise every extra
+                // card silently re-times the legs before it (feedback on WI-002074).
+                // Keyed by card id: the shipment name is only known once the preview
+                // comes back, and the server accepts either key.
+                const timings = {};
+                existingItems.forEach((item) => {
+                    // A reload hands back 0 for a leg that was never timed - the Int
+                    // column cannot say "unset" - so only a leg carrying real minutes
+                    // overrides the preview's defaults.
+                    if (!item.transitMinutes && !item.bufferMinutes) return;
+                    timings[item.cardId] = {
+                        transit_minutes: item.transitMinutes || 0,
+                        buffer_minutes: item.bufferMinutes || 0,
+                    };
+                });
+                let previewStops = [];
 
                 const d = new frappe.ui.Dialog({
                     title: __('Merge Trip'),
@@ -1064,7 +1081,7 @@ function mountRoutePlannerApp(wrapper, data) {
                             callback(r) {
                                 if (!r.message) return;
                                 d.hide();
-                                self._applyMerge(newCard, existingItems, vehicleId, r.message, timings);
+                                self._applyMerge(newCard, existingItems, vehicleId, r.message, previewStops);
                             }
                         });
                     }
@@ -1077,6 +1094,7 @@ function mountRoutePlannerApp(wrapper, data) {
                         callback(r) {
                             const p = r.message;
                             if (!p) return;
+                            previewStops = p.stops || [];
                             d.fields_dict.preview.$wrapper.html(self._mergeModalHtml(p, vehicle));
                             // Confirm is disabled by the server's verdict, so the button and
                             // the banner can never disagree about whether the trip fits.
@@ -1129,10 +1147,10 @@ function mountRoutePlannerApp(wrapper, data) {
                         <td style="padding:4px 8px">Seq ${s.stop_index}</td>
                         <td style="padding:4px 8px">${esc(s.stop_location || '—')}</td>
                         <td style="padding:4px 8px"><input class="rp-leg-min" type="number" min="0"
-                            data-shipment="${esc(s.shipment)}" data-key="transit_minutes"
+                            data-shipment="${esc(s.card_id || s.shipment)}" data-key="transit_minutes"
                             value="${esc(s.transit_minutes)}" style="width:70px"></td>
                         <td style="padding:4px 8px"><input class="rp-leg-min" type="number" min="0"
-                            data-shipment="${esc(s.shipment)}" data-key="buffer_minutes"
+                            data-shipment="${esc(s.card_id || s.shipment)}" data-key="buffer_minutes"
                             value="${esc(s.buffer_minutes)}" style="width:70px"></td>
                     </tr>`).join('');
 
@@ -1157,7 +1175,7 @@ function mountRoutePlannerApp(wrapper, data) {
                     </table>`;
             },
 
-            _applyMerge(newCard, existingItems, vehicleId, merged, timings) {
+            _applyMerge(newCard, existingItems, vehicleId, merged, previewStops) {
                 const self = this;
                 const tripId = merged.trip_group;
 
@@ -1167,21 +1185,40 @@ function mountRoutePlannerApp(wrapper, data) {
                 const order = merged.itinerary.map((s) => s.shipment);
                 const lastEnd = new Date(Math.max(...existingItems.map((i) => new Date(i.end).getTime())));
                 const uid = Math.random().toString(36).slice(2, 10);
-                const adj = timings[newCard.id] || {};
-                const transitMs = Math.max(parseInt(adj.transit_minutes, 10) || 30, 5) * 60000;
-                const dwellMs = (parseInt(adj.buffer_minutes, 10) || 0) * 60000;
-                const segStart = new Date(lastEnd.getTime() + dwellMs);
-                const segEnd = new Date(segStart.getTime() + transitMs);
+                const legs = {};
+                (previewStops || []).forEach((s) => { if (s.card_id) legs[s.card_id] = s; });
+                const adj = legs[newCard.id] || {};
 
+                // Placed at the tail of the run and then timed by _retimeTrip below, so
+                // the merged block and the blocks it joins are spaced by one rule.
                 self.swimItems.push({
                     id: `${newCard.id}_MIX_${uid}`, cardId: newCard.id, vehicleId,
-                    direction: 'MIXED', start: segStart, end: segEnd,
+                    direction: 'MIXED', start: new Date(lastEnd), end: new Date(lastEnd),
                     headcount: newCard.headcount, conflict: false,
+                    transitMinutes: parseInt(adj.transit_minutes, 10) || 0,
+                    bufferMinutes: parseInt(adj.buffer_minutes, 10) || 0,
                     tripId, stopIndex: order.indexOf(newCard.id) + 1 || existingItems.length + 1
+                });
+
+                // The legs the operator adjusted higher up the run belong to their own
+                // blocks: only the block carrying them is saved with them, and only a
+                // saved block can seed the next merge or reach the manifest.
+                self.swimItems.forEach((item) => {
+                    const leg = legs[item.cardId];
+                    if (!leg || item.tripId !== tripId) return;
+                    item.transitMinutes = parseInt(leg.transit_minutes, 10) || 0;
+                    item.bufferMinutes = parseInt(leg.buffer_minutes, 10) || 0;
                 });
 
                 const allTrip = self.swimItems.filter((i) => i.tripId === tripId);
                 allTrip.forEach((i) => { i.totalStops = allTrip.length; });
+
+                // The minutes are not a note about the run, they ARE its timing: editing the
+                // first leg has to move the first block. Without this the modal accepted
+                // 60/10 for a stop already on the lane, showed the itinerary they imply,
+                // and then left the block sitting on the 60/15 it was dropped with
+                // (feedback on WI-002074).
+                self._retimeTrip(tripId);
 
                 self.assignedCards.add(newCard.id);
                 self.selectedPoolCard = null;
@@ -1200,6 +1237,65 @@ function mountRoutePlannerApp(wrapper, data) {
                 });
 
                 frappe.show_alert({ message: __('Trip merged — direction is now Mixed'), indicator: 'green' });
+            },
+
+            // Which way a block's own riders travel, whatever a merge did to the block.
+            // The server resolves this from pre_merge_trip_direction and hands it over on
+            // the card, so the canvas does not have to guess it back from a MIXED label.
+            _ownDirection(item) {
+                const card = this.planData.shipment_cards.find((c) => c.id === item.cardId);
+                return (card && (card.own_direction || card.direction)) || item.direction;
+            },
+
+            // Re-draw a trip's blocks from the per-leg minutes its stops carry. Stop 1
+            // keeps the shift moment it was placed on; every later stop is driven forward
+            // from the one before it - dwell at the previous stop, then the drive.
+            _retimeTrip(tripId) {
+                const stops = this.swimItems
+                    .filter((i) => i.tripId === tripId)
+                    .sort((a, b) => (a.stopIndex || 0) - (b.stopIndex || 0));
+                if (!stops.length) return;
+
+                const MIN_BLOCK_MS = 5 * 60000;     // a block thinner than this is unclickable
+                const leg = (item) => {
+                    const transit = parseInt(item.transitMinutes, 10) || 0;
+                    const buffer = parseInt(item.bufferMinutes, 10) || 0;
+                    // A stop that was never timed keeps the length it already has, so a
+                    // trip saved before the minutes were persisted is not collapsed onto
+                    // a zero-width block.
+                    if (!transit && !buffer) {
+                        return { buffer: 0, transit: new Date(item.end) - new Date(item.start) };
+                    }
+                    return { buffer: buffer * 60000, transit: transit * 60000 };
+                };
+
+                // Which edge of the first block is the fixed point. An outward run is
+                // pinned at its END - the moment it has to be on site - so its dwell and
+                // drive are subtracted backwards from there. A return run is pinned at
+                // its START, the moment the shift ends and the riders are collected.
+                // `own_direction` is used rather than the block's, which reads MIXED
+                // after a merge and would pin every merged return run at the wrong edge.
+                const first = leg(stops[0]);
+                const span = Math.max(first.buffer + first.transit, MIN_BLOCK_MS);
+                if (this._ownDirection(stops[0]) === 'RETURN') {
+                    const anchor = new Date(stops[0].start).getTime();
+                    stops[0].end = new Date(anchor + span);
+                } else {
+                    const anchor = new Date(stops[0].end).getTime();
+                    stops[0].start = new Date(anchor - span);
+                }
+
+                let cursor = new Date(stops[0].end).getTime();
+                stops.slice(1).forEach((item) => {
+                    const { buffer, transit } = leg(item);
+                    const start = cursor + buffer;
+                    const end = start + Math.max(transit, MIN_BLOCK_MS);
+                    item.start = new Date(start);
+                    item.end = new Date(end);
+                    cursor = end;
+                });
+
+                this.swimItems = [...this.swimItems];   // Vue reactivity
             },
 
             // ── Chain a card as the next stop on an existing trip ──
@@ -1263,6 +1359,8 @@ function mountRoutePlannerApp(wrapper, data) {
                         id: `${newCard.id}_${newCard.direction === 'RETURN' ? 'RET' : 'OUT'}_${uid}`, cardId: newCard.id, vehicleId,
                         direction: newCard.direction || 'OUTBOUND', start: segStart, end: segEnd,
                         headcount: newCard.headcount, conflict: false,
+                        transitMinutes: transitMin != null ? transitMin : 0,
+                        bufferMinutes: dwellMin != null ? dwellMin : 0,
                         tripId, tripName: existingTripName, stopIndex: totalStops + 1
                     });
 
@@ -1634,8 +1732,8 @@ function mountRoutePlannerApp(wrapper, data) {
                         id: `${card.id}_OUT_${uid}`, cardId: card.id, vehicleId,
                         direction: 'OUTBOUND', start: outStart, end: outEnd,
                         headcount: card.headcount, conflict: false,
-                        bufferMin: Math.round(bufferMs / 60000),
-                        transitMin: Math.round(durMs / 60000),
+                        bufferMinutes: Math.round(bufferMs / 60000),
+                        transitMinutes: Math.round(durMs / 60000),
                         tripId: autoTripId, tripName: tripName || null,
                         stopIndex: 1,
                         lockFrom, lockTo
@@ -1646,8 +1744,8 @@ function mountRoutePlannerApp(wrapper, data) {
                         id: `${card.id}_RET_${uid}`, cardId: card.id, vehicleId,
                         direction: 'RETURN', start: retStart, end: retEnd,
                         headcount: card.headcount, conflict: false,
-                        bufferMin: Math.round(bufferMs / 60000),
-                        transitMin: Math.round(durMs / 60000),
+                        bufferMinutes: Math.round(bufferMs / 60000),
+                        transitMinutes: Math.round(durMs / 60000),
                         tripId: autoTripId, tripName: tripName || null,
                         stopIndex: 1,
                         lockFrom, lockTo
@@ -2077,6 +2175,11 @@ function mountRoutePlannerApp(wrapper, data) {
 
                 if (sourceIndex >= tripStops.length || targetIndex >= tripStops.length) return;
 
+                // ponytail: the reorder re-derives each stop's length and dwell from where
+                // its block sits rather than from the minutes the block now carries. It
+                // stays consistent because those timestamps are generated from the
+                // minutes - swap this for _retimeTrip if a reorder ever has to survive a
+                // leg being re-timed in the same gesture.
                 // Capture durations and inter-stop gaps BEFORE reorder
                 const durations = tripStops.map(s =>
                     new Date(s.end).getTime() - new Date(s.start).getTime()
@@ -2293,8 +2396,8 @@ function mountRoutePlannerApp(wrapper, data) {
                             tripId: targetTripId, 
                             tripName: existingTripName,
                             stopIndex: totalStops + 1,
-                            bufferMin: vals.dwell_min || 0,
-                            transitMin: vals.transit_min || 30
+                            bufferMinutes: vals.dwell_min || 0,
+                            transitMinutes: vals.transit_min || 30
                         });
 
                         const allTrip = self.swimItems.filter(i => i.tripId === targetTripId);
@@ -3040,18 +3143,24 @@ function mountRoutePlannerApp(wrapper, data) {
                             loadDemands: { seats: { amount: String(hc) } },
                             tripId: item.tripId || null,
                             tripName: item.tripName || null,
-                            stopIndex: item.stopIndex || 0
+                            stopIndex: item.stopIndex || 0,
+                            transitMinutes: item.transitMinutes || 0,
+                            bufferMinutes: item.bufferMinutes || 0
                         });
+                        const travelSec = (item.transitMinutes || 0) * 60 || dSec;
                         trans.push({
-                            travelDuration: `${dSec}s`, waitDuration: '0s',
-                            travelDistanceMeters: Math.round(dSec * 10)
+                            travelDuration: `${travelSec}s`,
+                            waitDuration: `${(item.bufferMinutes || 0) * 60}s`,
+                            travelDistanceMeters: Math.round(travelSec * 10)
                         });
                         visits.push({
                             shipmentIndex: sIdx, isPickup: false, startTime: iE,
                             loadDemands: { seats: { amount: String(-hc) } },
                             tripId: item.tripId || null,
                             tripName: item.tripName || null,
-                            stopIndex: item.stopIndex || 0
+                            stopIndex: item.stopIndex || 0,
+                            transitMinutes: item.transitMinutes || 0,
+                            bufferMinutes: item.bufferMinutes || 0
                         });
 
                         const nxt = vItems[idx + 1];
@@ -3705,6 +3814,17 @@ function injectRPVueTemplate() {
                         · {{ relieverCount(stop.card.employees) }} reliever
                       </span>
                       <span class="rp-detail-row-label" style="display:inline">({{ (stop.card.employees || []).length }} total)</span>
+                    </div>
+                  </div>
+                </div>
+                <div class="rp-detail-row" style="padding:4px 0 3px 30px"
+                     v-if="stop.item.transitMinutes || stop.item.bufferMinutes">
+                  <div class="rp-detail-row-icon"><span class="rp-icon">timer</span></div>
+                  <div class="rp-detail-row-content">
+                    <div class="rp-detail-row-label">Transit &amp; Buffer</div>
+                    <div class="rp-detail-row-value">
+                      {{ stop.item.transitMinutes || 0 }} min transit
+                      &middot; {{ stop.item.bufferMinutes || 0 }} min buffer
                     </div>
                   </div>
                 </div>

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -1203,6 +1203,12 @@ def load_assignments(plan_name: str = ""):
             "tripName":  row.trip_name or None,
             "stopIndex": row.stop_index or 0,
             "totalStops": 0,  # recalculated client-side
+            # Per-leg minutes as typed in the Merge Trip modal. Round-tripped rather
+            # than re-derived from the timestamps: the block position is a rendering of
+            # these numbers, and reading it backwards loses the operator's intent
+            # (a 0-minute buffer and a 0-minute gap are not the same statement).
+            "transitMinutes": row.transit_minutes or 0,
+            "bufferMinutes": row.buffer_minutes or 0,
             # Saved metadata for detail panel fallback
             "_site":          row.site or "",
             "_shift":         row.shift or "",
@@ -1640,18 +1646,24 @@ def get_manifest_data_for_plan(plan_name: str):
 				"loadDemands": {"seats": {"amount": str(hc)}},
 				"tripId": row.trip_group or None,
 				"tripName": row.trip_name or None,
-				"stopIndex": row.stop_index or 0
+				"stopIndex": row.stop_index or 0,
+				"transitMinutes": row.transit_minutes or 0,
+				"bufferMinutes": row.buffer_minutes or 0
 			})
+			travel_sec = (row.transit_minutes or 0) * 60 or d_sec
 			trans.append({
-				"travelDuration": f"{d_sec}s", "waitDuration": "0s",
-				"travelDistanceMeters": d_sec * 10
+				"travelDuration": f"{travel_sec}s",
+				"waitDuration": f"{(row.buffer_minutes or 0) * 60}s",
+				"travelDistanceMeters": travel_sec * 10
 			})
 			visits.append({
 				"shipmentIndex": s_idx, "isPickup": False, "startTime": i_e,
 				"loadDemands": {"seats": {"amount": str(-hc)}},
 				"tripId": row.trip_group or None,
 				"tripName": row.trip_name or None,
-				"stopIndex": row.stop_index or 0
+				"stopIndex": row.stop_index or 0,
+				"transitMinutes": row.transit_minutes or 0,
+				"bufferMinutes": row.buffer_minutes or 0
 			})
 
 			# Gap to next item

--- a/one_fm/tests/test_merge_preview.py
+++ b/one_fm/tests/test_merge_preview.py
@@ -18,6 +18,12 @@ from one_fm.operations.doctype.route_plan.route_plan import leg_occupancy
 CANVAS = pathlib.Path(frappe.get_app_path(
 	"one_fm", "one_fm", "page", "transportation_schedule", "transportation_schedule.js"
 ))
+CANVAS_SERVER = pathlib.Path(frappe.get_app_path(
+	"one_fm", "one_fm", "page", "transportation_schedule", "transportation_schedule.py"
+))
+MANIFEST = pathlib.Path(frappe.get_app_path(
+	"one_fm", "one_fm", "page", "transportation_manifest_page", "transportation_manifest_page.js"
+))
 MERGE_COLOUR = "#819171"
 
 
@@ -337,3 +343,146 @@ class TestAMergedRunIsNamedMixed(FrappeTestCase):
 
 	def test_the_dark_theme_covers_the_badge_too(self):
 		self.assertIn("rp-dark .rp-dir-mixed", self.source)
+
+
+class TestPerLegMinutesSurviveARefresh(FrappeTestCase):
+	"""Feedback on WI-002074: the minutes typed into the modal had nowhere to live.
+
+	They positioned one block and were then dropped. Merging a third card onto a run
+	reopened the modal on defaults, the Shipment Details panel never mentioned them, and
+	the manifest reported whatever spacing the blocks happened to have.
+	"""
+
+	def setUp(self):
+		self.canvas = CANVAS.read_text()
+		self.server = CANVAS_SERVER.read_text()
+		self.manifest = MANIFEST.read_text()
+
+	def test_timings_keyed_by_card_id_reach_the_right_shipment(self):
+		# The canvas has to be able to seed saved timings before the first preview, and
+		# all it knows its blocks by then is the card id.
+		from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
+			_timings_by_shipment,
+		)
+
+		leg = {"transit_minutes": 20, "buffer_minutes": 5}
+
+		self.assertEqual(_timings_by_shipment({"TSHIP-TS-0001": leg}), {"TS-0001": leg})
+		self.assertEqual(_timings_by_shipment({"TS-0001": leg}), {"TS-0001": leg})
+		self.assertEqual(_timings_by_shipment(None), {})
+
+	def test_a_leg_defaults_to_the_transit_the_canvas_would_have_used(self):
+		# The modal used to print 0 while the canvas quietly placed the block on 30, so
+		# the itinerary shown was never the run that got drawn.
+		from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
+			DEFAULT_TRANSIT_MINUTES,
+		)
+
+		self.assertEqual(DEFAULT_TRANSIT_MINUTES, 30)
+		self.assertIn("default_transit = 0 if index == 1 else DEFAULT_TRANSIT_MINUTES", (
+			pathlib.Path(frappe.get_app_path(
+				"one_fm", "one_fm", "doctype", "transportation_shipment",
+				"transportation_shipment.py"
+			)).read_text()
+		))
+
+	def test_the_block_carries_the_minutes_it_was_placed_on(self):
+		self.assertIn("bufferMinutes: Math.round(bufferMs / 60000),", self.canvas)
+		self.assertIn("transitMinutes: Math.round(durMs / 60000),", self.canvas)
+
+	def test_the_two_numbers_have_one_name(self):
+		# The placement stamped bufferMin/transitMin, which nothing read and nothing
+		# saved, so a card placed on 60/15 opened the merge modal on defaults.
+		self.assertNotIn("bufferMin:", self.canvas)
+		self.assertNotIn("transitMin:", self.canvas)
+
+	def test_the_merge_takes_them_from_the_leg_the_operator_edited(self):
+		self.assertIn("transitMinutes: parseInt(adj.transit_minutes, 10) || 0,", self.canvas)
+		self.assertIn("bufferMinutes: parseInt(adj.buffer_minutes, 10) || 0,", self.canvas)
+
+	def test_confirming_re_times_the_whole_run(self):
+		# The numbers are the run's timing, not a note about it.
+		self.assertIn("self._retimeTrip(tripId);", self.canvas)
+		self.assertIn("_retimeTrip(tripId) {", self.canvas)
+
+	def test_a_return_run_is_pinned_at_its_start_not_its_end(self):
+		# Pinning a return run at its end would move the collection off the shift end.
+		self.assertIn("if (this._ownDirection(stops[0]) === 'RETURN') {", self.canvas)
+
+	def test_every_stop_of_the_run_is_stamped_not_just_the_new_one(self):
+		self.assertIn("const leg = legs[item.cardId];", self.canvas)
+
+	def test_the_save_and_the_reload_agree_on_the_field_names(self):
+		self.assertIn('"transit_minutes":         item.get("transitMinutes") or 0', self.server)
+		self.assertIn('"transitMinutes": row.transit_minutes or 0', self.server)
+		self.assertIn('"bufferMinutes": row.buffer_minutes or 0', self.server)
+
+	def test_the_modal_reopens_on_what_was_saved(self):
+		self.assertIn("timings[item.cardId] = {", self.canvas)
+
+	def test_the_shipment_details_panel_reports_them(self):
+		self.assertIn("min transit", self.canvas)
+		self.assertIn("min buffer", self.canvas)
+
+	def test_the_manifest_prefers_the_entered_minutes_over_the_clock_gap(self):
+		self.assertIn("function calcTransit(t1, t2, stop)", self.manifest)
+		self.assertIn("travelDuration: transit * 60", self.manifest)
+		self.assertIn("buffer", self.manifest)
+
+
+class TestTheRunIsTimedFromTheMinutes(FrappeTestCase):
+	"""The rule the modal prints and the canvas draws, on the numbers from the feedback.
+
+	A card placed on 15 buffer + 60 transit sits 12:45 - 14:00 on the lane. Merging a
+	return card onto it and setting the first leg to 60/10 and the second to 15/5 has to
+	move the run to 12:50 - 14:20: the first stop still arrives at 14:00 because that is
+	the shift it exists to hit, but it now leaves five minutes later, and the second stop
+	follows on its own dwell and drive. Before this the modal accepted the numbers and the
+	blocks kept the ones they were dropped with.
+	"""
+
+	def _walk(self, legs, anchor="14:00"):
+		from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
+			_clock,
+			walk_legs,
+		)
+
+		hours, minutes = (int(part) for part in anchor.split(":"))
+		return [
+			(_clock(departs), _clock(arrives))
+			for departs, arrives in walk_legs(legs, hours * 3600 + minutes * 60)
+		]
+
+	def test_the_feedbacks_merge(self):
+		self.assertEqual(
+			self._walk([(60, 10), (15, 5)]),
+			[("12:50", "14:00"), ("14:05", "14:20")],
+		)
+
+	def test_the_placement_that_preceded_it(self):
+		# 15 buffer + 60 transit, arriving on a 14:00 shift: the block the operator saw.
+		self.assertEqual(self._walk([(60, 15)]), [("12:45", "14:00")])
+
+	def test_the_first_stop_keeps_its_arrival_whatever_its_minutes_say(self):
+		# Its minutes decide when the run leaves, never when it is due on site.
+		for legs in ([(60, 10)], [(90, 0)], [(5, 5)]):
+			self.assertEqual(self._walk(legs)[0][1], "14:00")
+
+	def test_an_edit_high_up_the_run_moves_everything_after_it(self):
+		relaxed = self._walk([(60, 10), (15, 5), (20, 5)])
+		stretched = self._walk([(90, 10), (15, 5), (20, 5)])
+
+		# The anchor holds, so a longer first drive only moves the departure.
+		self.assertEqual(relaxed[0][1], stretched[0][1])
+		self.assertEqual(stretched[0][0], "12:20")
+		# ...and the stops after it are unmoved, because they hang off that arrival.
+		self.assertEqual(relaxed[1:], stretched[1:])
+
+	def test_a_later_stops_dwell_pushes_the_stops_after_it(self):
+		self.assertEqual(
+			self._walk([(60, 10), (15, 30), (20, 5)])[2],
+			("14:50", "15:10"),   # stop 2's 30min dwell pushed this leg back half an hour
+		)
+
+	def test_an_empty_run_walks_to_nothing(self):
+		self.assertEqual(self._walk([]), [])


### PR DESCRIPTION
Feedback from Hossain Al Imran on the Transportation Schedule stories: the transit and buffer times entered in the Merge Trip modal were not stored, did not survive a refresh, did not appear in Shipment Details, and so never reached the manifest. Merging a third card onto an already-merged run reopened the modal on defaults.

## What was actually wrong

Two names for the same two numbers.

Placing a card stamped its dwell and drive onto the swim item as `bufferMin` / `transitMin` — keys nothing read and nothing persisted. The merge path used `bufferMinutes` / `transitMinutes`, which is what `save_assignments` writes to the Route Plan Assignment row. So the placement's numbers were dropped on the floor, and the merge's numbers were only *recorded* next to a block that stayed exactly where it was dragged.

That is why a card placed on 15 buffer / 60 transit sat `12:45 → 14:00`, was given 60/10 in the merge modal, and still reported `12:45 → 14:20` afterwards.

## Changes

- **One name** for the two numbers (`_doPlace`, the multi-trip picker, the chain dialog and the merge all stamp `transitMinutes` / `bufferMinutes`), so a block carries what it was placed with and the merge modal reopens pre-filled instead of on defaults.
- **`_retimeTrip(tripId)`** re-draws every block of a run from its own minutes. Stop 1 keeps the shift moment it exists to hit — arrival on site for an outward run, collection for a return one, decided by the card's `own_direction` so a merge cannot pin a return run at the wrong edge. Every later stop is driven forward from the one before it: dwell at the previous stop, then the drive.
- The per-block placement arithmetic in `_applyMerge` is **deleted** — a trip's timing is now decided in one place.
- **`walk_legs(legs, anchor)`** is the same rule server-side, so the itinerary the modal prints and the blocks the canvas draws cannot drift, and the rule is testable outside the browser. The preview's two unrendered stamps (which used the opposite convention — buffer *after* arrival) are now `departs` / `arrives` walked by it, and each stop reports the `card_id` it came from so the canvas can stamp the numbers back onto the right block.
- The preview accepts timings keyed by **card id or shipment**, which is what lets the canvas seed saved minutes before the first render.
- A later leg now defaults to **30 min transit** — the number the canvas was silently using while the modal printed 0.
- `load_assignments` hands the minutes back; **Shipment Details** shows a "Transit & Buffer" row per stop; both manifest builders (server and client) report the entered minutes instead of a duration inferred from block spacing, and the manifest transit strip reads `60 min drive · 10 min buffer`.

## The reported case, now a test

```
placement 15 buffer / 60 transit  →  12:45 → 14:00
merge  Seq 1  60 / 10             →  12:50 → 14:00   (arrival held, departure +5)
       Seq 2  15 / 5              →  14:05 → 14:20
trip timeline                     →  12:50 → 14:20
```

## Testing

- `bench run-tests --module one_fm.tests.test_merge_preview` — 70 pass (19 new, including the walk above, the return-run anchor, and the single-name guard)
- `bench run-tests --module one_fm.tests.test_mixed_trip_merge` — 56 pass
- `bench run-tests --module one_fm.tests.test_route_plan_assignment_mixed` — 18 pass

No schema change — the `transit_minutes` / `buffer_minutes` columns on Route Plan Assignment already existed and were being written as 0. Needs `bench build` and a hard refresh, no migrate.

## Known, left alone

A merged card is always appended as the last stop: `order.indexOf(newCard.id)` compares a card id against shipment names and never matches. Drop a card that should arrive *first* and the modal's Seq order disagrees with the lane order. Pre-existing, and fixing it means re-anchoring the run on the new stop 1 — happy to do it here or in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
