### PR TITLE
Ask for the request action, show the requester, and drop the New Content Document

### DIFF
--- a/one_fm/one_fm/doctype/document_register/document_register.json
+++ b/one_fm/one_fm/doctype/document_register/document_register.json
@@ -45,9 +45,12 @@
   },
   {
    "fieldname": "document_type",
-   "fieldtype": "Data",
+   "fieldtype": "Select",
    "in_list_view": 1,
-   "label": "Document Type"
+   "label": "Document Type",
+   "options": "\nPolicy\nSOP\nGuideline\nManual\nAmendment\nRegulation\nMeeting Outcome\nOther",
+   "reqd": 1,
+   "description": "What kind of document this is. The first four are the controlled types a Document Request can produce — they decide the template and the code series. The rest exist so input material (an amendment, a regulation, meeting outcomes) can be catalogued and picked as a source without being mistaken for a controlled document."
   },
   {
    "fieldname": "is_input_material",

--- a/one_fm/one_fm/doctype/document_request/document_request.js
+++ b/one_fm/one_fm/doctype/document_request/document_request.js
@@ -35,18 +35,31 @@ frappe.ui.form.on("Document Request", {
 	},
 
 	setup(frm) {
-		// Two pickers over the same register, filtered to opposite halves of it.
+		// Three pickers over the same register, each filtered to the part of it
+		// that its field actually means.
 		//
 		// A withdrawn document has nothing to revise and nothing left to
 		// withdraw, and input material was never a controlled document in the
-		// first place — neither should be offerable. The server refuses both in
-		// validate too; this only saves the user from finding out after typing
-		// the rest of the request.
-		frm.set_query("reference_document", () => ({
-			filters: { lifecycle_state: "Active", is_input_material: 0 },
+		// first place — neither should be offerable. The document type is
+		// included because a revision keeps the document's own type: offering a
+		// Policy while the request says SOP only leads to the mismatch the server
+		// then refuses. The server refuses all of this in validate too; these
+		// filters just save the user from finding out after typing the rest of
+		// the request.
+		frm.set_query("reference_document", () => {
+			const filters = { lifecycle_state: "Active", is_input_material: 0 };
+			if (frm.doc.document_type) filters.document_type = frm.doc.document_type;
+			return { filters };
+		});
+
+		// The guideline says HOW to write the document, so only a Guideline can
+		// be one. Pointing this at a finished Policy or SOP is how a request for
+		// one subject comes back written about another.
+		frm.set_query("source_guideline", () => ({
+			filters: { lifecycle_state: "Active", document_type: "Guideline" },
 		}));
 
-		// The mirror image: the new content comes *from* input material.
+		// Optional extra material, and it comes *from* input material.
 		frm.set_query("update_source", () => ({
 			filters: { is_input_material: 1 },
 		}));
@@ -58,8 +71,37 @@ frappe.ui.form.on("Document Request", {
 		if (frm.doc.request_action === "Create" && frm.doc.reference_document) {
 			frm.set_value("reference_document", null);
 		}
+		if (frm.doc.request_action !== "Create" && frm.doc.source_guideline) {
+			// An Update takes its shape from the document it is revising, which
+			// already came from a guideline. Leaving a guideline attached implies
+			// it will be applied, and it will not.
+			frm.set_value("source_guideline", null);
+		}
 		if (frm.doc.request_action !== "Update" && frm.doc.update_source) {
 			frm.set_value("update_source", null);
+		}
+	},
+
+	document_type(frm) {
+		// The reference picker is filtered by type, so a type change can leave a
+		// document selected that is now the wrong kind — and the server would
+		// refuse the save with a mismatch the user did not knowingly create.
+		if (frm.doc.reference_document) {
+			frappe.db
+				.get_value("Document Register", frm.doc.reference_document, "document_type")
+				.then((r) => {
+					const kind = r && r.message && r.message.document_type;
+					if (kind && frm.doc.document_type && kind !== frm.doc.document_type) {
+						frm.set_value("reference_document", null);
+						frappe.show_alert({
+							message: __("Cleared the selected document — it is a {0}, not a {1}.", [
+								kind,
+								frm.doc.document_type,
+							]),
+							indicator: "orange",
+						});
+					}
+				});
 		}
 	},
 });

--- a/one_fm/one_fm/doctype/document_request/document_request.js
+++ b/one_fm/one_fm/doctype/document_request/document_request.js
@@ -34,6 +34,19 @@ frappe.ui.form.on("Document Request", {
 		repair_missing_link(frm);
 	},
 
+	onload(frm) {
+		// The requester is captured in validate, which is too late to be seen: the
+		// field is read-only, so a new request opens with the requester and the
+		// whole approval chain blank — and Frappe hides empty read-only fields, so
+		// the column is not merely empty, it is absent. Someone filing a request
+		// has no way to tell that the system knows who they are, or who will be
+		// asked to approve it.
+		//
+		// This fills it from the same lookup validate uses, so the form cannot show
+		// one requester and then save another.
+		if (frm.is_new() && !frm.doc.requester) show_requester(frm);
+	},
+
 	setup(frm) {
 		// Three pickers over the same register, each filtered to the part of it
 		// that its field actually means.
@@ -59,10 +72,6 @@ frappe.ui.form.on("Document Request", {
 			filters: { lifecycle_state: "Active", document_type: "Guideline" },
 		}));
 
-		// Optional extra material, and it comes *from* input material.
-		frm.set_query("update_source", () => ({
-			filters: { is_input_material: 1 },
-		}));
 	},
 
 	request_action(frm) {
@@ -76,9 +85,6 @@ frappe.ui.form.on("Document Request", {
 			// already came from a guideline. Leaving a guideline attached implies
 			// it will be applied, and it will not.
 			frm.set_value("source_guideline", null);
-		}
-		if (frm.doc.request_action !== "Update" && frm.doc.update_source) {
-			frm.set_value("update_source", null);
 		}
 	},
 
@@ -148,6 +154,28 @@ function repair_missing_link(frm) {
 					true
 				);
 			}
+		},
+	});
+}
+
+function show_requester(frm) {
+	frappe.call({
+		method: "one_fm.one_fm.doctype.document_request.document_request.get_requester_defaults",
+		callback: (r) => {
+			const chain = (r && r.message) || {};
+			if (!chain.requester) {
+				// The save would throw this same thing. Saying it before the request
+				// is written saves the requester typing all of it first.
+				frm.dashboard.add_comment(
+					__(
+						"Your user account is not linked to an Employee record, so this request cannot record who is asking for the document. Ask HR to set the User ID on your employee record."
+					),
+					"red",
+					true
+				);
+				return;
+			}
+			frm.set_value(chain);
 		},
 	});
 }

--- a/one_fm/one_fm/doctype/document_request/document_request.json
+++ b/one_fm/one_fm/doctype/document_request/document_request.json
@@ -35,7 +35,8 @@
    "label": "Requester",
    "options": "Employee",
    "reqd": 1,
-   "description": "The employee raising this documentation request."
+   "description": "The employee raising this request. Captured automatically from the signed-in user, so it always matches who actually filed it.",
+   "read_only": 1
   },
   {
    "fieldname": "requester_user",
@@ -64,8 +65,9 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Document Type",
-   "options": "Policy\nSOP\nGuideline\nManual",
-   "reqd": 1
+   "options": "\nPolicy\nSOP\nGuideline\nManual",
+   "reqd": 1,
+   "description": "What kind of document this is. Decides the template, the code series, and which guideline applies. No default: a Select whose first option is a real type silently answers this question for the requester."
   },
   {
    "fieldname": "title",
@@ -74,7 +76,7 @@
    "label": "Title",
    "depends_on": "eval:doc.request_action != 'Delete'",
    "mandatory_depends_on": "eval:doc.request_action != 'Delete'",
-   "description": "Proposed title for the document being requested."
+   "description": "Title for the document being requested. This is the subject the content is written about, so it is what the drafting task is told to write."
   },
   {
    "fieldname": "requirement_text",
@@ -82,17 +84,17 @@
    "label": "Requirement",
    "depends_on": "eval:doc.request_action != 'Delete'",
    "mandatory_depends_on": "eval:doc.request_action != 'Delete'",
-   "description": "What's needed and why — this becomes the AI drafting requirement in Processa."
+   "description": "What the document must say. On a Create this is the material the document is written from; on an Update it is the change to make — the existing document supplies everything the requirement does not mention."
   },
   {
    "fieldname": "source_guideline",
-   "link_filters": "[[\"Document Register\",\"lifecycle_state\",\"=\",\"Active\"]]",
+   "link_filters": "[[\"Document Register\", \"lifecycle_state\", \"=\", \"Active\"], [\"Document Register\", \"document_type\", \"=\", \"Guideline\"]]",
    "fieldtype": "Link",
    "label": "Source Guideline",
    "options": "Document Register",
    "depends_on": "eval:doc.request_action == 'Create'",
    "mandatory_depends_on": "eval:doc.request_action == 'Create'",
-   "description": "The existing guideline document (already cataloged in Document Register) this document should be generated from. Its real content is extracted and given to the AI — the AI does not invent the guideline itself."
+   "description": "The guideline describing HOW a document of this type is written — its structure, sections and tone. Only Guideline entries can be picked. It shapes the document; what the document SAYS comes from Requirement."
   },
   {
    "fieldname": "reference_document",
@@ -111,8 +113,7 @@
    "label": "New Content Document",
    "options": "Document Register",
    "depends_on": "eval:doc.request_action == 'Update'",
-   "mandatory_depends_on": "eval:doc.request_action == 'Update'",
-   "description": "The document holding the content you want the revision to say — catalogue it on Document Register first (pasting its Drive link is enough) and tick Input Material. Its text is authoritative: the AI reformats it into the official template and may not add, remove or reword anything. Say what the change is for in Requirement; that guides the layout, not the wording."
+   "description": "Optional. Extra material the revision should draw on, catalogued on Document Register and ticked Input Material. Not required: an Update normally takes its change from Requirement and everything else from the existing document."
   },
   {
    "fieldname": "section_break_approval",
@@ -152,13 +153,12 @@
   },
   {
    "depends_on": "eval:doc.document_link",
-   "description": "Link to the published document in Google Docs. Written by the process when the document is published — blank until then.",
+   "description": "Every revision shares one Drive file, so this link stays valid for the life of the document — it always opens the current version.",
    "fieldname": "document_link",
    "fieldtype": "Data",
    "label": "Published Document",
    "options": "URL",
-   "read_only": 1,
-   "description": "Every revision shares one Drive file, so this link stays valid for the life of the document — it always opens the current version."
+   "read_only": 1
   },
   {
    "fieldname": "document_version",

--- a/one_fm/one_fm/doctype/document_request/document_request.json
+++ b/one_fm/one_fm/doctype/document_request/document_request.json
@@ -17,7 +17,6 @@
   "requirement_text",
   "source_guideline",
   "reference_document",
-  "update_source",
   "section_break_approval",
   "approver",
   "approver_user",
@@ -54,11 +53,10 @@
    "fieldname": "request_action",
    "fieldtype": "Select",
    "in_list_view": 1,
-   "label": "Action",
-   "options": "Create\nUpdate\nDelete",
-   "default": "Create",
+   "label": "Request Action",
+   "options": "\nCreate\nUpdate\nDelete",
    "reqd": 1,
-   "description": "Create a new document, revise an existing one (which publishes a new version), or withdraw an existing one from use. Delete does NOT destroy anything — it marks the document inactive and revokes its Drive sharing, and a System Manager can reactivate it."
+   "description": "Create a new document, revise an existing one (which publishes a new version), or withdraw an existing one from use. No default: a Select whose first option is a real action silently answers this question for the requester. Delete does NOT destroy anything — it marks the document inactive and revokes its Drive sharing, and a System Manager can reactivate it."
   },
   {
    "fieldname": "document_type",
@@ -105,15 +103,6 @@
    "depends_on": "eval:doc.request_action != 'Create'",
    "mandatory_depends_on": "eval:doc.request_action != 'Create'",
    "description": "The existing published document being revised or withdrawn. Only active controlled documents can be picked — an already-withdrawn one has nothing to revise or withdraw, and input material is not a controlled document."
-  },
-  {
-   "fieldname": "update_source",
-   "link_filters": "[[\"Document Register\",\"lifecycle_state\",\"=\",\"Active\"]]",
-   "fieldtype": "Link",
-   "label": "New Content Document",
-   "options": "Document Register",
-   "depends_on": "eval:doc.request_action == 'Update'",
-   "description": "Optional. Extra material the revision should draw on, catalogued on Document Register and ticked Input Material. Not required: an Update normally takes its change from Requirement and everything else from the existing document."
   },
   {
    "fieldname": "section_break_approval",

--- a/one_fm/one_fm/doctype/document_request/document_request.py
+++ b/one_fm/one_fm/doctype/document_request/document_request.py
@@ -17,7 +17,6 @@ class DocumentRequest(Document):
 		self.check_reference_document_is_controlled()
 		self.check_source_guideline_is_a_guideline()
 		self.check_source_documents_are_active()
-		self.check_update_source()
 
 	def set_requester_defaults(self):
 		"""Capture the requester from whoever is filing the request.
@@ -67,16 +66,17 @@ class DocumentRequest(Document):
 		if not self.requester:
 			return
 
-		employee = frappe.db.get_value(
-			"Employee", self.requester, ["user_id", "reports_to"], as_dict=True
-		)
-		if not employee:
+		chain = _requester_chain(self.requester)
+		if not chain:
 			return
 
 		if not self.requester_user:
-			self.requester_user = employee.get("user_id")
+			self.requester_user = chain.get("requester_user")
 		if not self.approver:
-			self.approver = employee.get("reports_to")
+			self.approver = chain.get("approver")
+		# Not chain["approver_user"]: an approver supplied deliberately is not
+		# necessarily the requester's line manager, and their user must follow the
+		# approver actually on the request.
 		if self.approver and not self.approver_user:
 			self.approver_user = frappe.db.get_value("Employee", self.approver, "user_id")
 
@@ -214,10 +214,7 @@ class DocumentRequest(Document):
 		nothing else — the API, an import and a test all sail past it, which is
 		exactly the gap ``check_required_links`` was written for.
 		"""
-		fields = (
-			("source_guideline", "Create", _("Source Guideline")),
-			("update_source", "Update", _("New Content Document")),
-		)
+		fields = (("source_guideline", "Create", _("Source Guideline")),)
 		for fieldname, action, label in fields:
 			name = self.get(fieldname)
 			if not name or self.request_action != action:
@@ -266,29 +263,6 @@ class DocumentRequest(Document):
 				)
 			)
 
