### PR TITLE
WI-002094: derive the nationals a sector needs from its ratio

### DIFF
--- a/one_fm/grd/doctype/pam_license_details/pam_license_details.py
+++ b/one_fm/grd/doctype/pam_license_details/pam_license_details.py
@@ -11,6 +11,7 @@ licence that reads compliant when it is not.
 import frappe
 from frappe.model.document import Document
 from frappe.query_builder import DocType
+from frappe.utils import flt
 
 KUWAITI = "Kuwaiti"
 
@@ -30,7 +31,66 @@ WATCHED_EMPLOYEE_FIELDS = (
 
 
 class PAMLicenseDetails(Document):
-	pass
+	def validate(self):
+		self.set_sector_figures()
+
+	def set_sector_figures(self):
+		"""Derive every figure a sector row computes from its ratio (WI-002094).
+
+		On validate as well as on a recount, because the ratio is the half an operator
+		types: it is entered here and the figures that follow from it have to move with it
+		without waiting for somebody to be transferred.
+		"""
+		for row in self.pam_license_stats:
+			for fieldname, value in derived_figures(
+				row.ratio_number_of_national_workers,
+				row.national_number_of_workers,
+				row.expatriate_number_of_workers,
+			).items():
+				row.set(fieldname, value)
+
+
+def round_to_half(value):
+	"""PAM states its figures to the nearest half a person (WI-002094)."""
+	return round(flt(value) * 2) / 2
+
+
+def as_figure(value):
+	"""A figure as it goes into a Data field: "3" rather than "3.0", "2.5" as it is."""
+	value = round_to_half(value)
+	return str(int(value)) if value == int(value) else str(value)
+
+
+def derived_figures(ratio, nationals, expatriates):
+	"""What one sector row's ratio and two actual headcounts imply (WI-002094).
+
+	The ratio is the share of the workforce PAM requires to be Kuwaiti, so the nationals a
+	licence needs to carry its expatriates is expatriates x ratio / (100 - ratio).
+
+	Outside 0 < ratio < 100 there is no requirement to state: at 100 the formula divides by
+	zero, above it the answer is negative, and at 0 or blank PAM asks for no nationals in
+	that sector. All three come out as no requirement rather than as an error - the ratio is
+	typed by hand and a licence should not refuse to save because one row is unfilled.
+
+	Excess Nationals is what the licence is still short of that requirement, and never less
+	than zero: a sector already carrying enough nationals is not short of any.
+
+	Kept as a plain function so the arithmetic can be checked without a licence, and so the
+	controller and the recount both go through one copy of it.
+	"""
+	ratio = flt(ratio)
+
+	required = 0.0
+	if 0 < ratio < 100:
+		required = flt(expatriates) * ratio / (100 - ratio)
+	required = round_to_half(required)
+
+	excess = max(required - flt(nationals), 0)
+
+	return {
+		"required_number_of_national_workers": as_figure(required),
+		"exceeding_the_ratio_number_of_national_workers": as_figure(excess),
+	}
 
 
 def update_counts_from_employee(doc, method=None):
@@ -100,15 +160,21 @@ def recount_sector(license_number, sector):
 
 	nationals, expatriates = count_workers(license_number, sector)
 	for row in rows:
-		frappe.db.set_value(
-			"PAM License Stats",
-			row.name,
-			{
-				"national_number_of_workers": str(nationals),
-				"expatriate_number_of_workers": str(expatriates),
-			},
-			update_modified=False,
+		figures = {
+			"national_number_of_workers": str(nationals),
+			"expatriate_number_of_workers": str(expatriates),
+		}
+		# The derived figures move with the counts they are derived from. Written here as
+		# well as on validate because db_set bypasses the controller, and a row left with
+		# yesterday's requirement beside today's headcount is worse than either.
+		figures.update(
+			derived_figures(
+				frappe.db.get_value("PAM License Stats", row.name, "ratio_number_of_national_workers"),
+				nationals,
+				expatriates,
+			)
 		)
+		frappe.db.set_value("PAM License Stats", row.name, figures, update_modified=False)
 
 
 def count_workers(license_number, sector):

--- a/one_fm/grd/doctype/pam_license_details/test_pam_sector_figures.py
+++ b/one_fm/grd/doctype/pam_license_details/test_pam_sector_figures.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002094: the nationals a sector needs, and what it is short of."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.grd.doctype.pam_license_details.pam_license_details import (
+	as_figure,
+	derived_figures,
+	round_to_half,
+)
+
+SECTOR = "_Test Figures Sector"
+
+
+def _a_sector(name):
+	if not frappe.db.exists("Occupational Sector", name):
+		frappe.get_doc({"doctype": "Occupational Sector", "occupational_sector_type": name}).insert(
+			ignore_permissions=True
+		)
+	return name
+
+
+class TestRoundToHalf(FrappeTestCase):
+	def test_it_rounds_to_the_nearest_half(self):
+		for value, expected in ((0, 0), (0.2, 0), (0.3, 0.5), (0.7, 0.5), (0.8, 1.0), (2.24, 2.0), (2.26, 2.5)):
+			with self.subTest(value=value):
+				self.assertEqual(round_to_half(value), expected)
+
+	def test_a_whole_figure_loses_its_decimal(self):
+		self.assertEqual(as_figure(3.0), "3")
+		self.assertEqual(as_figure(3.5), "3.5")
+		self.assertEqual(as_figure(0), "0")
+
+	def test_a_blank_reads_as_nothing(self):
+		"""Every figure on the row is a Data field, so it can be empty rather than zero."""
+		self.assertEqual(as_figure(None), "0")
+		self.assertEqual(as_figure(""), "0")
+
+
+class TestDerivedFigures(FrappeTestCase):
+	def test_the_requirement_follows_the_ratio(self):
+		# 20% of the workforce Kuwaiti: 8 expats need 8 x 20 / 80 = 2 nationals.
+		figures = derived_figures(ratio=20, nationals=0, expatriates=8)
+		self.assertEqual(figures["required_number_of_national_workers"], "2")
+
+	def test_the_requirement_is_stated_to_the_nearest_half(self):
+		# 9 x 20 / 80 = 2.25 -> 2
+		self.assertEqual(derived_figures(20, 0, 9)["required_number_of_national_workers"], "2")
+		# 11 x 20 / 80 = 2.75 -> 2.5... rounds to 3 at .75
+		self.assertEqual(derived_figures(20, 0, 11)["required_number_of_national_workers"], "3")
+		# 10 x 20 / 80 = 2.5, already a half
+		self.assertEqual(derived_figures(20, 0, 10)["required_number_of_national_workers"], "2.5")
+
+	def test_a_shortfall_is_what_the_sector_is_missing(self):
+		figures = derived_figures(ratio=20, nationals=1, expatriates=8)
+		self.assertEqual(figures["required_number_of_national_workers"], "2")
+		self.assertEqual(figures["exceeding_the_ratio_number_of_national_workers"], "1")
+
+	def test_a_sector_that_already_has_enough_is_short_of_nothing(self):
+		"""Never negative - a sector carrying more nationals than required is not short."""
+		figures = derived_figures(ratio=20, nationals=5, expatriates=8)
+		self.assertEqual(figures["exceeding_the_ratio_number_of_national_workers"], "0")
+
+	def test_no_ratio_asks_for_no_nationals(self):
+		for ratio in (None, "", 0):
+			with self.subTest(ratio=ratio):
+				figures = derived_figures(ratio, nationals=0, expatriates=8)
+				self.assertEqual(figures["required_number_of_national_workers"], "0")
+				self.assertEqual(figures["exceeding_the_ratio_number_of_national_workers"], "0")
+
+	def test_a_ratio_of_a_hundred_or_more_states_no_requirement(self):
+		"""At 100 the formula divides by zero and above it the answer is negative. A
+		hand-typed ratio must not stop the licence saving."""
+		for ratio in (100, 120):
+			with self.subTest(ratio=ratio):
+				self.assertEqual(
+					derived_figures(ratio, nationals=0, expatriates=8)["required_number_of_national_workers"],
+					"0",
+				)
+
+	def test_the_counts_may_arrive_as_the_strings_the_row_stores(self):
+		figures = derived_figures("20", "1", "8")
+		self.assertEqual(figures["required_number_of_national_workers"], "2")
+		self.assertEqual(figures["exceeding_the_ratio_number_of_national_workers"], "1")
+
+
+class TestLicenceRecalculates(FrappeTestCase):
+	def setUp(self):
+		self.sector = _a_sector(SECTOR)
+
+	def test_saving_a_licence_fills_the_figures_in(self):
+		license = frappe.get_doc({
+			"doctype": "PAM License Details",
+			"label_name": "_Test Figures Licence",
+			"civil_id_number_for_licensing": "_TEST-PAM-FIG",
+			"license_name": "_Test Figures Licence",
+			"classification": "Commercial",
+			"status": "Not suspended",
+			"pam_license_stats": [{
+				"occupational_sector": self.sector,
+				"ratio_number_of_national_workers": "20",
+				"national_number_of_workers": "1",
+				"expatriate_number_of_workers": "8",
+			}],
+		})
+		license.flags.ignore_permissions = True
+		license.insert()
+
+		row = license.pam_license_stats[0]
+		self.assertEqual(row.required_number_of_national_workers, "2")
+		self.assertEqual(row.exceeding_the_ratio_number_of_national_workers, "1")
+
+	def test_changing_the_ratio_moves_the_figures(self):
+		license = frappe.get_doc({
+			"doctype": "PAM License Details",
+			"label_name": "_Test Ratio Change Licence",
+			"civil_id_number_for_licensing": "_TEST-PAM-RATIO",
+			"license_name": "_Test Ratio Change Licence",
+			"classification": "Commercial",
+			"status": "Not suspended",
+			"pam_license_stats": [{
+				"occupational_sector": self.sector,
+				"ratio_number_of_national_workers": "20",
+				"national_number_of_workers": "0",
+				"expatriate_number_of_workers": "8",
+			}],
+		})
+		license.flags.ignore_permissions = True
+		license.insert()
+		self.assertEqual(license.pam_license_stats[0].required_number_of_national_workers, "2")
+
+		license.pam_license_stats[0].ratio_number_of_national_workers = "50"
+		license.save()
+
+		# 8 x 50 / 50 = 8
+		self.assertEqual(license.pam_license_stats[0].required_number_of_national_workers, "8")
+		self.assertEqual(license.pam_license_stats[0].exceeding_the_ratio_number_of_national_workers, "8")


### PR DESCRIPTION
[WI-002094] PAM License National Ratio Calculation — Operations-019, Ambrin.

> **Stacked on #6754 (WI-002091) → #6753 (WI-002102).**

## The AC

Ratio entered per sector → `Required Number of Nationals = (Actual Expats × Ratio) / (100 − Ratio)`, `Excess Nationals = Required − Actual Nationals` floored at 0, everything rounded to the nearest 0.5.

## What it does

The ratio is the one figure on the row an operator types. Everything following from it was typed too, so the requirement and the shortfall were only ever as current as the last person to work them out by hand.

Both are now derived, to the nearest half, which is how PAM states them. Recalculated **on validate and again on every recount** — `db_set` bypasses the controller, and a row left with yesterday's requirement beside today's headcount is worse than either being stale alone.

## Edge cases, deliberately not errors

Outside `0 < ratio < 100` there is no requirement to state: at 100 the formula divides by zero, above it the answer is negative, and at 0 or blank PAM asks for no nationals in that sector. All three come out as **no requirement** rather than an exception — the ratio is hand-typed and a licence shouldn't refuse to save over one unfilled row.

`Excess Nationals` never goes below zero: a sector already carrying enough nationals isn't short of any. (Note the field's label reads "Excess" but the AC's formula measures a *shortfall* — `Required − Actual`. Implemented as specified; the naming is PAM's.)

## Shape

The arithmetic is a plain function taking three values, so it can be checked without a licence, and the controller and the recount share one copy of it. The next two PRs in the stack extend the same function.

## Tests

`bench run-tests --module one_fm.grd.doctype.pam_license_details.test_pam_sector_figures` — 12 passing: rounding to the nearest half (including that `3.0` prints as `"3"` and blanks read as `0`), the requirement following the ratio, the shortfall, the floor at zero, no-ratio and ratio ≥ 100, values arriving as the strings the Data fields store, and a real licence filling in and then moving its figures when the ratio changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)