### PR TITLE
WI-002095: open the medical and the PCC attestation an overseas hire needs

### DIFF
--- a/one_fm/grd/doctype/medical_appointment/medical_appointment.json
+++ b/one_fm/grd/doctype/medical_appointment/medical_appointment.json
@@ -355,7 +355,6 @@
    "fieldtype": "Section Break"
   },
   {
-   "default": "User",
    "fieldname": "government_relations_operator",
    "fieldtype": "Link",
    "label": "Government Relations Operator",

--- a/one_fm/grd/doctype/medical_appointment/medical_appointment.py
+++ b/one_fm/grd/doctype/medical_appointment/medical_appointment.py
@@ -172,6 +172,31 @@ class MedicalAppointment(Document):
 		attendance_doc.submit()
 
 
+# WI-002095: the medical an overseas hire needs is opened by the Preparation that hires
+# them. "First Time" for a first arrival; the field's other option, Renewal, belongs to the
+# renewal path, which does not open one.
+FIRST_TIME = "First Time"
+
+
+def create_medical_appointment(employee, appointment_type, preparation_name=None):
+	"""Open the medical appointment a Preparation row calls for (WI-002095).
+
+	Inserted without its mandatory fields. The appointment date, whether transport is
+	needed and which PRO takes it are not facts anybody holds when the Preparation is
+	submitted - the supervisor and the GR Operator supply them as the record moves through
+	the workflow, which is what the Pending Supervisor state it opens in is for. Mandatory
+	is enforced again on every later save, so nothing reaches submit half-filled.
+	"""
+	appointment = frappe.new_doc("Medical Appointment")
+	appointment.employee = employee.name
+	appointment.medical_appointment_type = appointment_type
+	appointment.preparation = preparation_name
+	appointment.date_of_application = today()
+	appointment.insert(ignore_mandatory=True)
+
+	return appointment
+
+
 @frappe.whitelist()
 def send_supervisor_notification_on_pending_medical_appointments():
 	pending_appointments = frappe.get_all(

--- a/one_fm/grd/doctype/pcc_attestation/pcc_attestation.py
+++ b/one_fm/grd/doctype/pcc_attestation/pcc_attestation.py
@@ -38,6 +38,23 @@ RECEIPT_TIMESTAMPS = (
 )
 
 
+def create_pcc_attestation(employee, category, preparation_name=None, attestation_type=ATTESTATION):
+	"""Open a PCC record for an overseas hire (WI-002095).
+
+	The requirements and the fees are not passed in: the controller derives them from the
+	candidate's nationality on validate, so there is one place that reads the Nationality
+	Attestation Rules and the caller cannot hand it a different answer.
+	"""
+	pcc = frappe.new_doc("PCC Attestation")
+	pcc.employee = employee.name
+	pcc.type = attestation_type
+	pcc.category = category
+	pcc.preparation = preparation_name
+	pcc.insert()
+
+	return pcc
+
+
 class PCCAttestation(Document):
 	def validate(self):
 		self.set_attestation_requirements()

--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -26,6 +26,8 @@ from one_fm.grd.doctype.medical_insurance import medical_insurance
 from one_fm.grd.doctype.residency_payment_request import residency_payment_request
 from one_fm.grd.doctype.residency import residency
 from one_fm.grd.doctype.paci import paci
+from one_fm.grd.doctype.medical_appointment import medical_appointment
+from one_fm.grd.doctype.pcc_attestation import pcc_attestation
 from one_fm.grd.doctype.fingerprint_appointment import fingerprint_appointment
 from one_fm.processor import sendemail
 
@@ -47,6 +49,12 @@ from one_fm.processor import sendemail
 # The creators keep their derivations for their other callers, which do not come through a
 # Preparation row and have nothing to pass. Residency still takes its application date
 # from MOI_CATEGORY_BY_ACTION; only the category is handed to it.
+#
+# WI-002095: the two overseas Actions also open the medical the candidate has to pass and
+# the attestation of their police clearance - the two steps of overseas onboarding the GRO
+# was still raising by hand. No Fingerprint Appointment is opened for any Action: the
+# fingerprint is taken once the candidate is in the country and holds a civil ID, so it is
+# not part of what a Preparation generates.
 NEW_ACTION_DOCUMENTS = {
     "New Kuwaiti": {
         "work_permit": "New Kuwaiti",
@@ -56,6 +64,8 @@ NEW_ACTION_DOCUMENTS = {
         "medical_insurance": "New",
         "residency": "First Time",
         "paci": "New Application",
+        "medical_appointment": "First Time",
+        "pcc_attestation": "Overseas",
     },
     # WI-002024: the same overseas hire, but against a government contract file rather
     # than a private one. Every document it opens is the one Overseas opens - what
@@ -69,6 +79,8 @@ NEW_ACTION_DOCUMENTS = {
         "medical_insurance": "New",
         "residency": "First Time",
         "paci": "New Application",
+        "medical_appointment": "First Time",
+        "pcc_attestation": "Overseas (Government)",
     },
     # The process map groups Local Transfer with Overseas and the non-Kuwaiti renewal:
     # all four documents, opened by the Preparation itself. There is no Transfer Paper in
@@ -480,6 +492,16 @@ def create_documents_for_row(row, preparation_name):
 
     if "paci" in plan:
         paci.create_PACI(employee_doc, plan["paci"], preparation_name)
+
+    if "medical_appointment" in plan:
+        medical_appointment.create_medical_appointment(
+            employee_doc, plan["medical_appointment"], preparation_name
+        )
+
+    if "pcc_attestation" in plan:
+        pcc_attestation.create_pcc_attestation(
+            employee_doc, plan["pcc_attestation"], preparation_name
+        )
 
     return work_permit_doc
 

--- a/one_fm/grd/doctype/preparation/test_preparation_new_actions.py
+++ b/one_fm/grd/doctype/preparation/test_preparation_new_actions.py
@@ -18,6 +18,9 @@ from one_fm.grd.doctype.residency.residency import create_moi_record
 
 SUB_DOCUMENTS = ("Work Permit", "Medical Insurance", "Residency", "PACI")
 
+# WI-002095: the two the overseas Actions add on top of those four.
+OVERSEAS_ONLY_DOCUMENTS = ("Medical Appointment", "PCC Attestation")
+
 
 def _an_active_employee():
 	"""An employee the GRD documents can be opened for.
@@ -243,3 +246,66 @@ class TestNewActionDocuments(FrappeTestCase):
 				frappe.db.get_value(doctype, opened[doctype][0], "preparation"),
 				preparation.name,
 			)
+
+	# ── WI-002095: the two documents the overseas Actions added ───────────────────
+
+	def test_overseas_opens_the_medical_and_the_attestation(self):
+		for action in ("Overseas", "Overseas (Government)"):
+			with self.subTest(action=action):
+				preparation = self._preparation_with(action)
+
+				create_documents_for_row(preparation.preparation_record[0], preparation.name)
+
+				for doctype in OVERSEAS_ONLY_DOCUMENTS:
+					opened = frappe.get_all(
+						doctype, filters={"preparation": preparation.name}, pluck="name"
+					)
+					self.assertEqual(len(opened), 1, f"{doctype} was not opened exactly once")
+
+				appointment = frappe.get_last_doc(
+					"Medical Appointment", filters={"preparation": preparation.name}
+				)
+				self.assertEqual(appointment.medical_appointment_type, "First Time")
+
+				# The PCC is opened under the same government classification as the row,
+				# which is what tells the fee apart on a government file.
+				attestation = frappe.get_last_doc(
+					"PCC Attestation", filters={"preparation": preparation.name}
+				)
+				self.assertEqual(attestation.category, action)
+				self.assertEqual(attestation.type, "Attestation")
+				self.assertEqual(attestation.workflow_state, "Draft")
+
+	def test_no_action_opens_a_fingerprint_appointment(self):
+		"""The fingerprint is taken once the candidate is here and holds a civil ID."""
+		for action in NEW_ACTION_DOCUMENTS:
+			with self.subTest(action=action):
+				preparation = self._preparation_with(action)
+
+				create_documents_for_row(preparation.preparation_record[0], preparation.name)
+
+				self.assertEqual(
+					frappe.get_all(
+						"Fingerprint Appointment",
+						filters={"preparation": preparation.name},
+						pluck="name",
+					),
+					[],
+				)
+
+	def test_the_other_actions_open_neither(self):
+		"""Only an overseas hire needs a medical and a police clearance attestation."""
+		for action in ("New Kuwaiti", "Local Transfer"):
+			with self.subTest(action=action):
+				preparation = self._preparation_with(action)
+
+				create_documents_for_row(preparation.preparation_record[0], preparation.name)
+
+				for doctype in OVERSEAS_ONLY_DOCUMENTS:
+					self.assertEqual(
+						frappe.get_all(
+							doctype, filters={"preparation": preparation.name}, pluck="name"
+						),
+						[],
+						f"{doctype} should not be opened for {action}",
+					)


### PR DESCRIPTION
[WI-002095] Automated Sub-Document Generation Matrix — Operations-019, Ms Iman.

## What the ACs asked for

| Action | Documents |
|---|---|
| Overseas / Overseas (Government) | Work Permit, Medical Insurance, Residency, PACI, **Medical Appointment**, **PCC Attestation** — and **no** Fingerprint Appointment |
| Local Transfer / Renewal (Non-Kuwaiti) | Work Permit, Medical Insurance, Residency, PACI |
| New Kuwaiti / Renewal (Kuwaiti) | Work Permit only |
| Extend 1 / 2 / 3 months | Residency only |

Everything but the two bolded ones already behaved this way. This PR adds those, and pins the rest with tests.

## The change

- `NEW_ACTION_DOCUMENTS` gains `medical_appointment` and `pcc_attestation` for both overseas Actions, so the one table an operator reads to see what an Action produces says so.
- `medical_appointment.create_medical_appointment` and `pcc_attestation.create_pcc_attestations` — creators live beside the documents they open, as the other four do.
- The PCC opens under the row's own government classification. Its requirements and fees stay derived from the candidate's nationality by the controller, so there is still one place reading the Nationality Attestation Rules.
- The Medical Appointment is inserted without its mandatory fields: the appointment date, the transport decision and the PRO are not facts anyone holds at submit — the supervisor and the GRO supply them as the record moves through its workflow, which is what the Pending Supervisor state it opens in is for. Mandatory is enforced again on every later save.
- No Fingerprint Appointment for any Action — the fingerprint is taken once the candidate is in the country and holds a civil ID.

## Bug found on the way

`Medical Appointment.government_relations_operator` carried a default of the literal string `"User"` — the options value pasted into the default. Every insert failed link validation with *Could not find Government Relations Operator: User*, from this path or from the form. Removed.

## Tests

`bench run-tests --module one_fm.grd.doctype.preparation.test_preparation_new_actions` — 12 passing, including the three new cases (both overseas Actions open the two documents; no Action opens a Fingerprint Appointment; New Kuwaiti and Local Transfer open neither).

## Deploy

`bench migrate` picks up the Medical Appointment doctype change (no patch needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)