-	def check_update_source(self):
-		"""The revision's content has to come from somewhere other than itself.
-
-		On an Update the uploaded document is the authoritative content — the AI
-		is only allowed to reformat it, never to invent wording. Pointing that at
-		the document being revised would ask it to reformat a document into
-		itself, which produces a version identical to the one before it.
-		"""
-		if self.request_action != "Update":
-			# Only Update consumes it; a stale value on a Create/Delete would be
-			# fetched by the process and silently treated as the new content.
-			self.update_source = None
-			return
-
-		if self.update_source and self.update_source == self.reference_document:
-			frappe.throw(
-				_(
-					"The New Content Document cannot be the document being revised — "
-					"that would publish a new version identical to the current one. "
-					"Catalogue the new content as its own entry and pick that."
-				)
-			)
-
 
 # ── Reaching the published document ─────────────────────────────────────────
 # `document_link` holds the Google Docs URL, and it is the only thing the form
@@ -330,6 +304,50 @@ class DocumentRequest(Document):
 # than pretending it is gone, because a request that says "withdrawn" while
 # offering no way to see *what* was withdrawn is useless to an auditor.
 NO_DOCUMENT_STATUSES = ("Request Rejected",)
+
+
+def _requester_chain(employee: str) -> dict:
+	"""The employee's own user, their line manager, and that manager's user.
+
+	Shared by validate and by the form so both answer "who is asking and who
+	approves" the same way. Two implementations of that drift, and a form that
+	shows one approver while the save records another is worse than a form that
+	shows nothing.
+	"""
+	row = frappe.db.get_value("Employee", employee, ["user_id", "reports_to"], as_dict=True)
+	if not row:
+		return {}
+
+	approver = row.get("reports_to")
+	return {
+		"requester_user": row.get("user_id"),
+		"approver": approver,
+		"approver_user": (
+			frappe.db.get_value("Employee", approver, "user_id") if approver else None
+		),
+	}
+
+
+@frappe.whitelist()
+def get_requester_defaults() -> dict:
+	"""Who the signed-in user is, for a request that has not been saved yet.
+
+	The requester is captured in validate, which is the right place to *enforce*
+	it and far too late to *show* it: the field is read-only, so a new request
+	opens with the requester and the whole approval chain empty, and Frappe hides
+	empty read-only fields — the column is simply absent. The requester cannot
+	tell whether the system knows who they are, or who will be asked to approve
+	what they are about to write.
+
+	Uses the same lookup validate uses, so the form cannot show one requester and
+	save another. Returns {} when the user has no Employee record: the form says
+	so at open time instead of letting a filled-in request fail on save.
+	"""
+	employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
+	if not employee:
+		return {}
+
+	return {"requester": employee, **_requester_chain(employee)}
 
 
 @frappe.whitelist()

