### PR TITLE
WI-002100: carry a permit's expiry down to the Residency and PACI, and write a Damj back

### DIFF
--- a/one_fm/grd/doctype/paci/paci.py
+++ b/one_fm/grd/doctype/paci/paci.py
@@ -229,8 +229,35 @@ class PACI(Document):
     def on_submit(self):
         self.validate_mandatory_fields_on_submit()
         self.set_New_civil_id_Expiry_date_in_employee_doctype()
+        self.apply_damj_civil_id()
         self.db_set('paci_status',"Completed")
         self.db_set('completed_on', today())
+
+    def apply_damj_civil_id(self):
+        """Put the merged Civil ID on the Employee once the application completes (WI-002100).
+
+        A Damj merges two civil ID numbers the government issued the same person, and the
+        surviving one is the original. Until it is written back, every record that reads the
+        Civil ID off the Employee is quoting the number the government just retired.
+
+        Residency does the same thing when its own Damj completes (WI-002022). Either
+        document can be the one that finishes first, and both write the same number, so
+        whichever completes last is a no-op rather than a conflict.
+
+        Written with set_value rather than a full Employee save: a full save re-validates the
+        whole Employee, and over a thousand of them hold a Marital Status the field's options
+        no longer accept, so any such save throws on data that has nothing to do with the
+        civil ID.
+
+        This record's own mirror of the number is updated too - it is fetched from the
+        Employee and would otherwise keep showing the retired number on the very document
+        that recorded the merge.
+        """
+        if not (self.damj_is_applicable and self.original_civil_id):
+            return
+
+        frappe.db.set_value('Employee', self.employee, 'one_fm_civil_id', self.original_civil_id)
+        self.db_set('civil_id', self.original_civil_id)
 
     def validate_mandatory_fields_on_submit(self):
         if self.workflow_state == 'Completed':

