### PR TITLE
WI-002091: count a licence's nationals and expatriates from the employees on it

### DIFF
--- a/one_fm/grd/doctype/pam_license_details/pam_license_details.py
+++ b/one_fm/grd/doctype/pam_license_details/pam_license_details.py
@@ -2,12 +2,151 @@
 # For license information, please see license.txt
 """A single PAM license and the sector statistics PAM rations it by (WI-002102).
 
-The workforce numbers on the child rows are derived rather than typed - see the
-calculation added on top of this migration.
+The two actual headcounts on each sector row are derived from the employees on the license
+rather than typed (WI-002091): PAM counts nationals and expatriates per occupational
+sector, and an operator maintaining those numbers by hand is one transfer away from a
+licence that reads compliant when it is not.
 """
 
+import frappe
 from frappe.model.document import Document
+from frappe.query_builder import DocType
+
+KUWAITI = "Kuwaiti"
+
+# The Employee fields a headcount depends on. A save that touches none of them cannot have
+# moved anybody between licences or sectors, and Employee is saved constantly - so the
+# recount is skipped rather than run on every save.
+#
+# The occupational sector is not an Employee field: it is fetched from the employee's PAM
+# designation, so a change of designation is what moves them between sectors.
+WATCHED_EMPLOYEE_FIELDS = (
+	"pam_file",
+	"pam_file_number",
+	"one_fm_pam_designation",
+	"one_fm_nationality",
+	"status",
+)
 
 
 class PAMLicenseDetails(Document):
 	pass
+
+
+def update_counts_from_employee(doc, method=None):
+	"""Recount whatever this employee just joined or left (WI-002091).
+
+	Both sides, because a designation or a licence number that changed moves the employee
+	out of one sector row and into another - recounting only where they are now would leave
+	the row they came from carrying them for good.
+
+	A recount rather than an increment: the count is a query over the employees on the
+	licence, so it cannot drift out of step with them the way a running total would.
+	"""
+	if not any(doc.has_value_changed(fieldname) for fieldname in WATCHED_EMPLOYEE_FIELDS):
+		return
+
+	before = doc.get_doc_before_save()
+	for license_number, sector in {
+		_license_and_sector(doc),
+		_license_and_sector(before) if before else None,
+	} - {None}:
+		recount_sector(license_number, sector)
+
+
+def _license_and_sector(employee):
+	"""The licence number and occupational sector this employee counts against, or None."""
+	license_number = employee.get("pam_file_number")
+	designation = employee.get("one_fm_pam_designation")
+	if not license_number or not designation:
+		return None
+
+	sector = frappe.db.get_value("PAM Designation List", designation, "occupational_sector")
+	if not sector:
+		return None
+
+	return license_number, sector
+
+
+def recount_sector(license_number, sector):
+	"""Write the national and expatriate headcounts onto every row for this licence/sector.
+
+	Keyed on the licence *number* rather than the licence record: that is what an Employee
+	carries, and PAM's own numbering, so a licence renamed here still counts the same
+	people.
+
+	Written with db_set on the child row rather than by saving the parent, so a headcount
+	moving does not drag a licence through validation - and does not need permission to
+	edit a licence, which the employee's own editor has no reason to hold.
+	"""
+	rows = frappe.get_all(
+		"PAM License Stats",
+		filters={"occupational_sector": sector, "parenttype": "PAM License Details"},
+		fields=["name", "parent"],
+	)
+	if not rows:
+		return
+
+	licenses = set(
+		frappe.get_all(
+			"PAM License Details",
+			filters={"civil_id_number_for_licensing": license_number},
+			pluck="name",
+		)
+	)
+	rows = [row for row in rows if row.parent in licenses]
+	if not rows:
+		return
+
+	nationals, expatriates = count_workers(license_number, sector)
+	for row in rows:
+		frappe.db.set_value(
+			"PAM License Stats",
+			row.name,
+			{
+				"national_number_of_workers": str(nationals),
+				"expatriate_number_of_workers": str(expatriates),
+			},
+			update_modified=False,
+		)
+
+
+def count_workers(license_number, sector):
+	"""How many nationals and expatriates this licence holds in this sector.
+
+	Only active employees: someone who has left is not on the licence, and PAM counts who
+	is working under it today.
+
+	One query, grouped on nationality, rather than one count per side - the join to
+	PAM Designation List is the expensive half and there is no reason to pay for it twice.
+	"""
+	Employee = DocType("Employee")
+	Designation = DocType("PAM Designation List")
+
+	rows = (
+		frappe.qb.from_(Employee)
+		.join(Designation)
+		.on(Employee.one_fm_pam_designation == Designation.name)
+		.select(Employee.one_fm_nationality, frappe.qb.terms.Function("Count", Employee.name).as_("count"))
+		.where(Employee.pam_file_number == license_number)
+		.where(Employee.status == "Active")
+		.where(Designation.occupational_sector == sector)
+		.groupby(Employee.one_fm_nationality)
+	).run(as_dict=True)
+
+	nationals = sum(row["count"] for row in rows if row["one_fm_nationality"] == KUWAITI)
+	expatriates = sum(row["count"] for row in rows if row["one_fm_nationality"] != KUWAITI)
+
+	return nationals, expatriates
+
+
+def recount_license(license_name):
+	"""Recount every sector row on one licence.
+
+	Used to fill in a licence that has just been configured, and by the migration backfill -
+	the per-employee hook only fires when an employee is saved.
+	"""
+	license = frappe.get_doc("PAM License Details", license_name)
+	for row in license.pam_license_stats:
+		if row.occupational_sector:
+			recount_sector(license.civil_id_number_for_licensing, row.occupational_sector)