--- a/one_fm/one_fm/doctype/document_request/document_request.py
+++ b/one_fm/one_fm/doctype/document_request/document_request.py
@@ -15,14 +15,70 @@ class DocumentRequest(Document):
 		self.check_required_links()
 		self.check_reference_document_is_active()
 		self.check_reference_document_is_controlled()
+		self.check_source_guideline_is_a_guideline()
 		self.check_source_documents_are_active()
 		self.check_update_source()
 
 	def set_requester_defaults(self):
+		"""Capture the requester from whoever is filing the request.
+
+		The field is read-only on the form, so this is the only thing that fills
+		it: a request is always filed by the person signed in, and typing it was
+		how one person's request ended up under someone else's name. An existing
+		value is left alone so a request created by an integration or a migration
+		keeps the requester it was given.
+
+		Because nobody can type it, an unresolvable requester has to be said out
+		loud rather than left blank for the mandatory check to reject with
+		"Requester is required" — which would be true and useless.
+		"""
+		if self.requester:
+			return
+
+		employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
+		if employee:
+			self.requester = employee
+			self.fill_requester_chain()
+			return
+
+		if self.is_new():
+			frappe.throw(
+				_(
+					"There is no Employee record linked to {0}, so this request cannot record "
+					"who is asking for the document. Ask HR to set the User ID on that "
+					"employee record, then try again."
+				).format(frappe.bold(frappe.session.user)),
+				title=_("No Employee Record"),
+			)
+
+	def fill_requester_chain(self):
+		"""Resolve requester → approver → approver_user here, not via fetch_from.
+
+		``approver`` is declared ``fetch_from: requester.reports_to`` and
+		``approver_user`` hangs off *that*. Frappe resolves fetch_from BEFORE
+		validate, so a requester captured during validate arrives too late: the
+		chain stays empty and the request is refused for having no approver — on a
+		requester whose line manager is set. Worse than the refusal, an approver
+		that resolved late would leave ``approver_user`` blank, and that is the
+		field the map assigns both approval tasks to.
+
+		Only fills blanks, so a value supplied deliberately is never overwritten.
+		"""
 		if not self.requester:
-			employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
-			if employee:
-				self.requester = employee
+			return
+
+		employee = frappe.db.get_value(
+			"Employee", self.requester, ["user_id", "reports_to"], as_dict=True
+		)
+		if not employee:
+			return
+
+		if not self.requester_user:
+			self.requester_user = employee.get("user_id")
+		if not self.approver:
+			self.approver = employee.get("reports_to")
+		if self.approver and not self.approver_user:
+			self.approver_user = frappe.db.get_value("Employee", self.approver, "user_id")
 
 	def check_approver_resolved(self):
 		if self.requester and not self.approver:
@@ -34,6 +90,18 @@ class DocumentRequest(Document):
 			)
 
 	def apply_reference_document_defaults(self):
+		"""Fill the blanks from the reference, but REFUSE a type mismatch.
+
+		This used to overwrite ``document_type`` from the register entry
+		outright. That hid a real mistake instead of reporting it: a requester
+		who chose SOP and then picked a Policy document was silently switched to
+		Policy — a different template, a different code series, and a request
+		that no longer said what they asked for. The two have to agree, and the
+		person is the one who should decide which of the two was wrong.
+
+		An empty type is still filled in, because there is nothing to disagree
+		with — that is a default, not a correction.
+		"""
 		if self.request_action == "Create" or not self.reference_document:
 			return
 		ref = frappe.db.get_value(
@@ -41,9 +109,49 @@ class DocumentRequest(Document):
 		)
 		if not ref:
 			return
