### PR TITLE
WI-002110: show only the fields the PCC's Type actually uses

### DIFF
--- a/one_fm/grd/doctype/pcc_attestation/pcc_attestation.json
+++ b/one_fm/grd/doctype/pcc_attestation/pcc_attestation.json
@@ -244,17 +244,20 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval:doc.type",
    "fieldname": "attestation_and_cost_breakdown_section",
    "fieldtype": "Section Break",
    "label": "Attestation and Cost Breakdown"
   },
   {
+   "depends_on": "eval:doc.type == 'Attestation'",
    "fieldname": "requires_embassy_attestation",
    "fieldtype": "Currency",
    "label": "Embassy Attestation Fee",
    "read_only": 1
   },
   {
+   "depends_on": "eval:doc.type == 'Translation'",
    "fieldname": "translation_fee",
    "fieldtype": "Currency",
    "label": "Translation Fee",
@@ -265,29 +268,34 @@
    "fieldtype": "Column Break"
   },
   {
+   "depends_on": "eval:doc.type == 'Attestation'",
    "fieldname": "mofa_fee",
    "fieldtype": "Currency",
    "label": "MOFA Fee",
    "read_only": 1
   },
   {
+   "depends_on": "eval:doc.type",
    "fieldname": "section_break_42",
    "fieldtype": "Section Break"
   },
   {
    "allow_on_submit": 1,
+   "depends_on": "eval:doc.type == 'Attestation'",
    "fieldname": "upload_embassy_payment_receipt",
    "fieldtype": "Attach",
    "label": "Upload Embassy Payment Receipt"
   },
   {
    "allow_on_submit": 1,
+   "depends_on": "eval:doc.type == 'Attestation'",
    "fieldname": "upload_mofa_payment_receipt",
    "fieldtype": "Attach",
    "label": "Upload MOFA Payment Receipt"
   },
   {
    "allow_on_submit": 1,
+   "depends_on": "eval:doc.type == 'Translation'",
    "fieldname": "upload_translation_payment_receipt",
    "fieldtype": "Attach",
    "label": "Upload Translation Payment Receipt"
@@ -298,6 +306,7 @@
   },
   {
    "allow_on_submit": 1,
+   "depends_on": "eval:doc.type == 'Attestation' && doc.upload_embassy_payment_receipt",
    "fieldname": "upload_embassy_payment_receipt_on",
    "fieldtype": "Data",
    "label": "Upload Embassy Payment Receipt On",
@@ -305,6 +314,7 @@
   },
   {
    "allow_on_submit": 1,
+   "depends_on": "eval:doc.type == 'Attestation' && doc.upload_mofa_payment_receipt",
    "fieldname": "upload_mofa_payment_receipt_on",
    "fieldtype": "Data",
    "label": "Upload MOFA Payment Receipt On",
@@ -312,6 +322,7 @@
   },
   {
    "allow_on_submit": 1,
+   "depends_on": "eval:doc.type == 'Translation' && doc.upload_translation_payment_receipt",
    "fieldname": "upload_translation_payment_receipt_on",
    "fieldtype": "Data",
    "label": "Upload Translation Payment Receipt On",
@@ -343,6 +354,7 @@
   {
    "allow_on_submit": 1,
    "default": "0",
+   "depends_on": "eval:doc.type == 'Attestation'",
    "description": "Derived from the Nationality Attestation Rules in HR Settings.",
    "fieldname": "embassy_attestation_required",
    "fieldtype": "Check",
@@ -352,6 +364,7 @@
   {
    "allow_on_submit": 1,
    "default": "0",
+   "depends_on": "eval:doc.type == 'Attestation'",
    "description": "Derived from the Nationality Attestation Rules in HR Settings.",
    "fieldname": "mofa_attestation_required",
    "fieldtype": "Check",
@@ -361,6 +374,7 @@
   {
    "allow_on_submit": 1,
    "default": "0",
+   "depends_on": "eval:doc.type == 'Translation'",
    "description": "Derived from the Nationality Attestation Rules in HR Settings.",
    "fieldname": "translation_required",
    "fieldtype": "Check",
@@ -371,7 +385,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-13 09:30:00.000000",
+ "modified": "2026-08-19 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "PCC Attestation",

--- a/one_fm/grd/doctype/pcc_attestation/test_pcc_attestation_field_visibility.py
+++ b/one_fm/grd/doctype/pcc_attestation/test_pcc_attestation_field_visibility.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002110: which PCC Attestation fields the Type shows.
+
+An attestation and a translation are different pieces of work with different fees and
+different receipts, and the form used to show every field of both at once - including,
+before a Type was chosen, all of them.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+ATTESTATION = "eval:doc.type == 'Attestation'"
+TRANSLATION = "eval:doc.type == 'Translation'"
+
+# Shown only for an Attestation: the embassy and MOFA breakdown, and the receipts for them.
+ATTESTATION_ONLY = (
+	"embassy_attestation_required",
+	"requires_embassy_attestation",
+	"mofa_attestation_required",
+	"mofa_fee",
+	"upload_embassy_payment_receipt",
+	"upload_mofa_payment_receipt",
+)
+
+# Shown only for a Translation.
+TRANSLATION_ONLY = (
+	"translation_required",
+	"translation_fee",
+	"upload_translation_payment_receipt",
+)
+
+# A stamp appears with the file it stamps, never on its own.
+STAMPS = {
+	"upload_embassy_payment_receipt_on": f"{ATTESTATION} && doc.upload_embassy_payment_receipt",
+	"upload_mofa_payment_receipt_on": f"{ATTESTATION} && doc.upload_mofa_payment_receipt",
+	"upload_translation_payment_receipt_on": f"{TRANSLATION} && doc.upload_translation_payment_receipt",
+}
+
+# Neither section means anything until a Type is chosen.
+SECTIONS = ("attestation_and_cost_breakdown_section", "section_break_42")
+
+
+class TestPCCAttestationFieldVisibility(FrappeTestCase):
+	def setUp(self):
+		self.meta = frappe.get_meta("PCC Attestation")
+
+	def _depends_on(self, fieldname):
+		field = self.meta.get_field(fieldname)
+		self.assertIsNotNone(field, f"PCC Attestation has no {fieldname} field")
+		return field.depends_on
+
+	def test_the_embassy_and_mofa_fields_belong_to_an_attestation(self):
+		for fieldname in ATTESTATION_ONLY:
+			with self.subTest(fieldname=fieldname):
+				self.assertEqual(self._depends_on(fieldname), ATTESTATION)
+
+	def test_the_translation_fields_belong_to_a_translation(self):
+		for fieldname in TRANSLATION_ONLY:
+			with self.subTest(fieldname=fieldname):
+				self.assertEqual(self._depends_on(fieldname), TRANSLATION)
+
+	def test_a_receipt_stamp_waits_for_its_receipt(self):
+		for fieldname, condition in STAMPS.items():
+			with self.subTest(fieldname=fieldname):
+				self.assertEqual(self._depends_on(fieldname), condition)
+
+	def test_an_unchosen_type_hides_both_sections(self):
+		for fieldname in SECTIONS:
+			with self.subTest(fieldname=fieldname):
+				self.assertEqual(self._depends_on(fieldname), "eval:doc.type")


### PR DESCRIPTION
[WI-002110] PCC Attestation Doctype Update — Operations-019, Ms Iman.

## The ACs, and what each maps to

| Type | Shown | Hidden |
|---|---|---|
| `Attestation` | Embassy Attestation Required, Embassy Attestation Fee, MOFA Attestation Required, MOFA Fee, both receipt Attach fields | every Translation field |
| `Translation` | Translation Required, Translation Fee, the translation receipt | every Embassy / MOFA field |
| *(empty)* | nothing | all three breakdowns and both sections |

Plus: each **Upload … Receipt On** stamp appears only once its receipt is attached.

## The change

`depends_on` on 14 fields, no controller change. Mirrors the target doctype on the BA site (linked in the work item's Notes) and fills the four it left blank — `translation_fee` and the three timestamps, which the ACs are explicit about.

Visibility only. The controller still derives every requirement and fee from the candidate's nationality, and a hidden field keeps the value it was given, so nothing about the fee breakdown or the workflow conditions changes.

## Tests

`bench run-tests --module one_fm.grd.doctype.pcc_attestation.test_pcc_attestation_field_visibility` — 4 passing. Existing `test_pcc_attestation` (14) and `test_pcc_attestation_workflow` (27) still pass.

## Deploy

`bench migrate` picks up the doctype change; no patch needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)