### PR TITLE
WI-002104: open a second PCC record when the nationality needs a translation

### DIFF
--- a/one_fm/grd/doctype/pcc_attestation/pcc_attestation.py
+++ b/one_fm/grd/doctype/pcc_attestation/pcc_attestation.py
@@ -13,7 +13,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import now
 
-from one_fm.grd.utils import get_pcc_attestation_fees
+from one_fm.grd.utils import get_nationality_attestation_rule, get_pcc_attestation_fees
 
 ATTESTATION = "Attestation"
 TRANSLATION = "Translation"
@@ -43,6 +43,29 @@ RECEIPT_TIMESTAMPS = (
 	("upload_mofa_payment_receipt", "upload_mofa_payment_receipt_on"),
 	("upload_translation_payment_receipt", "upload_translation_payment_receipt_on"),
 )
+
+
+def create_pcc_attestations(employee, category, preparation_name=None):
+	"""Open the PCC records an overseas hire's nationality calls for (WI-002104).
+
+	Always the attestation itself. A nationality whose row in the Nationality Attestation
+	Rules has Translation Required ticked also gets a second, separate record for the
+	translation - separate because the two are different pieces of work, done by different
+	offices, each with its own fee and its own receipt, and the workflow routes them down
+	different paths. One record carrying both would have to be in two states at once.
+
+	A nationality with no row in the table needs no translation, which is the same answer
+	the fee resolver gives it.
+	"""
+	rule = get_nationality_attestation_rule(employee.one_fm_nationality)
+
+	records = [create_pcc_attestation(employee, category, preparation_name)]
+	if rule and rule.translation_required:
+		records.append(
+			create_pcc_attestation(employee, category, preparation_name, attestation_type=TRANSLATION)
+		)
+
+	return records
 
 
 def create_pcc_attestation(employee, category, preparation_name=None, attestation_type=ATTESTATION):

--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -499,7 +499,7 @@ def create_documents_for_row(row, preparation_name):
         )
 
     if "pcc_attestation" in plan:
-        pcc_attestation.create_pcc_attestation(
+        pcc_attestation.create_pcc_attestations(
             employee_doc, plan["pcc_attestation"], preparation_name
         )
 

--- a/one_fm/grd/doctype/preparation/test_preparation_dual_pcc.py
+++ b/one_fm/grd/doctype/preparation/test_preparation_dual_pcc.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002104: how many PCC records an overseas Preparation row opens.
+
+One for the attestation itself, and a second for the translation when the candidate's
+nationality is configured to need one.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import nowdate
+
+from one_fm.grd.doctype.preparation.preparation import create_documents_for_row
+
+# From the reporter's master data: a nationality whose certificate has to be translated,
+# and one whose does not.
+NEEDS_TRANSLATION = "Ugandan"
+NO_TRANSLATION = "Indian"
+
+
+def _an_active_employee():
+	name = frappe.db.get_value(
+		"Employee",
+		{"status": "Active", "relieving_date": ["is", "not set"]},
+		"name",
+		order_by="creation asc",
+	)
+	if not name:
+		raise frappe.DoesNotExistError("No active employee on this site to test against")
+	return name
+
+
+class TestDualPCCAttestation(FrappeTestCase):
+	def setUp(self):
+		for nationality in (NEEDS_TRANSLATION, NO_TRANSLATION):
+			if not frappe.db.exists("Nationality", nationality):
+				self.skipTest(f"Nationality {nationality} is not on this site")
+
+		self.employee = _an_active_employee()
+
+		settings = frappe.get_doc("HR Settings")
+		settings.set("nationality_attestation_rules", [])
+		settings.append("nationality_attestation_rules", {
+			"nationality": NEEDS_TRANSLATION,
+			"embassy_required": 0, "mofa_required": 0, "translation_required": 1,
+		})
+		settings.append("nationality_attestation_rules", {
+			"nationality": NO_TRANSLATION,
+			"embassy_required": 0, "mofa_required": 1, "translation_required": 0,
+		})
+		settings.flags.ignore_permissions = True
+		settings.save()
+		frappe.clear_cache(doctype="HR Settings")
+
+	def _submit_an_overseas_row(self, nationality):
+		"""Open the documents for one Overseas row, for an employee of this nationality."""
+		frappe.db.set_value("Employee", self.employee, "one_fm_nationality", nationality)
+
+		preparation = frappe.get_doc(
+			{
+				"doctype": "Preparation",
+				"posting_date": nowdate(),
+				"preparation_record": [
+					{"employee": self.employee, "renewal_or_extend": "Overseas"}
+				],
+			}
+		).insert(ignore_permissions=True)
+
+		create_documents_for_row(preparation.preparation_record[0], preparation.name)
+
+		return frappe.get_all(
+			"PCC Attestation",
+			filters={"preparation": preparation.name},
+			fields=["name", "type", "workflow_state"],
+			order_by="creation asc",
+		)
+
+	def test_a_nationality_needing_translation_gets_two_records(self):
+		opened = self._submit_an_overseas_row(NEEDS_TRANSLATION)
+
+		self.assertEqual([pcc.type for pcc in opened], ["Attestation", "Translation"])
+		# Both start with the GR Operator, who assigns the PRO to each in turn.
+		for pcc in opened:
+			self.assertEqual(pcc.workflow_state, "Draft")
+
+	def test_a_nationality_not_needing_translation_gets_one(self):
+		opened = self._submit_an_overseas_row(NO_TRANSLATION)
+
+		self.assertEqual([pcc.type for pcc in opened], ["Attestation"])
+
+	def test_a_nationality_with_no_rule_gets_one(self):
+		"""No row in the table means no translation, the same answer the fees give it."""
+		settings = frappe.get_doc("HR Settings")
+		settings.set("nationality_attestation_rules", [])
+		settings.flags.ignore_permissions = True
+		settings.save()
+		frappe.clear_cache(doctype="HR Settings")
+
+		opened = self._submit_an_overseas_row(NEEDS_TRANSLATION)
+
+		self.assertEqual([pcc.type for pcc in opened], ["Attestation"])


### PR DESCRIPTION
[WI-002104] Conditional Auto-Creation of Dual PCC Attestation Records Based on HR Settings — Operations-019, Ms Iman.

> **Stacked on #6743 (WI-002095).** Base is `WI-002095-preparation-subdocument-matrix`; merge that first and this retargets to `staging`.

## The ACs

- Overseas / Overseas (Government) row, nationality has **Translation Required = checked** in the HR Settings child table → **two** PCC Attestation records in Draft: `Type=Attestation` and `Type=Translation`.
- Same row, **unchecked** → **one** record, `Type=Attestation`.

## The change

`create_pcc_attestations` reads the candidate's Nationality Attestation Rule and opens the translation record only when the rule calls for one, reusing `get_nationality_attestation_rule` — the same lookup the fee resolver uses, so the two cannot disagree.

Two separate records rather than one carrying both: attestation and translation are different pieces of work, done by different offices, each with its own fee and its own receipt, and the workflow routes them down different paths (`Assign PRO` → Pending Embassy / Pending MOFA vs → Pending Translation). One record would have to be in two states at once.

A nationality with no row in the table gets one record — the same answer the fee resolver already gives it.

## Tests

`bench run-tests --module one_fm.grd.doctype.preparation.test_preparation_dual_pcc` — 3 passing: checked → two records in the right order and both in Draft, unchecked → one, no rule → one.

Note: these tests need `add_embassy_attestation_rates_to_hr_settings` (WI-002025) applied, which also gates the existing `test_pcc_attestation` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)