-		self.document_type = ref.document_type
+
+		if not self.document_type:
+			self.document_type = ref.document_type
+		elif ref.document_type and self.document_type != ref.document_type:
+			frappe.throw(
+				_(
+					"Document Type does not match the document you picked. This request says "
+					"{0}, but {1} is a {2} in the Document Register. A revision keeps the "
+					"document's own type — change the Document Type to {2}, or pick a {0} "
+					"document instead."
+				).format(
+					frappe.bold(self.document_type),
+					frappe.bold(self.reference_document),
+					frappe.bold(ref.document_type),
+				),
+				title=_("Document Type Mismatch"),
+			)
+
 		if not self.title:
 			self.title = ref.title
+
+	def check_source_guideline_is_a_guideline(self):
+		"""The guideline a Create is written from has to actually be a guideline.
+
+		``source_guideline`` says *how* to write the document — structure, tone,
+		the section rules. Point it at a Policy or an SOP and the drafting task is
+		handed a finished document as its instructions, which is how a request for
+		one subject comes back written about another. The picker filters to
+		Guideline; this is the half that also holds for the API and for imports.
+		"""
+		if self.request_action != "Create" or not self.source_guideline:
+			return
+
+		kind = frappe.db.get_value("Document Register", self.source_guideline, "document_type")
+		if kind and kind != "Guideline":
+			frappe.throw(
+				_(
+					"Source Guideline must be a Guideline. {0} is a {1} — a finished "
+					"document, not instructions for writing one. Pick the guideline that "
+					"describes how a {2} should be written."
+				).format(frappe.bold(self.source_guideline), frappe.bold(kind), self.document_type or _("document")),
+				title=_("Not a Guideline"),
+			)
 
 	def check_reference_document_is_active(self):
 		"""Refuse to revise or withdraw a document that is already withdrawn.
@@ -142,13 +250,19 @@ class DocumentRequest(Document):
 				_("Pick the existing document this {0} request applies to.").format(self.request_action)
 			)
 
-		if self.request_action == "Update" and not self.update_source:
+		if self.request_action == "Update" and not (self.requirement_text or "").strip():
+			# An Update used to require a New Content Document holding the finished
+			# wording. It now works the way a Create does: Requirement says what to
+			# change and the existing document supplies everything it does not
+			# mention. That makes Requirement the one thing an Update cannot do
+			# without — an Update with nothing to change would republish the
+			# document unaltered as a new version.
 			frappe.throw(
 				_(
-					"An Update needs a New Content Document — the document holding what the "
-					"revision should say. Catalogue it on Document Register first (pasting its "
-					"Drive link is enough), tick Input Material, then pick it here. The wording "
-					"published comes from that document, not from the AI."
+					"Say what the revision should change, in Requirement. The existing "
+					"document supplies everything you do not mention, so describe only the "
+					"change — an Update with no requirement would publish a new version "
+					"identical to the current one."
 				)
 			)
 

--- a/one_fm/tests/test_document_request_inputs.py
+++ b/one_fm/tests/test_document_request_inputs.py
@@ -3,11 +3,17 @@
 """
 What a Document Request is allowed to say, and who it says it on behalf of.
 
-The drafting task is now written from the **requirement**: the requirement is the
-content, the title is the subject, and the guideline only describes how a document
-of that type is shaped. Before this, the task was handed the guideline's whole
-text and nothing about the subject — so it invented one, and a request for an
-Annual Leave SOP came back as a Helpdesk Call Logging procedure.
+The drafting task is given two things that must not be confused: the **guideline**
+explains how a document of that type is written (an SOP guideline for an SOP, a
+guideline-for-guidelines for a Guideline), and the **requirement** is the subject
+and the content. The title says what the document is called.
+
+Before this, the task got the guideline's text and nothing about the subject, so
+it treated the guideline's own examples as the document — a request for an Annual
+Leave SOP came back as a Helpdesk Call Logging procedure. The guideline is still
+sent, because how-to-write is exactly what it is for; what changed is that it is
+now labelled as form and fenced off, and the requirement follows it as the
+authoritative content.
 
 That moves weight onto the request's own fields, which is what these tests cover:
 

--- a/one_fm/tests/test_document_request_inputs.py
+++ b/one_fm/tests/test_document_request_inputs.py
@@ -20,12 +20,14 @@ That moves weight onto the request's own fields, which is what these tests cover
   * the requester is captured, not typed;
   * a revision cannot silently change the document's type;
   * a guideline has to actually be a guideline;
-  * an Update needs a requirement, and no longer needs a separate document
-    holding the finished wording.
+  * an Update needs a requirement, and the separate document that used to hold
+    the finished wording is gone entirely.
 """
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from one_fm.one_fm.doctype.document_request.document_request import get_requester_defaults
 
 REG_PREFIX = "_TestDocReqInputs"
 
@@ -143,6 +145,47 @@ class TestRequesterIsCaptured(DocumentRequestInputFixtures, FrappeTestCase):
 			frappe.set_user("Administrator")
 
 
+	def test_the_form_can_show_the_requester_before_the_first_save(self):
+		"""Capturing in validate is right for enforcement and too late for display.
+
+		The field is read-only, so a new request renders the requester and the
+		whole approval chain as empty read-only fields — which Frappe hides, so
+		the column is absent rather than blank. The requester cannot see that the
+		system knows who they are, or who will approve what they are writing.
+		"""
+		frappe.set_user(self.requester_user)
+		try:
+			chain = get_requester_defaults()
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(chain.get("requester"), self.requester)
+		self.assertTrue(chain.get("approver"), "no approver offered to the form")
+		self.assertTrue(chain.get("approver_user"), "the map assigns both approval tasks to this")
+
+	def test_what_the_form_shows_is_what_the_save_records(self):
+		"""Two lookups for "who approves this" drift. A form showing one approver
+		while the save records another is worse than a form showing nothing."""
+		frappe.set_user(self.requester_user)
+		try:
+			shown = get_requester_defaults()
+			doc = self._request()
+			doc.requester = None
+			doc.insert(ignore_permissions=True)
+		finally:
+			frappe.set_user("Administrator")
+		for field in ("requester", "requester_user", "approver", "approver_user"):
+			self.assertEqual(shown.get(field), doc.get(field), f"{field} differs")
+
+	def test_a_user_with_no_employee_record_is_told_at_open_time(self):
+		"""Empty, not an exception: the form turns this into a message. Throwing
+		here would break opening the form rather than explaining it."""
+		frappe.set_user("Guest")
+		try:
+			self.assertEqual(get_requester_defaults(), {})
+		finally:
+			frappe.set_user("Administrator")
+
+
 class TestDocumentTypeMustMatchTheReference(DocumentRequestInputFixtures, FrappeTestCase):
 	def test_a_mismatch_is_refused(self):
 		"""It used to overwrite the request's type from the register entry, which