--- a/one_fm/grd/doctype/paci/test_paci_expiry_and_damj_sync.py
+++ b/one_fm/grd/doctype/paci/test_paci_expiry_and_damj_sync.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002100: expiry dates carried down from the Work Permit, and the Damj write-back."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, nowdate
+
+from one_fm.grd.doctype.preparation.preparation import create_documents_for_row
+
+A_LETTER = "/files/damj-letter.pdf"
+MERGED_CIVIL_ID = "299010101010"
+
+
+def _an_active_employee():
+	name = frappe.db.get_value(
+		"Employee",
+		{"status": "Active", "relieving_date": ["is", "not set"]},
+		"name",
+		order_by="creation asc",
+	)
+	if not name:
+		raise frappe.DoesNotExistError("No active employee on this site to test against")
+	return name
+
+
+class TestExpirySyncFromWorkPermit(FrappeTestCase):
+	def setUp(self):
+		self.employee = _an_active_employee()
+		self.preparation = self._a_preparation()
+
+	def _a_preparation(self):
+		preparation = frappe.get_doc({
+			"doctype": "Preparation",
+			"category": "Onboarding",
+			"posting_date": nowdate(),
+			"preparation_record": [{"employee": self.employee, "renewal_or_extend": "Overseas"}],
+		})
+		preparation.flags.ignore_permissions = True
+		preparation.insert()
+		create_documents_for_row(preparation.preparation_record[0], preparation.name)
+		return preparation
+
+	def _linked(self, doctype):
+		return frappe.get_last_doc(doctype, filters={"preparation": self.preparation.name})
+
+	def test_a_new_expiry_reaches_the_residency_and_the_paci(self):
+		expiry = add_days(nowdate(), 365)
+		work_permit = self._linked("Work Permit")
+
+		work_permit.sync_expiry_dates_to_linked_documents(expiry)
+
+		self.assertEqual(str(self._linked("Residency").new_residency_expiry_date), expiry)
+		self.assertEqual(str(self._linked("PACI").new_civil_id_expiry_date), expiry)
+
+	def test_a_correction_reaches_them_too(self):
+		"""Both read the date off the Employee once, when they are opened, so a later
+		correction would otherwise never arrive."""
+		work_permit = self._linked("Work Permit")
+		work_permit.sync_expiry_dates_to_linked_documents(add_days(nowdate(), 365))
+
+		corrected = add_days(nowdate(), 730)
+		work_permit.sync_expiry_dates_to_linked_documents(corrected)
+
+		self.assertEqual(str(self._linked("Residency").new_residency_expiry_date), corrected)
+		self.assertEqual(str(self._linked("PACI").new_civil_id_expiry_date), corrected)
+
+	def test_no_expiry_date_changes_nothing(self):
+		work_permit = self._linked("Work Permit")
+		work_permit.sync_expiry_dates_to_linked_documents(add_days(nowdate(), 365))
+		before = self._linked("PACI").new_civil_id_expiry_date
+
+		work_permit.sync_expiry_dates_to_linked_documents(None)
+
+		self.assertEqual(self._linked("PACI").new_civil_id_expiry_date, before)
+
+	def test_a_permit_with_no_preparation_has_nothing_to_pair_with(self):
+		work_permit = self._linked("Work Permit")
+		before = self._linked("PACI").new_civil_id_expiry_date
+		work_permit.preparation = None
+
+		work_permit.sync_expiry_dates_to_linked_documents(add_days(nowdate(), 365))
+
+		self.assertEqual(self._linked("PACI").new_civil_id_expiry_date, before)
+
+
+class TestPACIDamjWriteBack(FrappeTestCase):
+	def setUp(self):
+		self.employee = _an_active_employee()
+		self.before = frappe.db.get_value("Employee", self.employee, "one_fm_civil_id")
+
+	def tearDown(self):
+		frappe.db.set_value("Employee", self.employee, "one_fm_civil_id", self.before, update_modified=False)
+
+	def _a_completed_paci(self, **kwargs):
+		paci = frappe.get_doc({
+			"doctype": "PACI",
+			"employee": self.employee,
+			"category": "Renewal",
+			"date_of_application": nowdate(),
+			"new_civil_id_expiry_date": add_days(nowdate(), 365),
+			**kwargs,
+		})
+		paci.flags.ignore_permissions = True
+		paci.insert()
+		paci.db_set("workflow_state", "Completed")
+		paci.reload()
+		paci.submit()
+		return paci
+
+	def test_completing_a_damj_puts_the_merged_number_on_the_employee(self):
+		self._a_completed_paci(
+			damj_is_applicable=1, original_civil_id=MERGED_CIVIL_ID, upload_damj_letter=A_LETTER
+		)
+
+		self.assertEqual(
+			frappe.db.get_value("Employee", self.employee, "one_fm_civil_id"), MERGED_CIVIL_ID
+		)
+
+	def test_the_record_stops_quoting_the_retired_number(self):
+		paci = self._a_completed_paci(
+			damj_is_applicable=1, original_civil_id=MERGED_CIVIL_ID, upload_damj_letter=A_LETTER
+		)
+
+		paci.reload()
+		self.assertEqual(paci.civil_id, MERGED_CIVIL_ID)
+
+	def test_a_completion_with_no_damj_leaves_the_employee_alone(self):
+		self._a_completed_paci()
+
+		self.assertEqual(
+			frappe.db.get_value("Employee", self.employee, "one_fm_civil_id"), self.before
+		)

--- a/one_fm/grd/doctype/work_permit/work_permit.py
+++ b/one_fm/grd/doctype/work_permit/work_permit.py
@@ -334,6 +334,43 @@ class WorkPermit(Document):
                     to_remove.append(document)
             [document.delete(document) for document in to_remove]
 
