### PR TITLE
WI-002107: give the Preparation a badge for the medical and the attestation

### DIFF
--- a/one_fm/grd/doctype/preparation/preparation_dashboard.py
+++ b/one_fm/grd/doctype/preparation/preparation_dashboard.py
@@ -20,6 +20,15 @@ def get_data():
             {
                 'items': ['Fingerprint Appointment']
             },
+            # WI-002107: the two overseas sub-documents WI-002095 opens. Without a badge
+            # each, the only way to reach them from the Preparation that created them was
+            # to search their own lists.
+            {
+                'items': ['Medical Appointment']
+            },
+            {
+                'items': ['PCC Attestation']
+            },
             # {
             #     'items': ['Payment Request']
             # }

--- a/one_fm/grd/doctype/preparation/test_preparation_dashboard.py
+++ b/one_fm/grd/doctype/preparation/test_preparation_dashboard.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002107: what the Preparation Connections section offers."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.grd.doctype.preparation.preparation_dashboard import get_data
+
+
+class TestPreparationDashboard(FrappeTestCase):
+	def test_every_sub_document_has_a_badge(self):
+		data = get_data()
+		linked = [doctype for group in data["transactions"] for doctype in group["items"]]
+
+		for doctype in (
+			"Work Permit",
+			"Medical Insurance",
+			"Residency",
+			"PACI",
+			"Medical Appointment",
+			"PCC Attestation",
+		):
+			self.assertIn(doctype, linked)
+
+	def test_each_badge_can_filter_on_the_link_the_dashboard_names(self):
+		"""A badge on a doctype with no `preparation` field renders but finds nothing."""
+		data = get_data()
+
+		for group in data["transactions"]:
+			for doctype in group["items"]:
+				with self.subTest(doctype=doctype):
+					self.assertTrue(
+						frappe.get_meta(doctype).get_field(data["fieldname"]),
+						f"{doctype} has no {data['fieldname']} field to filter on",
+					)


### PR DESCRIPTION
[WI-002107] Preparation Connections for Medical & PCC — Operations-019, Ms Iman.

> **Stacked on #6744 (WI-002104), which is stacked on #6743 (WI-002095).** Merge order: 6743 → 6744 → this.

## The AC

The Preparation Connections section shows shortcut badges for **Medical Appointment** and **PCC Attestation**, and clicking either opens the filtered list of records linked to that Preparation.

## The change

Two entries in `preparation_dashboard.py`. The dashboard filters on `preparation`, which both doctypes already carry, so the badges open pre-filtered straight away.

Depends on WI-002095 for there to be anything behind the badges.

## Tests

`bench run-tests --module one_fm.grd.doctype.preparation.test_preparation_dashboard` — 2 passing. The second one pins that every badge names a doctype that actually has the `preparation` field the dashboard filters on: a badge on one that does not renders fine and silently finds nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)