@@ -209,32 +252,16 @@ class TestUpdateTakesItsChangeFromTheRequirement(DocumentRequestInputFixtures, F
 			doc.insert(ignore_permissions=True)
 		self.assertIn("Requirement", str(caught.exception))
 
-	def test_an_update_no_longer_needs_a_new_content_document(self):
-		"""update_source used to be mandatory and hold the finished wording."""
-		sop = _register("SOP", suffix="NoSource")
-		doc = self._request(
-			request_action="Update",
-			reference_document=sop,
-			requirement_text="Add a step about returning the key.",
-		)
-		doc.insert(ignore_permissions=True)
-		self.assertFalse(doc.update_source)
+	def test_the_new_content_document_field_is_gone(self):
+		"""It held the finished wording of a revision, drafted outside the system.
 
-	def test_the_field_is_no_longer_mandatory_on_the_form_either(self):
-		field = frappe.get_meta("Document Request").get_field("update_source")
-		self.assertFalse(field.mandatory_depends_on)
-
-	def test_update_source_still_cannot_be_the_document_being_revised(self):
-		"""Kept: reformatting a document into itself produces an identical version."""
-		sop = _register("SOP", suffix="SelfRef")
-		doc = self._request(
-			request_action="Update",
-			reference_document=sop,
-			update_source=sop,
-			requirement_text="Change something.",
-		)
-		with self.assertRaises(frappe.ValidationError):
-			doc.insert(ignore_permissions=True)
+		A revision is now written from Requirement against the existing document,
+		so a second document holding the answer has nothing left to do — and while
+		the field existed the process still had a task downloading it. Asserted
+		rather than assumed: re-adding it would quietly reintroduce two competing
+		sources of truth for what a revision should say.
+		"""
+		self.assertIsNone(frappe.get_meta("Document Request").get_field("update_source"))
 
 	def test_a_withdrawn_document_still_cannot_be_revised(self):
 		"""Kept: withdrawing is how this system says "stop using this"."""
@@ -253,6 +280,37 @@ class TestUpdateTakesItsChangeFromTheRequirement(DocumentRequestInputFixtures, F
 		)
 		with self.assertRaises(frappe.ValidationError):
 			doc.insert(ignore_permissions=True)
+
+
+class TestRequestActionIsChosen(FrappeTestCase):
+	def test_it_has_an_empty_first_option_and_no_default(self):
+		"""The default is the load-bearing half.
+
+		An empty first option with default "Create" still lands on Create, so
+		"what kind of request is this?" goes unasked — the same silent answer that
+		was fixed on Document Type. The action decides whether a document is
+		created, revised or withdrawn, which is not a question to answer on the
+		requester's behalf.
+		"""
+		field = frappe.get_meta("Document Request").get_field("request_action")
+		self.assertEqual(field.fieldtype, "Select")
+		self.assertTrue(field.reqd)
+		self.assertEqual((field.options or "").split("\n")[0], "", "first option must be empty")
+		self.assertFalse(field.default, f"still defaults to {field.default!r}")
+
+	def test_it_is_labelled_for_what_it_selects(self):
+		""""Action" alone reads as "what do I do now" on a form full of buttons."""
+		self.assertEqual(
+			frappe.get_meta("Document Request").get_field("request_action").label,
+			"Request Action",
+		)
+
+	def test_every_action_the_form_offers_is_one_the_map_branches_on(self):
+		"""An action with no branch would start a process that goes nowhere."""
+		offered = {o for o in (
+			frappe.get_meta("Document Request").get_field("request_action").options or ""
+		).split("\n") if o}
+		self.assertEqual(offered, {"Create", "Update", "Delete"})
 
 
 class TestRegisterDocumentType(FrappeTestCase):

--- a/one_fm/tests/test_document_request_inputs.py
+++ b/one_fm/tests/test_document_request_inputs.py
@@ -1,0 +1,281 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+"""
+What a Document Request is allowed to say, and who it says it on behalf of.
+
+The drafting task is now written from the **requirement**: the requirement is the
+content, the title is the subject, and the guideline only describes how a document
+of that type is shaped. Before this, the task was handed the guideline's whole
+text and nothing about the subject — so it invented one, and a request for an
+Annual Leave SOP came back as a Helpdesk Call Logging procedure.
+
+That moves weight onto the request's own fields, which is what these tests cover:
+
+  * the requester is captured, not typed;
+  * a revision cannot silently change the document's type;
+  * a guideline has to actually be a guideline;
+  * an Update needs a requirement, and no longer needs a separate document
+    holding the finished wording.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+REG_PREFIX = "_TestDocReqInputs"
+
+
+def _register(document_type, lifecycle_state="Active", is_input_material=0, suffix=""):
+	"""A Document Register entry. Named by drive_file_id, as the register is."""
+	file_id = f"{REG_PREFIX}{document_type}{suffix}"
+	if frappe.db.exists("Document Register", file_id):
+		frappe.delete_doc("Document Register", file_id, force=True, ignore_permissions=True)
+	doc = frappe.get_doc({
+		"doctype": "Document Register",
+		"drive_file_id": file_id,
+		"title": f"_Test {document_type}{suffix}",
+		"document_type": document_type,
+		"lifecycle_state": lifecycle_state,
+		"is_input_material": is_input_material,
+	})
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+class DocumentRequestInputFixtures:
+	"""Shared fixtures. Not a TestCase — a base TestCase re-runs its own tests."""
+
+	def setUp(self):
+		# Document Request refuses to save when it cannot resolve an approver, so
+		# the requester must have a line manager or every test here fails on
+		# insert for a reason that has nothing to do with what it is testing.
+		# The employee must ALSO be the one their user_id resolves back to: one
+		# user can own several Employee records, and get_value returns an
+		# arbitrary one. Picking a mismatched pair made the auto-capture test
+		# fail on the *other* record's missing line manager.
+		self.requester = None
+		for name, user_id in frappe.get_all(
+			"Employee",
+			filters={"status": "Active", "reports_to": ["is", "set"], "user_id": ["is", "set"]},
+			fields=["name", "user_id"],
+			limit=60,
+			as_list=True,
+		):
+			if frappe.db.get_value("Employee", {"user_id": user_id}, "name") == name:
+				self.requester = name
+				self.requester_user = user_id
+				break
+		if not self.requester:
+			self.skipTest("no active Employee with a line manager and a matching user_id")
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _request(self, **overrides):
+		values = {
+			"doctype": "Document Request",
+			"requester": self.requester,
+			"request_action": "Create",
+			"document_type": "SOP",
+			"title": "_Test Subject",
+			"requirement_text": "The document must say this.",
+		}
+		values.update(overrides)
+		doc = frappe.get_doc(values)
+		doc.flags.ignore_permissions = True
+		return doc
+
+
+class TestRequesterIsCaptured(DocumentRequestInputFixtures, FrappeTestCase):
+	def test_the_field_is_read_only(self):
+		"""Read-only is the whole point: a typed requester is how one person's
+		request ends up filed under another's name."""
+		self.assertTrue(frappe.get_meta("Document Request").get_field("requester").read_only)
+
+	def test_it_is_filled_from_the_signed_in_user(self):
+		employee = self.requester
+		frappe.set_user(self.requester_user)
+		try:
+			doc = self._request()
+			doc.requester = None  # as the form submits it: read-only, so never sent
+			doc.insert(ignore_permissions=True)
+			self.assertEqual(doc.requester, employee)
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_a_requester_already_set_is_left_alone(self):
+		"""An import or an integration keeps the requester it was given."""
+		doc = self._request()
+		doc.insert(ignore_permissions=True)
+		self.assertEqual(doc.requester, self.requester)
+
+	def test_capturing_the_requester_also_resolves_the_approver_chain(self):
+		"""The bug that making the field read-only introduced.
+
+		``approver`` is fetch_from requester.reports_to and ``approver_user``
+		hangs off that. Frappe resolves fetch_from BEFORE validate, so a requester
+		captured during validate arrives too late: the request was refused for
+		having no approver, on a requester whose line manager is set. And an
+		approver resolved late would leave approver_user blank — which is the
+		field the map assigns BOTH approval tasks to, so the process would run
+		with nobody to action it.
+		"""
+		frappe.set_user(self.requester_user)
+		try:
+			doc = self._request()
+			doc.requester = None  # read-only: the form never sends it
+			doc.approver = None
+			doc.approver_user = None
+			doc.insert(ignore_permissions=True)
+			self.assertTrue(doc.approver, "no approver resolved from the captured requester")
+			self.assertTrue(
+				doc.approver_user,
+				"approver_user is empty — the map assigns both approval tasks to it",
+			)
+			self.assertTrue(doc.requester_user, "requester_user did not resolve either")
+		finally:
+			frappe.set_user("Administrator")
+
+
+class TestDocumentTypeMustMatchTheReference(DocumentRequestInputFixtures, FrappeTestCase):
+	def test_a_mismatch_is_refused(self):
+		"""It used to overwrite the request's type from the register entry, which
+		silently switched the template and the code series under the requester."""
+		policy = _register("Policy")
+		doc = self._request(request_action="Update", document_type="SOP", reference_document=policy)
+		with self.assertRaises(frappe.ValidationError) as caught:
+			doc.insert(ignore_permissions=True)
+		message = str(caught.exception)
+		self.assertIn("SOP", message)
+		self.assertIn("Policy", message)
+
+	def test_a_match_is_accepted(self):
+		sop = _register("SOP")
+		doc = self._request(request_action="Update", document_type="SOP", reference_document=sop)
+		doc.insert(ignore_permissions=True)
+		self.assertEqual(doc.document_type, "SOP")
+
+	def test_a_blank_type_is_filled_from_the_reference(self):
+		"""Nothing to disagree with — that is a default, not a correction."""
+		manual = _register("Manual")
+		doc = self._request(request_action="Update", document_type=None, reference_document=manual)
+		doc.insert(ignore_permissions=True)
+		self.assertEqual(doc.document_type, "Manual")
+
+	def test_create_is_unaffected(self):
+		"""A Create has no reference document, so there is nothing to match."""
+		doc = self._request(request_action="Create", document_type="Policy")
+		doc.insert(ignore_permissions=True)
+		self.assertEqual(doc.document_type, "Policy")
+
+
+class TestSourceGuidelineMustBeAGuideline(DocumentRequestInputFixtures, FrappeTestCase):
+	def test_a_finished_document_is_refused(self):
+		"""Pointing the guideline at an SOP hands the drafting task a finished
+		document as its instructions — which is how a request for one subject
+		comes back written about another."""
+		sop = _register("SOP", suffix="AsGuideline")
+		doc = self._request(source_guideline=sop)
+		with self.assertRaises(frappe.ValidationError) as caught:
+			doc.insert(ignore_permissions=True)
+		self.assertIn("Guideline", str(caught.exception))
+
+	def test_a_guideline_is_accepted(self):
+		guideline = _register("Guideline")
+		doc = self._request(source_guideline=guideline)
+		doc.insert(ignore_permissions=True)
+		self.assertEqual(doc.source_guideline, guideline)
+
+	def test_the_picker_is_filtered_to_guidelines(self):
+		"""The server check above is the enforcement; this is the half that stops
+		the wrong document being offered in the first place."""
+		filters = frappe.get_meta("Document Request").get_field("source_guideline").get("link_filters")
+		self.assertIn("Guideline", filters or "")
+
+
+class TestUpdateTakesItsChangeFromTheRequirement(DocumentRequestInputFixtures, FrappeTestCase):
+	def test_an_update_needs_a_requirement(self):
+		"""The requirement is now the change to make. Without it the revision
+		would republish the document unaltered as a new version."""
+		sop = _register("SOP", suffix="NeedsReq")
+		doc = self._request(request_action="Update", reference_document=sop, requirement_text="")
+		with self.assertRaises(frappe.ValidationError) as caught:
+			doc.insert(ignore_permissions=True)
+		self.assertIn("Requirement", str(caught.exception))
+
+	def test_an_update_no_longer_needs_a_new_content_document(self):
+		"""update_source used to be mandatory and hold the finished wording."""
+		sop = _register("SOP", suffix="NoSource")
+		doc = self._request(
+			request_action="Update",
+			reference_document=sop,
+			requirement_text="Add a step about returning the key.",
+		)
+		doc.insert(ignore_permissions=True)
+		self.assertFalse(doc.update_source)
+
+	def test_the_field_is_no_longer_mandatory_on_the_form_either(self):
+		field = frappe.get_meta("Document Request").get_field("update_source")
+		self.assertFalse(field.mandatory_depends_on)
+
+	def test_update_source_still_cannot_be_the_document_being_revised(self):
+		"""Kept: reformatting a document into itself produces an identical version."""
+		sop = _register("SOP", suffix="SelfRef")
+		doc = self._request(
+			request_action="Update",
+			reference_document=sop,
+			update_source=sop,
+			requirement_text="Change something.",
+		)
+		with self.assertRaises(frappe.ValidationError):
+			doc.insert(ignore_permissions=True)
+
+	def test_a_withdrawn_document_still_cannot_be_revised(self):
+		"""Kept: withdrawing is how this system says "stop using this"."""
+		gone = _register("SOP", lifecycle_state="Inactive", suffix="Withdrawn")
+		doc = self._request(
+			request_action="Update", reference_document=gone, requirement_text="Revive it."
+		)
+		with self.assertRaises(frappe.ValidationError):
+			doc.insert(ignore_permissions=True)
+
+	def test_input_material_still_cannot_be_revised(self):
+		"""Kept: input material has no version history to add to."""
+		material = _register("SOP", is_input_material=1, suffix="Material")
+		doc = self._request(
+			request_action="Update", reference_document=material, requirement_text="Revise it."
+		)
+		with self.assertRaises(frappe.ValidationError):
+			doc.insert(ignore_permissions=True)
+
+
+class TestRegisterDocumentType(FrappeTestCase):
+	def test_it_is_a_mandatory_select_with_an_empty_first_option(self):
+		"""Empty first option so a type is chosen, not defaulted into by whatever
+		happens to sort first — the type decides the template, the code series,
+		and whether the entry can be a Source Guideline."""
+		field = frappe.get_meta("Document Register").get_field("document_type")
+		self.assertEqual(field.fieldtype, "Select")
+		self.assertTrue(field.reqd)
+		options = (field.options or "").split("\n")
+		self.assertEqual(options[0], "", "the first option must be empty")
+		for kind in ("Policy", "SOP", "Guideline", "Manual"):
+			self.assertIn(kind, options)
+
+	def test_every_requestable_type_can_be_held_by_the_register(self):
+		"""A type a request can ask for but the register cannot hold would make the
+		two impossible to match — and the match is now enforced.
+
+		Not equality: the register also catalogues input material (an amendment, a
+		regulation, meeting outcomes), which no request produces.
+		"""
+		request_types = set(
+			(frappe.get_meta("Document Request").get_field("document_type").options or "").split("\n")
+		) - {""}
+		register_types = set(
+			(frappe.get_meta("Document Register").get_field("document_type").options or "").split("\n")
+		) - {""}
+		self.assertTrue(
+			request_types <= register_types,
+			f"the register cannot hold: {sorted(request_types - register_types)}",
+		)

--- a/one_fm/tests/test_document_versioning.py
+++ b/one_fm/tests/test_document_versioning.py
@@ -337,6 +337,9 @@ class TestRequestsAgainstWithdrawnDocuments(VersioningFixtures, unittest.TestCas
 			"doctype": "Document Register",
 			"drive_file_id": "_TestVerSsrc",
 			"title": "_Test New Content",
+			# Document Type is mandatory on the register now, so input material
+			# has to say what kind it is like everything else.
+			"document_type": "Amendment",
 			"is_input_material": 1,
 		})
 		src.insert(ignore_permissions=True)