+    def sync_expiry_dates_to_linked_documents(self, new_expiry_date):
+        """Carry a new Work Permit expiry over to the Residency and PACI beside it (WI-002100).
+
+        The residency and the civil ID are both issued to run with the work permit, so the
+        permit's expiry is the date all three legally share. Both documents read it off the
+        Employee - once, when they are opened - so a permit whose expiry is set or corrected
+        afterwards left them quoting the old date on the paperwork submitted to MOI and PACI.
+
+        Paired by Preparation and employee, which is what "linked" means for these two: a
+        Preparation opens one Residency and one PACI per employee. A permit raised outside a
+        Preparation - a transfer, a cancellation - has nothing to pair with.
+
+        Cancelled documents are skipped; there can be more than one live record for the same
+        employee (a rejected application and its replacement) and both need the new date.
+
+        Written with set_value: the fields are read-only, the documents may already be
+        submitted, and a full save would re-run each document's own validation over a change
+        that has no business re-validating it.
+        """
+        if not (new_expiry_date and self.preparation):
+            return
+
+        for doctype, fieldname in (
+            ("Residency", "new_residency_expiry_date"),
+            ("PACI", "new_civil_id_expiry_date"),
+        ):
+            for name in frappe.get_all(
+                doctype,
+                filters={
+                    "preparation": self.preparation,
+                    "employee": self.employee,
+                    "docstatus": ["!=", 2],
+                },
+                pluck="name",
+            ):
+                frappe.db.set_value(doctype, name, fieldname, new_expiry_date)
+
     def set_work_permit_attachment_in_employee_doctype(self,new_expiry_date, work_permit_attachment=False):
         """
         runs: `on_submit`
@@ -346,6 +383,7 @@ class WorkPermit(Document):
         """
         if not work_permit_attachment:
             frappe.db.set_value("Employee", self.employee, "work_permit_expiry_date", new_expiry_date)
+            self.sync_expiry_dates_to_linked_documents(new_expiry_date)
             return
 
         today = date.today()
@@ -373,6 +411,7 @@ class WorkPermit(Document):
             })
         employee.work_permit_expiry_date = new_expiry_date
         employee.save()
+        self.sync_expiry_dates_to_linked_documents(new_expiry_date)
 
     @frappe.whitelist()
     def get_required_documents(self):


### PR DESCRIPTION
[WI-002100] Residency & PACI Expiry Sync, Damj Merges & Fine Handling — Operations-019, Ambrin.

> **Stacked on #6762 (WI-002109) → #6749 (WI-002136).** WI-002109 adds the Damj fields this PR writes to.

## The two ACs

**1. Work Permit Expiry Date set → Residency Expiry Date and Civil ID Expiry Date updated across the linked Residency and PACI.**

A residency and a civil ID are both issued to run with the work permit, so the permit's expiry is the date all three legally share. The Residency and the PACI each read it off the Employee **when they are opened and never again** — so a permit whose expiry was set or corrected afterwards left them quoting the old date on the paperwork submitted to MOI and PACI.

Both routes that write the expiry onto the Employee now push it on to `Residency.new_residency_expiry_date` and `PACI.new_civil_id_expiry_date`.

**2. PACI with DAMJ checked + a valid Original Civil ID reaching Completed → the Civil ID on the Employee profile is updated.**

Residency wrote the merged number back when *its* Damj completed (WI-002022), but the civil ID application — the document whose whole subject is the number — did not. Either can finish first and both write the same number, so whichever completes last is a no-op rather than a conflict. The record's own mirror is corrected too; it's fetched from the Employee and would otherwise keep showing the retired number on the very document that recorded the merge.

## How "linked" is resolved

By **Preparation + employee**. Residency and PACI carry no `work_permit` field, and a Preparation opens exactly one of each per employee — the same pairing WI-002027's existing Damj sync already uses. A permit raised outside a Preparation (a transfer, a cancellation) has nothing to pair with and is left alone.

Cancelled documents are skipped: there can be more than one live record for an employee — a rejected application and its replacement — and both need the new date.

Written with `set_value` rather than full saves. The fields are read-only, the documents may already be submitted, and a full Employee save re-validates the whole record — which throws for the thousand-odd employees holding a Marital Status the field no longer offers.

## Note on the "Fine Handling" in the title

The story title mentions fines but no AC covers them. Fine handling on Residency is WI-002105 (#6761) and on PACI is WI-002109 (#6762), both of which make the amount required and non-negative when its box is ticked. Nothing extra was invented here — say the word if an AC is missing.

## Tests

`bench run-tests --module one_fm.grd.doctype.paci.test_paci_expiry_and_damj_sync` — 7 passing: a new expiry reaching both documents, a later correction reaching them too, no date changing nothing, a permit with no Preparation having nothing to pair with, and the Damj write-back reaching the Employee, correcting the record's own mirror, and leaving the Employee alone when no merge is claimed.

`test_paci_damj_and_fine_fields` (9), `test_paci_no_payment` (14), `test_paci_fine` (6), `test_paci_pro_workflow` (16) and `test_residency_damj` (9) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)