--- a/one_fm/grd/doctype/pam_license_details/test_pam_license_worker_counts.py
+++ b/one_fm/grd/doctype/pam_license_details/test_pam_license_worker_counts.py
@@ -1,0 +1,243 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002091: the actual national and expatriate headcounts on a licence's sector rows."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.grd.doctype.pam_license_details.pam_license_details import (
+	WATCHED_EMPLOYEE_FIELDS,
+	count_workers,
+	recount_license,
+	recount_sector,
+	update_counts_from_employee,
+)
+
+LICENSE = "_Test Counted License"
+LICENSE_NUMBER = "_TEST-PAM-9001"
+SECTOR = "_Test Sector Technicians"
+OTHER_SECTOR = "_Test Sector Managers"
+
+
+def _a_sector(name):
+	if not frappe.db.exists("Occupational Sector", name):
+		frappe.get_doc({"doctype": "Occupational Sector", "occupational_sector_type": name}).insert(
+			ignore_permissions=True
+		)
+	return name
+
+
+def _a_designation(name, sector):
+	"""A PAM designation in a sector - what puts an employee in that sector."""
+	if frappe.db.exists("PAM Designation List", name):
+		frappe.db.set_value("PAM Designation List", name, "occupational_sector", sector)
+		return name
+
+	designation = frappe.get_doc({
+		"doctype": "PAM Designation List",
+		"designation_name_english": name,
+		# The record is named after the Arabic name, so it cannot be left out.
+		"designation_name_arabic": name,
+		"designation_code": name,
+		"occupational_sector": sector,
+	})
+	designation.flags.ignore_permissions = True
+	designation.insert()
+	return designation.name
+
+
+class TestPAMLicenseWorkerCounts(FrappeTestCase):
+	def setUp(self):
+		self.sector = _a_sector(SECTOR)
+		self.other_sector = _a_sector(OTHER_SECTOR)
+		self.designation = _a_designation("_Test PAM Technician", self.sector)
+		self.other_designation = _a_designation("_Test PAM Manager", self.other_sector)
+		# What each borrowed employee looked like before the test pointed it at the licence.
+		# Restored explicitly in tearDown: one_fm's Employee override commits mid-save, so
+		# nothing here can rely on FrappeTestCase's rollback to undo an employee.
+		self.borrowed = {}
+		self.license = self._a_license()
+
+	def tearDown(self):
+		for name, before in self.borrowed.items():
+			frappe.db.set_value("Employee", name, before, update_modified=False)
+		if frappe.db.exists("PAM License Details", LICENSE):
+			frappe.delete_doc("PAM License Details", LICENSE, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def _a_license(self):
+		"""Rebuilt each run rather than reused: one_fm's Employee override commits, so a
+		test that touches an employee cannot rely on the rollback to clear this away."""
+		if frappe.db.exists("PAM License Details", LICENSE):
+			frappe.delete_doc("PAM License Details", LICENSE, force=True, ignore_permissions=True)
+
+		license = frappe.get_doc({
+			"doctype": "PAM License Details",
+			"label_name": LICENSE,
+			"civil_id_number_for_licensing": LICENSE_NUMBER,
+			"license_name": LICENSE,
+			"classification": "Commercial",
+			"status": "Not suspended",
+			"pam_license_stats": [
+				{"occupational_sector": self.sector},
+				{"occupational_sector": self.other_sector},
+			],
+		})
+		license.flags.ignore_permissions = True
+		license.insert()
+		return license
+
+	def _an_employee(self, nationality, designation=None, status="Active"):
+		"""An employee on the test licence.
+
+		Re-pointed rather than created: Employee sits at MariaDB's row-size limit here and a
+		fixture would need a Company, a Fiscal Year and a Designation before it inserted.
+		Written with db.set_value, which the rollback does undo.
+		"""
+		name = frappe.db.get_value(
+			"Employee",
+			{
+				"pam_file_number": ["!=", LICENSE_NUMBER],
+				"name": ["not in", list(self.borrowed) or ["__none__"]],
+			},
+			"name",
+			order_by="creation asc",
+		)
+		if not name:
+			self.skipTest("No spare Employee on this site to point at the test licence")
+
+		self.borrowed[name] = frappe.db.get_value(
+			"Employee",
+			name,
+			["pam_file_number", "one_fm_pam_designation", "one_fm_nationality", "status", "employee_name"],
+			as_dict=True,
+		)
+		frappe.db.set_value("Employee", name, {
+			"pam_file_number": LICENSE_NUMBER,
+			"one_fm_pam_designation": designation or self.designation,
+			"one_fm_nationality": nationality,
+			"status": status,
+		}, update_modified=False)
+		return name
+
+	def _row(self, sector):
+		license = frappe.get_doc("PAM License Details", self.license.name)
+		return next(row for row in license.pam_license_stats if row.occupational_sector == sector)
+
+	# ── counting ──────────────────────────────────────────────────────────────────
+
+	def test_an_empty_sector_counts_nobody(self):
+		self.assertEqual(count_workers(LICENSE_NUMBER, self.sector), (0, 0))
+
+	def test_kuwaitis_count_as_nationals_and_everyone_else_as_expatriates(self):
+		self._an_employee("Kuwaiti")
+		self._an_employee("Indian")
+		self._an_employee("Nepali")
+
+		self.assertEqual(count_workers(LICENSE_NUMBER, self.sector), (1, 2))
+
+	def test_someone_who_has_left_is_not_on_the_licence(self):
+		self._an_employee("Kuwaiti")
+		self._an_employee("Kuwaiti", status="Left")
+
+		self.assertEqual(count_workers(LICENSE_NUMBER, self.sector), (1, 0))
+
+	def test_a_sector_counts_only_its_own_designations(self):
+		self._an_employee("Kuwaiti")
+		self._an_employee("Indian", designation=self.other_designation)
+
+		self.assertEqual(count_workers(LICENSE_NUMBER, self.sector), (1, 0))
+		self.assertEqual(count_workers(LICENSE_NUMBER, self.other_sector), (0, 1))
+
+	def test_another_licence_is_counted_separately(self):
+		self._an_employee("Kuwaiti")
+
+		self.assertEqual(count_workers("_TEST-PAM-NOBODY", self.sector), (0, 0))
+
+	# ── writing the counts onto the row ───────────────────────────────────────────
+
+	def test_recounting_writes_both_figures(self):
+		self._an_employee("Kuwaiti")
+		self._an_employee("Indian")
+
+		recount_sector(LICENSE_NUMBER, self.sector)
+
+		row = self._row(self.sector)
+		self.assertEqual(row.national_number_of_workers, "1")
+		self.assertEqual(row.expatriate_number_of_workers, "1")
+
+	def test_recounting_a_licence_covers_every_sector(self):
+		self._an_employee("Kuwaiti")
+		self._an_employee("Indian", designation=self.other_designation)
+
+		recount_license(self.license.name)
+
+		self.assertEqual(self._row(self.sector).national_number_of_workers, "1")
+		self.assertEqual(self._row(self.other_sector).expatriate_number_of_workers, "1")
+
+	def test_a_licence_number_nobody_holds_leaves_the_row_alone(self):
+		recount_sector("_TEST-PAM-NOBODY", self.sector)
+
+		self.assertFalse(self._row(self.sector).national_number_of_workers)
+
+	# ── the hook ──────────────────────────────────────────────────────────────────
+	#
+	# Driven directly rather than through Employee.save(): one_fm's Employee override
+	# commits mid-save, which would take the fixtures out of the rollback's reach.
+
+	def _edit(self, name, **changed):
+		"""Apply an edit to an employee and hand the handler the document as a save would.
+
+		The before-state is captured before the write and the after-state read back after
+		it, which is the order that makes has_value_changed answer honestly.
+		"""
+		before = frappe.get_doc("Employee", name)
+		frappe.db.set_value("Employee", name, changed, update_modified=False)
+
+		doc = frappe.get_doc("Employee", name)
+		doc._doc_before_save = before
+		update_counts_from_employee(doc)
+
+	def test_a_changed_nationality_moves_the_employee_between_the_two_counts(self):
+		employee = self._an_employee("Kuwaiti")
+		recount_license(self.license.name)
+		self.assertEqual(self._row(self.sector).national_number_of_workers, "1")
+
+		self._edit(employee, one_fm_nationality="Indian")
+
+		row = self._row(self.sector)
+		self.assertEqual(row.national_number_of_workers, "0")
+		self.assertEqual(row.expatriate_number_of_workers, "1")
+
+	def test_moving_sector_empties_the_row_left_behind(self):
+		"""Recounting only where they landed would leave the old row carrying them for good."""
+		employee = self._an_employee("Indian")
+		recount_license(self.license.name)
+		self.assertEqual(self._row(self.sector).expatriate_number_of_workers, "1")
+
+		self._edit(employee, one_fm_pam_designation=self.other_designation)
+
+		self.assertEqual(self._row(self.sector).expatriate_number_of_workers, "0")
+		self.assertEqual(self._row(self.other_sector).expatriate_number_of_workers, "1")
+
+	def test_a_save_that_touches_nothing_relevant_is_skipped(self):
+		"""Employee is saved constantly; a recount on every save would be a query per save."""
+		employee = self._an_employee("Kuwaiti")
+		recount_license(self.license.name)
+
+		# Stale on purpose: if the handler ran it would correct this back to "1".
+		frappe.db.set_value(
+			"PAM License Stats", self._row(self.sector).name, "national_number_of_workers", "99",
+			update_modified=False,
+		)
+
+		self._edit(employee, employee_name="Renamed Only")
+
+		self.assertEqual(self._row(self.sector).national_number_of_workers, "99")
+
+	def test_the_watched_fields_all_exist_on_employee(self):
+		"""A typo here would silently stop the recount ever firing."""
+		meta = frappe.get_meta("Employee")
+		for fieldname in WATCHED_EMPLOYEE_FIELDS:
+			with self.subTest(fieldname=fieldname):
+				self.assertIsNotNone(meta.get_field(fieldname), fieldname)

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -239,6 +239,14 @@ doc_events = {
 			"one_fm.overrides.todo.delete_linked_todos"
 		]
 	},
