### PR TITLE
WI-002109: give PACI the Damj details, and show each block only when it applies

### DIFF
--- a/one_fm/grd/doctype/paci/paci.json
+++ b/one_fm/grd/doctype/paci/paci.json
@@ -21,6 +21,8 @@
   "third_name_arabic",
   "last_name_arabic",
   "civil_id",
+  "damj_is_applicable",
+  "original_civil_id",
   "column_break_8",
   "first_name_english",
   "second_name_english",
@@ -42,11 +44,13 @@
   "upload_civil_id_payment",
   "upload_hawiyati",
   "upload_civil_id",
+  "upload_damj_letter",
   "new_civil_id_expiry_date",
   "pro_user",
   "column_break_25",
   "upload_civil_id_payment_datetime",
   "upload_civil_id_datetime",
+  "upload_damj_letter_on",
   "completed_on",
   "amended_from",
   "grd_operator",
@@ -198,10 +202,12 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "is_paci_fine_applicable",
+   "depends_on": "eval:doc.is_paci_fine_applicable == 1",
    "fieldname": "paci_fine_amount_kwd",
    "fieldtype": "Currency",
    "label": "PACI Fine Amount (KWD)",
+   "mandatory_depends_on": "eval:doc.is_paci_fine_applicable == 1",
+   "non_negative": 1,
    "read_only": 1
   },
   {
@@ -354,6 +360,7 @@
    "label": "Reminder Government Relations Operator Again"
   },
   {
+   "depends_on": "eval:doc.workflow_state == \"Rejected\"",
    "fieldname": "rejection_details_section",
    "fieldtype": "Section Break",
    "label": "Rejection Details"
@@ -389,11 +396,39 @@
    "fieldtype": "Link",
    "label": "PRO User",
    "options": "User"
+  },
+  {
+   "default": "0",
+   "fieldname": "damj_is_applicable",
+   "fieldtype": "Check",
+   "label": "DAMJ is Applicable"
+  },
+  {
+   "depends_on": "eval:doc.damj_is_applicable == 1",
+   "fieldname": "original_civil_id",
+   "fieldtype": "Data",
+   "label": "Original Civil ID",
+   "mandatory_depends_on": "eval:doc.damj_is_applicable == 1"
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval:doc.damj_is_applicable == 1",
+   "fieldname": "upload_damj_letter",
+   "fieldtype": "Attach",
+   "label": "Upload DAMJ Letter",
+   "mandatory_depends_on": "eval:doc.damj_is_applicable == 1"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "upload_damj_letter_on",
+   "fieldtype": "Data",
+   "label": "Upload DAMJ Letter On",
+   "read_only": 1
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-20 10:00:00.000000",
+ "modified": "2026-08-20 13:30:00.000000",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "PACI",

--- a/one_fm/grd/doctype/paci/paci.py
+++ b/one_fm/grd/doctype/paci/paci.py
@@ -54,6 +54,60 @@ class PACI(Document):
         self.set_grd_values()
         self.set_new_expiry_date()
         self.set_paci_fine_amount()
+        self.clear_unticked_damj_details()
+        self.validate_exception_details()
+
+    def validate_exception_details(self):
+        """Hold the save until a ticked exception carries its evidence (WI-002109).
+
+        mandatory_depends_on is a form rule only - Frappe's server-side mandatory check reads
+        `reqd` and nothing else - so a record arriving by import or through the API would
+        otherwise claim a Damj merge with no original civil ID and no letter behind it.
+
+        A fine amount of zero counts as missing: the amount comes from the master rate in HR
+        Settings, so a ticked box that produces nothing means the rate is not configured, and
+        a zero-value fine has nothing for finance to reference. Same rule Residency applies.
+        """
+        field_list = []
+
+        if self.damj_is_applicable:
+            field_list += [
+                {'Original Civil ID': 'original_civil_id'},
+                {'Upload DAMJ Letter': 'upload_damj_letter'},
+            ]
+
+        if field_list:
+            self.set_mendatory_fields(field_list)
+
+        # The fine amount is read-only and comes from the master rate, so a ticked box that
+        # produces nothing is a gap in HR Settings rather than something the operator forgot
+        # to type - and the message has to say so, or it points at a field they cannot edit.
+        # WI-002109 requires the amount to be greater than zero; WI-002023 let a record save
+        # with a zero fine, which recorded a fine finance had nothing to reference.
+        if self.is_paci_fine_applicable and not flt(self.paci_fine_amount_kwd):
+            frappe.throw(
+                _("The PACI fine rate is not configured. Set <b>PACI Fine Amount (KWD)</b> in "
+                  "HR Settings, or untick <b>Is PACI Fine Applicable?</b>."),
+                title=_("PACI Fine Rate Not Configured"),
+            )
+
+    def clear_unticked_damj_details(self):
+        """Empty the Damj details when the box is unticked (WI-002109).
+
+        Both fields are hidden then, so anything left in them is invisible - and an original
+        civil ID still on a record that no longer claims a merge is the number the employee's
+        profile would be set to if the box were ever ticked again.
+
+        Cleared on the server rather than only in the browser: the box can be unticked by an
+        import, a patch or the API, none of which run the form's handlers. The fine amount
+        already clears itself the same way in set_paci_fine_amount.
+        """
+        if self.damj_is_applicable:
+            return
+
+        self.original_civil_id = None
+        self.upload_damj_letter = None
+        self.upload_damj_letter_on = None
 
     def set_paci_fine_amount(self):
         """Fetch the PACI late fine off HR Settings, or clear it (WI-002023).
@@ -102,6 +156,18 @@ class PACI(Document):
     def on_update(self):
         self.validate_payment_invoice_on_done()
         self.validate_pro_submission()
+        self.stamp_damj_letter()
+
+    def stamp_damj_letter(self):
+        """Record when the Damj letter went up, from the server's clock (WI-002109).
+
+        The Attach field is allow_on_submit, so the letter can arrive after the record is
+        submitted - which is why this is on on_update and written with db_set.
+        """
+        if self.upload_damj_letter and not self.upload_damj_letter_on:
+            self.db_set("upload_damj_letter_on", now_datetime())
+        elif not self.upload_damj_letter and self.upload_damj_letter_on:
+            self.db_set("upload_damj_letter_on", None)
 
     def validate_pro_submission(self):
         """Hold a first application with the PRO until they have filed it (WI-002136).

--- a/one_fm/grd/doctype/paci/test_paci_damj_and_fine_fields.py
+++ b/one_fm/grd/doctype/paci/test_paci_damj_and_fine_fields.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002109: which PACI fields show, which are required, and what unticking clears."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import today
+
+DAMJ = "eval:doc.damj_is_applicable == 1"
+FINE = "eval:doc.is_paci_fine_applicable == 1"
+REJECTED = 'eval:doc.workflow_state == "Rejected"'
+
+A_LETTER = "/files/damj-letter.pdf"
+
+
+def _an_active_employee():
+	name = frappe.db.get_value("Employee", {"status": "Active"}, "name", order_by="creation asc")
+	if not name:
+		raise frappe.DoesNotExistError("No active employee on this site to test against")
+	return name
+
+
+class TestPACIDamjAndFineFields(FrappeTestCase):
+	def setUp(self):
+		self.employee = _an_active_employee()
+		self.meta = frappe.get_meta("PACI")
+
+	def _a_paci(self, **kwargs):
+		paci = frappe.get_doc({
+			"doctype": "PACI",
+			"employee": self.employee,
+			"category": "Renewal",
+			"date_of_application": today(),
+			**kwargs,
+		})
+		paci.flags.ignore_permissions = True
+		paci.insert()
+		return paci
+
+	# ── the fields exist ──────────────────────────────────────────────────────────
+
+	def test_the_record_can_carry_a_damj_merge(self):
+		for fieldname in ("damj_is_applicable", "original_civil_id", "upload_damj_letter", "upload_damj_letter_on"):
+			with self.subTest(fieldname=fieldname):
+				self.assertIsNotNone(self.meta.get_field(fieldname), fieldname)
+
+	# ── visibility ────────────────────────────────────────────────────────────────
+
+	def test_the_damj_details_follow_the_damj_checkbox(self):
+		for fieldname in ("original_civil_id", "upload_damj_letter"):
+			with self.subTest(fieldname=fieldname):
+				field = self.meta.get_field(fieldname)
+				self.assertEqual(field.depends_on, DAMJ)
+				self.assertEqual(field.mandatory_depends_on, DAMJ)
+
+	def test_the_fine_amount_follows_the_fine_checkbox(self):
+		field = self.meta.get_field("paci_fine_amount_kwd")
+		self.assertEqual(field.depends_on, FINE)
+		self.assertEqual(field.mandatory_depends_on, FINE)
+		self.assertTrue(field.non_negative)
+
+	def test_the_whole_rejection_block_waits_for_a_rejection(self):
+		"""Not only the reason - an empty section headed Rejection Details on a record nobody
+		rejected is noise."""
+		self.assertEqual(self.meta.get_field("rejection_details_section").depends_on, REJECTED)
+		self.assertEqual(self.meta.get_field("paci_rejection_reason").depends_on, REJECTED)
+
+	# ── required when ticked ──────────────────────────────────────────────────────
+
+	def test_a_ticked_damj_needs_its_civil_id_and_letter(self):
+		with self.assertRaises(frappe.ValidationError):
+			self._a_paci(damj_is_applicable=1)
+
+	def test_a_ticked_damj_with_both_saves(self):
+		paci = self._a_paci(
+			damj_is_applicable=1, original_civil_id="299010101010", upload_damj_letter=A_LETTER
+		)
+		self.assertEqual(paci.original_civil_id, "299010101010")
+
+	# ── cleared when unticked ─────────────────────────────────────────────────────
+
+	def test_unticking_the_damj_clears_what_it_claimed(self):
+		paci = self._a_paci(
+			damj_is_applicable=1, original_civil_id="299010101010", upload_damj_letter=A_LETTER
+		)
+
+		paci.damj_is_applicable = 0
+		paci.save()
+
+		self.assertFalse(paci.original_civil_id)
+		self.assertFalse(paci.upload_damj_letter)
+		self.assertFalse(paci.upload_damj_letter_on)
+
+	def test_unticking_the_fine_puts_the_amount_back_to_zero(self):
+		"""Already how set_paci_fine_amount behaved; pinned here with the rest."""
+		frappe.db.set_single_value("HR Settings", "paci_fine_amount_kwd", 10)
+		paci = self._a_paci(is_paci_fine_applicable=1)
+		self.assertEqual(paci.paci_fine_amount_kwd, 10)
+
+		paci.is_paci_fine_applicable = 0
+		paci.save()
+
+		self.assertEqual(paci.paci_fine_amount_kwd, 0)
+
+	# ── the letter's timestamp ────────────────────────────────────────────────────
+
+	def test_the_letter_is_stamped_when_it_arrives(self):
+		paci = self._a_paci(
+			damj_is_applicable=1, original_civil_id="299010101010", upload_damj_letter=A_LETTER
+		)
+
+		paci.reload()
+		self.assertTrue(paci.upload_damj_letter_on)

--- a/one_fm/grd/doctype/paci/test_paci_fine.py
+++ b/one_fm/grd/doctype/paci/test_paci_fine.py
@@ -62,9 +62,12 @@ class TestPaciFine(FrappeTestCase):
 		self.assertEqual(paci.paci_fine_amount_kwd, MASTER_RATE)
 
 	@change_settings("HR Settings", {"paci_fine_amount_kwd": 0})
-	def test_an_unconfigured_master_rate_yields_zero_rather_than_none(self):
-		paci = self._paci(is_paci_fine_applicable=1)
-		self.assertEqual(paci.paci_fine_amount_kwd, 0)
+	def test_an_unconfigured_master_rate_is_refused(self):
+		"""WI-002109 requires a fine greater than zero. This used to save with a zero fine,
+		which recorded a fine finance had nothing to reference - the message now names the
+		HR Settings rate, because the amount field itself is read-only."""
+		with self.assertRaises(frappe.ValidationError):
+			self._paci(is_paci_fine_applicable=1)
 
 	@change_settings("HR Settings", {"paci_fine_amount_kwd": 25.5})
 	def test_a_changed_master_rate_is_picked_up_on_the_next_save(self):

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -587,3 +587,4 @@ one_fm.patches.v15_0.add_pcc_processing_fees_to_hr_settings #2026-08-12 WI-00202
 one_fm.patches.v15_0.add_shift_request_shift_preview #2026-08-12 WI-001834
 one_fm.patches.v15_0.restore_stranded_mixed_shipments #2026-08-17 WI-002071
 one_fm.patches.v15_0.update_paci_no_payment_workflow #2026-08-19 WI-002136
+one_fm.patches.v15_0.add_paci_damj_fields #2026-08-20 WI-002109

--- a/one_fm/patches/v15_0/add_paci_damj_fields.py
+++ b/one_fm/patches/v15_0/add_paci_damj_fields.py
@@ -1,0 +1,19 @@
+import frappe
+
+# WI-002109: PACI carries the Damj merge details now - the civil ID the employee held before
+# and the government letter authorising the merge - and the fine amount and the rejection
+# block only show when they apply.
+FIELDS = ("damj_is_applicable", "original_civil_id", "upload_damj_letter", "upload_damj_letter_on")
+
+
+def execute():
+	frappe.reload_doc("grd", "doctype", "paci")
+
+	verify()
+
+
+def verify():
+	meta = frappe.get_meta("PACI")
+	missing = [fieldname for fieldname in FIELDS if not meta.get_field(fieldname)]
+	if missing:
+		frappe.throw(f"WI-002109: {missing} were not added to PACI.")


### PR DESCRIPTION
[WI-002109] PACI Doctype Update — Operations-019, Ambrin.

> **Stacked on #6749 (WI-002136, Iman)** — that PR adds `no_payment_required` and `pro_user` to the same doctype JSON.

## AC by AC

| AC | Status |
|---|---|
| DAMJ checked → Original Civil ID + Upload DAMJ Letter visible **and mandatory** | fields **added** (PACI had neither) + `depends_on`/`mandatory_depends_on` + server enforcement |
| DAMJ unchecked → both hidden | `depends_on`; also **cleared** server-side |
| Is PACI Fine Applicable checked → amount visible and mandatory (> 0); unchecked → hidden, reset to 0.000 | `mandatory_depends_on` + a > 0 check; the reset already existed |
| Rejected → Rejection Details section **and** the reason visible | `depends_on` on both |

A Damj merge replaces the employee's civil ID with the one they held before, so the record has to carry that number and the government letter authorising the merge. Residency has both; **PACI had neither**, which is also why WI-002100's write-back had nothing to read.

## Why the enforcement is server-side too

`mandatory_depends_on` is a **form rule only** — Frappe's server-side mandatory check reads `reqd` and nothing else. Without a matching validation, a record arriving by import or through the API claims a merge with no civil ID and no letter behind it.

Unticking clears what the box claimed, on the server. An original civil ID left on a record that no longer claims a merge is the number the employee's profile would be set to if the box were ever ticked again.

The letter is stamped with the server's clock when it arrives and unstamped if removed — the Attach field is `allow_on_submit`, so it can land after submit.

## ⚠️ One behaviour change

WI-002109 requires the fine amount to be **greater than zero**. WI-002023 let a ticked box save with a **zero** fine when the master rate was unconfigured — recording a fine finance had nothing to reference. That's refused now.

Because the amount is read-only and derived from HR Settings, the message names the **HR Settings rate** rather than pointing at a field the operator can't edit. WI-002023's `test_an_unconfigured_master_rate_yields_zero_rather_than_none` is renamed and flipped to match.

## Tests

`bench run-tests --module one_fm.grd.doctype.paci.test_paci_damj_and_fine_fields` — 9 passing: the four new fields exist, both blocks' visibility and mandatory rules, the non-negative fine, the whole rejection block gated, a ticked Damj without evidence refused, a ticked Damj with both saving, unticking clearing each block, and the letter's timestamp.

`test_paci_fine` (6), `test_paci_no_payment` (14) and `test_paci_pro_workflow` (16) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)