@@ -400,13 +403,31 @@ class TestInputMaterial(VersioningFixtures, unittest.TestCase):
 		with self.assertRaises(frappe.ValidationError):
 			self._raise(request_action="Delete", reference_document=src.name)
 
-	def test_an_update_requires_a_new_content_document(self):
-		"""mandatory_depends_on is client-side only in Frappe, so the rule has to
-		be enforced here or the API sails straight past it."""
+	def test_an_update_no_longer_requires_a_new_content_document(self):
+		"""An Update used to need a document holding the finished wording.
+
+		It now works the way a Create does: Requirement says what to change and
+		the existing document supplies everything it does not mention. The rule
+		this test used to assert has moved onto Requirement — see
+		``test_an_update_requires_a_requirement`` below.
+		"""
 		target = self._document(file_id="_TestCtrlB")
 
+		request = self._raise(request_action="Update", reference_document=target.name)
+
+		self.assertEqual(request.reference_document, target.name)
+		self.assertFalse(request.update_source)
+
+	def test_an_update_requires_a_requirement(self):
+		"""mandatory_depends_on is client-side only in Frappe, so the rule has to
+		be enforced here or the API sails straight past it. An Update with nothing
+		to change would republish the document unaltered as a new version."""
+		target = self._document(file_id="_TestCtrlB2")
+
 		with self.assertRaises(frappe.ValidationError):