+	"Employee": {
+		# WI-002091: keep the PAM licence headcounts in step with the employees on the
+		# licence. The handler returns immediately unless the save touched one of the five
+		# fields that can move somebody between licences or sectors.
+		"on_update": [
+			"one_fm.grd.doctype.pam_license_details.pam_license_details.update_counts_from_employee"
+		]
+	},
 	"HR Settings": {
 		"validate": [
 			"one_fm.grd.utils.set_renewal_extension_cost_totals",


### PR DESCRIPTION
[WI-002091] Automatic PAM License Worker Count Calculation — Operations-019, Ambrin.

> **Stacked on #6753 (WI-002102).** Merge order for the PAM group: 6753 → this → 6755 → 6756 → 6757.

## The AC

Employee details entered or updated (PAM File, PAM File Number, PAM Designation, Occupational Sector, Nationality) → on save the matching `PAM License Details → pam_license_stats` row updates `national_number_of_workers` for Kuwaitis and `expatriate_number_of_workers` for non-Kuwaitis, matched on PAM licence number and occupational sector, with no manual action on the licence.

## How it works

Both headcounts were fields an operator typed. They're the two numbers every compliance figure is derived from, so one transfer keyed in the wrong place leaves a licence reading compliant when it isn't.

- **Matched by value, not by link:** `Employee.pam_file_number` against `PAM License Details.civil_id_number_for_licensing`. That's PAM's own numbering and what the employee carries, so a licence renamed here still counts the same people. (The BA site re-points `Employee.pam_file` at PAM License Details; not done here — see the note below.)
- **Sector** comes from `one_fm_pam_designation → PAM Designation List.occupational_sector`.
- **Only active employees.** Someone who has left isn't on the licence, and PAM counts who is working under it today.
- **A recount, not a running total.** The count is a query over the employees on the licence, so it can't drift out of step with them.
- **Both sides of an edit are recounted.** A changed designation or licence number moves the employee out of one sector row and into another; recounting only where they landed would leave the row they came from carrying them for good.
- **One grouped query**, not one count per side — the join to PAM Designation List is the expensive half and there's no reason to pay for it twice.
- Written with `db_set` on the child row rather than by saving the licence, so a headcount moving doesn't drag a licence through validation and doesn't need permission to edit one — which whoever edits the employee has no reason to hold.

## The guard on the hook

Hung off `Employee.on_update`, but it returns immediately unless the save touched one of `pam_file`, `pam_file_number`, `one_fm_pam_designation`, `one_fm_nationality`, `status`. Employee is saved constantly and a recount is two joined queries; a save that can't have moved anybody shouldn't pay for one.

## Note on Employee.pam_file

The BA site changes `Employee.pam_file` to link **PAM License Details** instead of **PAM File**, and re-points `pam_file_number`'s `fetch_from` accordingly. Not done here: PAM License Details is empty on this site, so flipping the link would dangle every existing `Employee.pam_file` at once. Matching on the number sidesteps it entirely. If you want the link re-targeted, it needs a data migration (a PAM License Details record per existing PAM File first) — happy to do that as its own change.

## Tests

`bench run-tests --module one_fm.grd.doctype.pam_license_details.test_pam_license_worker_counts` — 12 passing: nationality split, leavers excluded, sectors kept apart, other licences kept apart, both figures written, a whole-licence recount, a nationality change moving someone between the counts, a sector change emptying the row left behind, an irrelevant save skipped, and every watched fieldname actually existing on Employee (a typo there would silently stop the recount ever firing).

The hook tests drive the handler directly rather than through `Employee.save()` — one_fm's Employee override commits mid-save, which would take the fixtures out of the rollback's reach. The fixtures restore every borrowed employee in `tearDown` for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)