### PR TITLE
fix(patch): skip HR-EMP-02814 leave allocation fix when records are missing

### DIFF
--- a/one_fm/patches/v15_0/fix_leave_allocation_carry_forward_hr_emp_02814.py
+++ b/one_fm/patches/v15_0/fix_leave_allocation_carry_forward_hr_emp_02814.py
@@ -23,7 +23,21 @@ def execute():
 	leave_type = "Annual Leave"
 	allocation_2024 = "HR-LAL-2024-01853"
 	allocation_2025 = "HR-LAL-2025-03301"
-	
+
+	# Site-specific data fix: skip on sites that don't have these records
+	required_records = [
+		("Employee", employee),
+		("Leave Type", leave_type),
+		("Leave Allocation", allocation_2024),
+		("Leave Allocation", allocation_2025),
+	]
+	missing = [f"{doctype} {name}" for doctype, name in required_records if not frappe.db.exists(doctype, name)]
+	if missing:
+		frappe.logger().info(
+			f"[Fix Leave Allocation Carry-Forward] Skipping patch, records not found: {', '.join(missing)}"
+		)
+		return
+
 	# ===== STEP 1: Delete the -17.0 ledger entries (data corruption) =====
 	# Use frappe.db.delete() instead of raw SQL to respect safe mode restrictions
 	deleted = frappe.db.delete("Leave Ledger Entry", {

--- a/one_fm/patches/v15_0/fix_leave_allocation_carry_forward_hr_emp_02814.py
+++ b/one_fm/patches/v15_0/fix_leave_allocation_carry_forward_hr_emp_02814.py
@@ -33,7 +33,7 @@ def execute():
 	]
 	missing = [f"{doctype} {name}" for doctype, name in required_records if not frappe.db.exists(doctype, name)]
 	if missing:
-		frappe.logger().info(
+		print(
 			f"[Fix Leave Allocation Carry-Forward] Skipping patch, records not found: {', '.join(missing)}"
 		)
 		return
@@ -48,7 +48,7 @@ def execute():
 		"leaves": -17.0
 	})
 	
-	frappe.logger().info(
+	print(
 		f"[Fix Leave Allocation Carry-Forward] Deleted {deleted} negative ledger entries "
 		f"for {employee} ({leave_type})"
 	)
@@ -74,7 +74,7 @@ def execute():
 		"modified": now()
 	})
 	
-	frappe.logger().info(
+	print(
 		f"[Fix Leave Allocation Carry-Forward] Updated {allocation_2024}: "
 		f"carry_forwarded_leaves_count: {alloc_2024.carry_forwarded_leaves_count} → {corrected_carry_forward_2024}, "
 		f"unused_leaves: {alloc_2024.unused_leaves} → {corrected_carry_forward_2024}, "
@@ -113,7 +113,7 @@ def execute():
 		"modified": now()
 	})
 	
-	frappe.logger().info(
+	print(
 		f"[Fix Leave Allocation Carry-Forward] Updated {allocation_2025}: "
 		f"earned_leaves: {earned_2025:.2f}, "
 		f"carry_forwarded_leaves: {alloc_2025.unused_leaves} → {corrected_carry_forward_2025:.2f}, "


### PR DESCRIPTION
## Summary

`bench migrate` on test-production fails with:

```
frappe.exceptions.DoesNotExistError: Leave Allocation HR-LAL-2025-03301 not found
```

The patch `v15_0/fix_leave_allocation_carry_forward_hr_emp_02814.py` is a site-specific data fix that hard-references production-only records (HR-EMP-02814, HR-LAL-2024-01853, HR-LAL-2025-03301), so it crashes the whole migration on any site that does not carry them.

## Fix

- Add `frappe.db.exists` checks at the start of the patch for all four referenced records (Employee, Leave Type, and both Leave Allocations). If any is missing, the patch prints which records were not found and returns, letting the migration continue. Behavior on production, where all records exist, is unchanged.
- Replace `frappe.logger()` calls with `print` so the patch output shows in the migrate console.

## Testing

- Syntax-checked; on a site without the records the patch now prints and skips instead of raising.
- Re-run `bench migrate` on test-production after merge - the patch is marked unexecuted (it failed), so it will re-run with the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)