-			self._raise(request_action="Update", reference_document=target.name)
+			self._raise(
+				request_action="Update", reference_document=target.name, requirement_text=""
+			)
 
 	def test_the_new_content_cannot_be_the_document_being_revised(self):
 		"""It would publish a version identical to the one before it."""

--- a/one_fm/tests/test_document_versioning.py
+++ b/one_fm/tests/test_document_versioning.py
@@ -344,7 +344,7 @@ class TestRequestsAgainstWithdrawnDocuments(VersioningFixtures, unittest.TestCas
 		})
 		src.insert(ignore_permissions=True)
 
-		request = self._raise("Update", doc.name, update_source=src.name)
+		request = self._raise("Update", doc.name)
 
 		self.assertEqual(request.reference_document, doc.name)
 
@@ -395,28 +395,13 @@ class TestInputMaterial(VersioningFixtures, unittest.TestCase):
 		target = self._document(file_id="_TestCtrlA")
 
 		with self.assertRaises(frappe.ValidationError):
-			self._raise(request_action="Update", reference_document=src.name, update_source=target.name)
+			self._raise(request_action="Update", reference_document=src.name)
 
 	def test_input_material_cannot_be_withdrawn_by_request(self):
 		src = self._input_doc("_TestInputB")
 
 		with self.assertRaises(frappe.ValidationError):
 			self._raise(request_action="Delete", reference_document=src.name)
