### PR TITLE
WI-002096: stop a step completing before the one in front of it

### DIFF
--- a/one_fm/grd/doctype/medical_insurance/medical_insurance.js
+++ b/one_fm/grd/doctype/medical_insurance/medical_insurance.js
@@ -1,19 +1,48 @@
 // Copyright (c) 2020, ONE FM and contributors
 // For license information, please see license.txt
 
+
+// WI-002096: the button that opens the next document in the legal sequence, once this one is
+// complete. Shown only for the classifications that have a next step. The next document is
+// found by the Preparation and employee this one carries, which is what pairs them: a
+// Preparation opens one of each per employee.
+var set_next_step_button = function(frm, next_doctype, classifications, classification_field){
+	if(frm.doc.workflow_state !== 'Completed'){
+		return;
+	}
+	if(!classifications.includes(frm.doc[classification_field])){
+		return;
+	}
+	if(!frm.doc.preparation || !frm.doc.employee){
+		return;
+	}
+
+	frm.add_custom_button(__('Go to {0}', [__(next_doctype)]), function(){
+		frappe.db.get_value(
+			next_doctype,
+			{preparation: frm.doc.preparation, employee: frm.doc.employee, docstatus: ['!=', 2]},
+			'name',
+			(r) => {
+				if(r && r.name){
+					frappe.set_route('Form', next_doctype, r.name);
+				} else {
+					frappe.msgprint({
+						title: __('Nothing to open'),
+						message: __('No {0} was opened for this candidate.', [__(next_doctype)]),
+						indicator: 'orange'
+					});
+				}
+			}
+		);
+	}).addClass('btn-primary');
+};
+
 frappe.ui.form.on('Medical Insurance', {
     refresh(frm){
-        if(frm.doc.docstatus === 1 && frm.doc.insurance_status == "Local Transfer"){
-            		frm.add_custom_button(__('Go to Residency'),
-            			  function () {
-            			frappe.db.get_value('Residency', {'category':'Transfer','one_fm_civil_id':frm.doc.civil_id}, 'name', (r) => {
-            			if (r && r.name) {
-            				frappe.set_route("Form", "Residency", r.name);
-            			}
-            		});
-            	}
-            ).addClass('btn-primary');
-        }
+        // WI-002096 widens this from Local Transfer alone to every insurance that has a
+        // residency behind it, and pairs on the Preparation rather than on a civil ID -
+        // which after a Damj merge is not the number the residency was opened under.
+        set_next_step_button(frm, 'Residency', ['Renewal', 'New', 'Local Transfer'], 'insurance_status');
     },
     // onload: function(frm){
     //     set_employee_details(frm);

--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -154,6 +154,91 @@ FALLBACK_PREFIX = 'PRE-'
 SUB_DOCUMENT_SEQUENCE = ("Work Permit", "Medical Insurance", "Residency", "PACI")
 
 
+# WI-002096: the classification that puts a document inside the legal sequence. Kuwaiti
+# permits and residency extensions are outside it - a Kuwaiti has no insurance, no residency
+# and no civil ID process to follow the permit, and an extension is a single document on its
+# own - so neither is gated and neither offers a next step.
+SEQUENCED_CLASSIFICATIONS = {
+    "Work Permit": ("work_permit_type", ("Renewal Non Kuwaiti", "Overseas", "Overseas (Government)", "Local Transfer")),
+    "Medical Insurance": ("insurance_status", ("Renewal", "New", "Local Transfer")),
+    "Residency": ("category", ("Renewal", "First Time", "Transfer")),
+    "PACI": ("category", ("Renewal", "New Application", "Transfer")),
+}
+
+COMPLETED = "Completed"
+
+
+def is_sequenced(doc):
+    """Does this document sit inside the Work Permit -> ... -> PACI sequence (WI-002096)?"""
+    classification = SEQUENCED_CLASSIFICATIONS.get(doc.doctype)
+    if not classification:
+        return False
+
+    fieldname, values = classification
+    return doc.get(fieldname) in values
+
+
+def upstream_of(doc):
+    """The document that legally has to be finished before this one (WI-002096)."""
+    if doc.doctype not in SUB_DOCUMENT_SEQUENCE:
+        return None
+
+    position = SUB_DOCUMENT_SEQUENCE.index(doc.doctype)
+    return SUB_DOCUMENT_SEQUENCE[position - 1] if position else None
+
+
+def validate_sequence(doc, method=None):
+    """Refuse to complete a step whose predecessor is not finished (WI-002096).
+
+    Kuwait issues these in one order: the work permit, then the insurance it is a condition
+    of, then the residency stamped against it, then the civil ID. Completing them out of
+    order produces paperwork the ministry rejects, and the operator finds out weeks later.
+
+    Only ever checks the step immediately before, because that step's own completion was
+    gated the same way - so the whole chain is enforced without every document querying all
+    of them.
+
+    Scoped to documents opened by a Preparation. A permit or a residency raised on its own -
+    a transfer paper, a cancellation - has no batch to be sequenced within, and there is
+    nothing to look up.
+
+    An upstream document that does not exist is not a blocker: the Action decides which
+    documents a candidate gets, and a step that was never opened is not a step that is
+    waiting.
+    """
+    if doc.get("workflow_state") != COMPLETED:
+        return
+    if not doc.get("preparation") or not doc.get("employee"):
+        return
+    if not is_sequenced(doc):
+        return
+
+    upstream = upstream_of(doc)
+    if not upstream:
+        return
+
+    pending = frappe.get_all(
+        upstream,
+        filters={
+            "preparation": doc.preparation,
+            "employee": doc.employee,
+            "docstatus": ["!=", 2],
+            "workflow_state": ["!=", COMPLETED],
+        },
+        pluck="name",
+        limit=1,
+    )
+    if not pending:
+        return
+
+    frappe.throw(
+        _("{0} {1} has to be completed first.").format(
+            _(upstream), frappe.bold(pending[0])
+        ),
+        title=_("Out of Sequence"),
+    )
+
+
 def update_row_reference(doc, method=None):
     """Point a Preparation row at the sub-document its candidate has reached (WI-002093).
 

--- a/one_fm/grd/doctype/preparation/test_sequential_progression.py
+++ b/one_fm/grd/doctype/preparation/test_sequential_progression.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002096: no step completes before the one in front of it."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import nowdate
+
+from one_fm.grd.doctype.preparation.preparation import (
+	SEQUENCED_CLASSIFICATIONS,
+	SUB_DOCUMENT_SEQUENCE,
+	create_documents_for_row,
+	is_sequenced,
+	upstream_of,
+	validate_sequence,
+)
+
+
+def _an_active_employee():
+	name = frappe.db.get_value(
+		"Employee",
+		{"status": "Active", "relieving_date": ["is", "not set"]},
+		"name",
+		order_by="creation asc",
+	)
+	if not name:
+		raise frappe.DoesNotExistError("No active employee on this site to test against")
+	return name
+
+
+class TestTheSequence(FrappeTestCase):
+	def test_the_order_is_the_legal_one(self):
+		self.assertEqual(SUB_DOCUMENT_SEQUENCE, ("Work Permit", "Medical Insurance", "Residency", "PACI"))
+
+	def test_each_step_knows_the_one_before_it(self):
+		self.assertIsNone(upstream_of(frappe._dict(doctype="Work Permit")))
+		self.assertEqual(upstream_of(frappe._dict(doctype="Medical Insurance")), "Work Permit")
+		self.assertEqual(upstream_of(frappe._dict(doctype="Residency")), "Medical Insurance")
+		self.assertEqual(upstream_of(frappe._dict(doctype="PACI")), "Residency")
+
+	def test_a_document_outside_the_sequence_has_no_predecessor(self):
+		self.assertIsNone(upstream_of(frappe._dict(doctype="Medical Appointment")))
+
+	def test_a_kuwaiti_permit_is_outside_the_sequence(self):
+		"""A Kuwaiti has no insurance, no residency and no civil ID process to follow."""
+		for work_permit_type in ("New Kuwaiti", "Renewal Kuwaiti"):
+			with self.subTest(work_permit_type=work_permit_type):
+				self.assertFalse(
+					is_sequenced(frappe._dict(doctype="Work Permit", work_permit_type=work_permit_type))
+				)
+
+	def test_an_extension_is_outside_the_sequence(self):
+		"""A single document on its own."""
+		self.assertFalse(is_sequenced(frappe._dict(doctype="Residency", category="Extend")))
+
+	def test_the_four_sequenced_actions_are_inside_it(self):
+		for doctype, (fieldname, values) in SEQUENCED_CLASSIFICATIONS.items():
+			for value in values:
+				with self.subTest(doctype=doctype, value=value):
+					self.assertTrue(is_sequenced(frappe._dict(doctype=doctype, **{fieldname: value})))
+
+
+class TestSequenceIsEnforced(FrappeTestCase):
+	def setUp(self):
+		self.employee = _an_active_employee()
+		self.preparation = self._a_preparation()
+
+	def _a_preparation(self):
+		preparation = frappe.get_doc({
+			"doctype": "Preparation",
+			"category": "Onboarding",
+			"posting_date": nowdate(),
+			"preparation_record": [{"employee": self.employee, "renewal_or_extend": "Overseas"}],
+		})
+		preparation.flags.ignore_permissions = True
+		preparation.insert()
+		create_documents_for_row(preparation.preparation_record[0], preparation.name)
+		return preparation
+
+	def _linked(self, doctype):
+		return frappe.get_last_doc(doctype, filters={"preparation": self.preparation.name})
+
+	def _complete(self, doctype):
+		frappe.db.set_value(
+			doctype, self._linked(doctype).name, "workflow_state", "Completed", update_modified=False
+		)
+
+	def test_the_insurance_cannot_complete_before_the_permit(self):
+		insurance = self._linked("Medical Insurance")
+		insurance.workflow_state = "Completed"
+
+		with self.assertRaises(frappe.ValidationError) as caught:
+			validate_sequence(insurance)
+
+		self.assertIn("Work Permit", str(caught.exception))
+
+	def test_it_can_once_the_permit_is_done(self):
+		self._complete("Work Permit")
+
+		insurance = self._linked("Medical Insurance")
+		insurance.workflow_state = "Completed"
+		validate_sequence(insurance)
+
+	def test_the_civil_id_cannot_complete_before_the_residency(self):
+		self._complete("Work Permit")
+		self._complete("Medical Insurance")
+
+		paci = self._linked("PACI")
+		paci.workflow_state = "Completed"
+
+		with self.assertRaises(frappe.ValidationError) as caught:
+			validate_sequence(paci)
+
+		self.assertIn("Residency", str(caught.exception))
+
+	def test_only_the_step_immediately_before_is_checked(self):
+		"""Each step's own completion was gated the same way, so the chain holds without every
+		document querying all of them."""
+		self._complete("Medical Insurance")
+
+		residency = self._linked("Residency")
+		residency.workflow_state = "Completed"
+		validate_sequence(residency)
+
+	def test_the_first_step_waits_for_nothing(self):
+		work_permit = self._linked("Work Permit")
+		work_permit.workflow_state = "Completed"
+		validate_sequence(work_permit)
+
+	def test_a_state_that_is_not_completion_is_not_gated(self):
+		"""The operator has to be able to work on a document before finishing it."""
+		insurance = self._linked("Medical Insurance")
+		insurance.workflow_state = "Apply Online by PRO"
+		validate_sequence(insurance)
+
+	def test_a_document_with_no_preparation_is_not_gated(self):
+		"""A transfer paper or a cancellation has no batch to be sequenced within."""
+		insurance = self._linked("Medical Insurance")
+		insurance.preparation = None
+		insurance.workflow_state = "Completed"
+		validate_sequence(insurance)
+
+	def test_a_step_that_was_never_opened_is_not_waiting(self):
+		"""The Action decides which documents a candidate gets."""
+		frappe.delete_doc(
+			"Medical Insurance", self._linked("Medical Insurance").name,
+			force=True, ignore_permissions=True,
+		)
+
+		residency = self._linked("Residency")
+		residency.workflow_state = "Completed"
+		validate_sequence(residency)

--- a/one_fm/grd/doctype/residency/residency.js
+++ b/one_fm/grd/doctype/residency/residency.js
@@ -1,19 +1,48 @@
 // Copyright (c) 2020, ONE FM and contributors
 // For license information, please see license.txt
+
+// WI-002096: the button that opens the next document in the legal sequence, once this one is
+// complete. Shown only for the classifications that have a next step. The next document is
+// found by the Preparation and employee this one carries, which is what pairs them: a
+// Preparation opens one of each per employee.
+var set_next_step_button = function(frm, next_doctype, classifications, classification_field){
+	if(frm.doc.workflow_state !== 'Completed'){
+		return;
+	}
+	if(!classifications.includes(frm.doc[classification_field])){
+		return;
+	}
+	if(!frm.doc.preparation || !frm.doc.employee){
+		return;
+	}
+
+	frm.add_custom_button(__('Go to {0}', [__(next_doctype)]), function(){
+		frappe.db.get_value(
+			next_doctype,
+			{preparation: frm.doc.preparation, employee: frm.doc.employee, docstatus: ['!=', 2]},
+			'name',
+			(r) => {
+				if(r && r.name){
+					frappe.set_route('Form', next_doctype, r.name);
+				} else {
+					frappe.msgprint({
+						title: __('Nothing to open'),
+						message: __('No {0} was opened for this candidate.', [__(next_doctype)]),
+						indicator: 'orange'
+					});
+				}
+			}
+		);
+	}).addClass('btn-primary');
+};
+
 frappe.ui.form.on('Residency', {
 	refresh(frm){
-			if(frm.doc.docstatus === 1 && frm.doc.category == "Transfer"){
-				frm.add_custom_button(__('Go to PACI'),
-					  function () {
-					frappe.db.get_value('PACI', {'category':frm.doc.category,'civil_id':frm.doc.one_fm_civil_id}, 'name', (r) => {
-					if (r && r.name) {
-						frappe.set_route("Form", "PACI", r.name);
-					}
-				});
-			}
-		).addClass('btn-primary');
-		}
-
+		// WI-002096 widens this from Transfer alone to every residency that has a civil ID
+		// behind it - an Extend does not, so it gets no button - and pairs on the Preparation
+		// rather than on a civil ID, which after a Damj merge is not the number the PACI was
+		// opened under.
+		set_next_step_button(frm, 'PACI', ['Renewal', 'First Time', 'Transfer'], 'category');
 	},
 	onload: function(frm) {
 		// set_employee_details(frm);

--- a/one_fm/grd/doctype/work_permit/work_permit.js
+++ b/one_fm/grd/doctype/work_permit/work_permit.js
@@ -81,18 +81,49 @@ frappe.ui.form.on('Work Permit', {
     //     inform_previous_company_for_rejection(frm);
     // }    
 });
-var set_button_for_medical_insurance_transfer = function(frm){
-    if(frm.doc.docstatus === 1 && frm.doc.work_permit_type == "Local Transfer" && frm.doc.workflow_state == "Completed"){
-        frm.add_custom_button(__('Go to Medical Insurance'),
-          	function () {
-            frappe.db.get_value('Medical Insurance', {'work_permit':frm.doc.name}, 'name', (r) => {
-			if (r && r.name) {
-				frappe.set_route("Form", "Medical Insurance", r.name);
+
+// WI-002096: the button that opens the next document in the legal sequence, once this one is
+// complete. Shown only for the classifications that have a next step - a Kuwaiti permit and a
+// residency extension are single documents and get nothing.
+//
+// The next document is found by the Preparation and employee this one carries, which is what
+// pairs them: a Preparation opens one of each per employee.
+var set_next_step_button = function(frm, next_doctype, classifications, classification_field){
+	if(frm.doc.workflow_state !== 'Completed'){
+		return;
+	}
+	if(!classifications.includes(frm.doc[classification_field])){
+		return;
+	}
+	if(!frm.doc.preparation || !frm.doc.employee){
+		return;
+	}
+
+	frm.add_custom_button(__('Go to {0}', [__(next_doctype)]), function(){
+		frappe.db.get_value(
+			next_doctype,
+			{preparation: frm.doc.preparation, employee: frm.doc.employee, docstatus: ['!=', 2]},
+			'name',
+			(r) => {
+				if(r && r.name){
+					frappe.set_route('Form', next_doctype, r.name);
+				} else {
+					frappe.msgprint({
+						title: __('Nothing to open'),
+						message: __('No {0} was opened for this candidate.', [__(next_doctype)]),
+						indicator: 'orange'
+					});
+				}
 			}
-		});
-    }
-).addClass('btn-primary');
-}
+		);
+	}).addClass('btn-primary');
+};
+
+// WI-002096 widens this from Local Transfer alone to every permit that has an insurance
+// behind it, and pairs on the Preparation rather than on the permit - a renewal's insurance
+// is opened against the permit too, but an overseas one is opened by the Preparation.
+var set_button_for_medical_insurance_transfer = function(frm){
+	set_next_step_button(frm, 'Medical Insurance', ['Renewal Non Kuwaiti', 'Overseas', 'Overseas (Government)', 'Local Transfer'], 'work_permit_type');
 };
 // WI-001828 retires "Restart Application": it sat on the same Rejected state as
 // Reapply and did the same thing, only without carrying anything over or linking back

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -243,15 +243,23 @@ doc_events = {
 	# where the row's status column comes from. The handler only ever moves a row forward
 	# along Work Permit -> Medical Insurance -> Residency -> PACI.
 	"Work Permit": {
+		# WI-002096: no step completes before the one in front of it.
+		"validate": ["one_fm.grd.doctype.preparation.preparation.validate_sequence"],
 		"on_update": ["one_fm.grd.doctype.preparation.preparation.update_row_reference"]
 	},
 	"Medical Insurance": {
+		# WI-002096: no step completes before the one in front of it.
+		"validate": ["one_fm.grd.doctype.preparation.preparation.validate_sequence"],
 		"on_update": ["one_fm.grd.doctype.preparation.preparation.update_row_reference"]
 	},
 	"Residency": {
+		# WI-002096: no step completes before the one in front of it.
+		"validate": ["one_fm.grd.doctype.preparation.preparation.validate_sequence"],
 		"on_update": ["one_fm.grd.doctype.preparation.preparation.update_row_reference"]
 	},
 	"PACI": {
+		# WI-002096: no step completes before the one in front of it.
+		"validate": ["one_fm.grd.doctype.preparation.preparation.validate_sequence"],
 		"on_update": ["one_fm.grd.doctype.preparation.preparation.update_row_reference"]
 	},
 	"Employee": {


### PR DESCRIPTION
[WI-002096] Sequential Progression & Direct Action Buttons — Operations-019, Ambrin.

> **Stacked on #6759 (WI-002093) → #6758 (WI-002101)** — it reuses the `SUB_DOCUMENT_SEQUENCE` that #6759 introduced.

## AC by AC

| AC | Status |
|---|---|
| For Renewal (Non-Kuwaiti) / Overseas / Overseas (Government) / Local Transfer: enforce Work Permit → Medical Insurance → Residency → PACI, blocking downstream steps while upstream is incomplete | new server-side gate on `validate` for all four |
| Completed document → button to the next: WP → Medical Insurance, MI → Residency, Residency → PACI | buttons existed but only for Local Transfer; widened |
| Completed Work Permit for Renewal (Kuwaiti) / New Kuwaiti, or a Residency "Extension" → no button | exempt from both the gate and the button |

## The gate

Kuwait issues these in one order and nothing enforced it, so an operator could mark the residency done while the permit was still with PAM — producing paperwork the ministry rejects, discovered weeks later.

Completing a step now requires **the step immediately before it** to be complete. Only that one: its own completion was gated the same way, so the whole chain holds without every document querying all of them.

Three exemptions, each because there's genuinely nothing to wait for:
- a document raised **outside a Preparation** (a transfer paper, a cancellation) has no batch to be sequenced within;
- a step the Action **never opened** isn't a step that's waiting;
- a **Kuwaiti permit or a residency extension** is a single document with nothing behind it.

## The buttons

They existed on all three documents but only for Local Transfer, and each found its successor a **different** way — the insurance by work permit, the residency and the PACI by civil ID. All three now share one helper and pair on **Preparation + employee**.

That's a correctness fix as well as a widening: the civil ID was the wrong key for two of them, because after a Damj merge it's no longer the number the next document was opened under.

Where the next document doesn't exist, the button says so rather than doing nothing — the old versions silently ignored a missing successor.

## Tests

`bench run-tests --module one_fm.grd.doctype.preparation.test_sequential_progression` — 14 passing: the order, each step's predecessor, documents outside the sequence, Kuwaiti permits and extensions exempt, all sequenced classifications recognised, the insurance blocked before the permit and allowed after, the civil ID blocked before the residency, only the immediate predecessor checked, the first step waiting for nothing, non-completion states not gated, no-Preparation not gated, and a never-opened step not blocking.

Rest of the Preparation suite green: `test_preparation_row_summary` (8), `test_preparation_category` (9), `test_preparation_new_actions` (9), `test_action_category_mapping` (7), `test_overseas_government_action` (8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)