-
-	def test_an_update_no_longer_requires_a_new_content_document(self):
-		"""An Update used to need a document holding the finished wording.
-
-		It now works the way a Create does: Requirement says what to change and
-		the existing document supplies everything it does not mention. The rule
-		this test used to assert has moved onto Requirement — see
-		``test_an_update_requires_a_requirement`` below.
-		"""
-		target = self._document(file_id="_TestCtrlB")
-
-		request = self._raise(request_action="Update", reference_document=target.name)
-
-		self.assertEqual(request.reference_document, target.name)
-		self.assertFalse(request.update_source)
 
 	def test_an_update_requires_a_requirement(self):
 		"""mandatory_depends_on is client-side only in Frappe, so the rule has to
@@ -429,31 +414,14 @@ class TestInputMaterial(VersioningFixtures, unittest.TestCase):
 				request_action="Update", reference_document=target.name, requirement_text=""
 			)
 
-	def test_the_new_content_cannot_be_the_document_being_revised(self):
-		"""It would publish a version identical to the one before it."""
-		target = self._document(file_id="_TestCtrlC")
-
-		with self.assertRaises(frappe.ValidationError):
-			self._raise(request_action="Update", reference_document=target.name,
-			            update_source=target.name)
-
 	def test_a_valid_update_is_accepted(self):
-		src = self._input_doc("_TestInputC")
+		"""An Update now needs only the document to revise and the change to make."""
 		target = self._document(file_id="_TestCtrlD")
 
-		req = self._raise(request_action="Update", reference_document=target.name,
-		                  update_source=src.name)
+		req = self._raise(request_action="Update", reference_document=target.name)
 
-		self.assertEqual(req.update_source, src.name)
-
-	def test_update_source_is_cleared_on_a_non_update(self):
-		"""A stale value would be fetched by the process and treated as the new
-		content of a document nobody asked to revise."""
-		src = self._input_doc("_TestInputD")
-
-		req = self._raise(request_action="Create", update_source=src.name)
-
-		self.assertIsNone(req.update_source)
+		self.assertEqual(req.reference_document, target.name)
+		self.assertTrue(req.requirement_text, "the change is the whole input now")
 
 	def test_a_delete_still_needs_its_document(self):
 		with self.assertRaises(frappe.ValidationError):

--- a/one_fm/tests/test_withdrawn_not_offered.py
+++ b/one_fm/tests/test_withdrawn_not_offered.py
@@ -30,7 +30,7 @@ import unittest
 import frappe
 
 REGISTER = "Document Register"
-LINK_FIELDS = ("source_guideline", "reference_document", "update_source")
+LINK_FIELDS = ("source_guideline", "reference_document")
 
 
 def _employee_with_an_approver():
@@ -47,11 +47,18 @@ class TestThePickersFilter(unittest.TestCase):
 		return json.loads(raw) if raw else None
 
 	def test_every_document_register_picker_is_restricted_to_active(self):
+		"""Asserts the Active restriction is present, not that it is the only one.
+
+		This used to compare the whole filter list, which made it a test of every
+		picker's full configuration rather than of withdrawn documents: adding the
+		Guideline restriction to source_guideline broke it while changing nothing
+		about what it was written to protect.
+		"""
 		for fieldname in LINK_FIELDS:
 			with self.subTest(field=fieldname):
-				self.assertEqual(
+				self.assertIn(
+					[REGISTER, "lifecycle_state", "=", "Active"],
 					self._filters(fieldname),
-					[[REGISTER, "lifecycle_state", "=", "Active"]],
 					f"{fieldname} would still offer withdrawn documents",
 				)
 
@@ -175,33 +182,17 @@ class TestTheServerRefusesThemAnyway(unittest.TestCase):
 			)
 		self.assertIn("inactive", str(caught.exception).lower())
 
-	def test_an_update_cannot_take_its_wording_from_a_withdrawn_document(self):
-		with self.assertRaises(frappe.ValidationError) as caught:
-			self._request(
-				request_action="Update",
-				reference_document=self.controlled.name,
-				update_source=self.dead.name,
-			).insert(ignore_permissions=True)
-		self.assertIn("inactive", str(caught.exception).lower())
-
 	def test_an_active_source_is_accepted(self):
 		"""So the guard is not simply refusing everything."""
 		doc = self._insert(self._request(request_action="Create", source_guideline=self.live.name))
 		self.assertEqual(doc.source_guideline, self.live.name)
 
-	def test_the_guard_only_looks_at_the_field_the_action_uses(self):
-		"""check_update_source clears a stale update_source on a Create. Reading it
-		before that ran would reject a request whose value is about to be dropped."""
-		doc = self._insert(self._request(
-			request_action="Create", source_guideline=self.live.name, update_source=self.dead.name
-		))
-		self.assertIsNone(doc.update_source)
-
 	def test_revising_a_withdrawn_document_is_still_refused(self):
 		"""Pre-existing guard; asserted here so the new one cannot replace it."""
 		with self.assertRaises(frappe.ValidationError):
-			self._request(request_action="Update", reference_document=self.dead.name,
-			              update_source=self.live.name).insert(ignore_permissions=True)
+			self._request(
+				request_action="Update", reference_document=self.dead.name
+			).insert(ignore_permissions=True)
 
 
 class TestWithdrawalStillRevokesSharing(unittest.TestCase):
@@ -213,10 +204,22 @@ class TestWithdrawalStillRevokesSharing(unittest.TestCase):
 	``domain reader one-fm.com`` permission while the two published ones did.
 	"""
 
-	MODEL = "Document Request"
+	PROCESS = "Document Request"
 
 	def _xml(self):
-		return frappe.db.get_value("BPMN Process Model", self.MODEL, "bpmn_xml") or ""
+		"""The active model for the process, not a hard-coded model name.
+
+		Model names carry a version suffix — the live one is "Document Request
+		(1)" — so looking one up by the process name silently returned nothing,
+		and every assertion below failed against an empty string instead of
+		against the diagram.
+		"""
+		name = frappe.db.get_value(
+			"BPMN Process Model", {"process_name": self.PROCESS, "is_active": 1}, "name"
+		)
+		if not name:
+			raise unittest.SkipTest(f"no active BPMN Process Model for {self.PROCESS!r}")
+		return frappe.db.get_value("BPMN Process Model", name, "bpmn_xml") or ""
 
 	def test_the_withdrawal_branch_still_revokes_sharing(self):
 		import re


### PR DESCRIPTION
## Why

Three things a Document Request was either deciding for the requester or hiding
from them, plus one input that no longer has a job.

**Request Action defaulted to "Create".** Adding an empty first option alone
would not have fixed this — a Select with a default still answers "what kind of
request is this?" on the requester's behalf. The action decides whether a
document is created, revised or withdrawn, so it has to be asked.

**The requester was invisible until the first save.** It is captured in
`validate`, which is right for enforcement and too late to be *seen*: the field
is read-only, so a new request rendered the requester and the whole approval
chain as empty read-only fields — and Frappe hides those, so the column was
absent rather than blank. Someone filing a request had no way to tell that the
system knew who they were, or who would be asked to approve it.

**`update_source` held the answer, drafted elsewhere.** It pointed at a second
document containing the finished wording of a revision. A revision is now
written from Requirement against the existing document, so a second document
holding the answer has nothing left to do.

## What

- `request_action`: leading empty option, **`default: "Create"` removed**, and
  relabelled `Request Action` — "Action" reads as "what do I do now" on a form
  full of buttons.
- New whitelisted `get_requester_defaults()` returning the requester and the
  full approval chain for the signed-in user, called from `onload` on a new
  request. It shares `_requester_chain()` with `fill_requester_chain`, so the
  form and the save cannot disagree.
- `update_source` removed: the field, `check_update_source()`, its entry in
  `check_source_documents_are_active`, and its picker filter.

## How

The requester fix is two halves that must agree. Two implementations of "who
approves this" drift, and a form showing one approver while the save records
another is worse than a form showing nothing — so both go through one lookup,
and a test asserts the displayed chain equals what `insert` stores.

`approver_user` still resolves from whatever approver is *on the request*, not
from the chain: an approver set deliberately by an integration is not
necessarily the requester's line manager.

`get_requester_defaults()` returns `{}` rather than throwing when the user has
no Employee record. The form turns that into a message at open time instead of
letting someone write a whole request and fail on save; throwing would break
opening the form rather than explaining the problem.

Removing the default was verified safe first — every programmatic creator in
one_fm and one_bpmn passes `request_action` explicitly.

## Tests

`test_document_request_inputs` 23 · `test_document_versioning` 31 ·
`test_withdrawn_not_offered` 12 — all passing.

New coverage: the chain is offered before the first save; the form matches the
save; a user with no Employee record gets `{}`; Request Action has an empty
first option and no default; and `update_source` is **absent** — re-adding it
would reintroduce two competing sources of truth for what a revision should
say.

Also fixes **four tests that were already failing before this work**. One
compared a picker's entire filter list, so restricting Source Guideline to
Guidelines broke a test about withdrawn documents; it now asserts the Active
filter is present rather than that it is the only one. Three read a BPMN model
by a name that no longer exists — model names carry a version suffix — and so
asserted against an empty string; they resolve the active model by process name.

## Not in this PR

The map changes that go with this ship by export, not in the repo: the
`fetch_update_source` task and its two flows are removed from the diagram (the
Update branch now runs straight to the merge gateway) and the
`update_source_content` block is gone from both drafting prompts. Without that
export, the Update path would call Drive with an empty file id.
