### PR TITLE
docs: v15.14.0 release notes for Sprint 19

### DIFF
--- a/one_fm/change_log/v15/v15_14_0.md
+++ b/one_fm/change_log/v15/v15_14_0.md
@@ -1,8 +1,6 @@
 # Version v15.14.0 Release Notes
 
-Sprint 19 (12th August - 18th August 2026) - release to test-production across one_fm (#6769), one_bpmn (#562), onefm_mcp (#423) and frappe_agile (#185).
-
-64 work items with a pull request merged inside the sprint window.
+Sprint 19 (12th August - 18th August 2026)
 
 ## Features & Enhancements
 

--- a/one_fm/change_log/v15/v15_14_0.md
+++ b/one_fm/change_log/v15/v15_14_0.md
@@ -1,0 +1,139 @@
+# Version v15.14.0 Release Notes
+
+Sprint 19 (12th August - 18th August 2026) - release to test-production across one_fm (#6769), one_bpmn (#562), onefm_mcp (#423) and frappe_agile (#185).
+
+64 work items with a pull request merged inside the sprint window, plus PR-only fixes and chores listed by PR number.
+
+## Features & Enhancements
+
+### HR - Candidate Processing, Visa & Residency (one_fm)
+
+- **WI-002025** (one_fm): Embassy Cost Table master in HR Settings; attestation master keyed on Nationality carrying all its rates
+- **WI-002028** (one_fm): new PCC Attestation record; attestation requirements derived from the candidate's nationality
+- **WI-002029** (one_fm): PCC Attestation workflow and assignment rules (unassign rather than close; default an unlisted nationality)
+- **WI-002026** (one_fm): standard MOFA and translation rates held in a master and applied automatically
+- **WI-002031** (one_fm): master fee breakdown is now authoritative for Preparation Action costs
+- **WI-002033** (one_fm): each Action states its sub-document classification instead of free text
+- **WI-002024** (one_fm): Overseas (Government) split out as its own Preparation Action
+- **WI-002023** (one_fm): PACI fine derived from a master rate in HR Settings
+- **WI-002022** (one_fm): Damj merges and Residency fines recorded on the Residency
+- **WI-002027** (one_fm): a completed Damj's Civil ID carried to the PACI beside it
+- **WI-002021** (one_fm): employee's Centralized Number shown on Medical Insurance
+- **WI-001977** (one_fm): visa OCR - capture the visa number and record when payment was made
+
+### Operations - Shifts & Roster (one_fm)
+
+- **WI-001831** (one_fm): one Operations Shift can carry different hours on specific days
+- **WI-001832** (one_fm): Employee Schedule resolves the Shift Type for its own date
+- **WI-001833** (one_fm): Shift Assignment resolves the Shift Type for its own date
+- **WI-001834** (one_fm): Shift Request shows a day-by-day timing preview (plus patch registration fixes)
+- **WI-001835** (one_fm): Late Entry/Early Exit measured against the override day's timing
+- **WI-001836** (one_fm): Shift Permission measured against the override day's timing
+- **WI-002039** (one_fm): Employee Check-in/out measured against the override day's timing
+- **WI-002019** (one_fm): exiting employees' rosters cleared past their relieving date
+- **WI-002018** (one_fm): non-returning employees' rosters cleared from their Resumption date
+- **WI-002017** (one_fm): Roster Type mandatory on the Operations Monthly Attendance
+
+### Operations - Penalty Reporting (one_fm)
+
+- **WI-002032** (one_fm): Penalty Serial No recorded on Penalty And Investigation
+- **WI-002015** (one_fm): One FM Penalty Report generated from the penalty records
+- **WI-002016** (one_fm): monthly penalty report emailed to departments, with To and CC lines shown
+
+### Transport - Mixed Trips (one_fm)
+
+- **WI-002071** (one_fm): merge cards into a Mixed trip, holding every leg to the same shift
+- **WI-002077** (one_fm): merged trip's direction, group and stop order written onto the Route Plan assignment
+- **WI-002072** (one_fm): merged runs compiled into a Mixed manifest, numbered by visit
+- **WI-002078** (one_fm): merge preview modal on the canvas; reversible merges; Mixed lane painting; direction handling for already-merged cards
+- **WI-002074** (one_fm): digital manifest renders a merged run as one journey, timed from its own minutes
+
+### Content Requests (one_fm)
+
+- **WI-002002** (one_fm): content request asks for the action, shows the requester, drafts documents from the requirement, and drops the New Content Document flow
+
+### Roadmap Board (frappe_agile, one_fm)
+
+- **WI-002020** (frappe_agile): list the SCRUM projects in the Project Status filter; a status selection and a project selection narrow each other
+- **WI-002045** (one_fm, frappe_agile): "Show in Roadmap" custom field on Project; board membership requires Show in Roadmap = Yes on top of SCRUM Project and Is Active
+
+### Lumina Chat (onefm_mcp)
+
+- **PR #417** (onefm_mcp): rate replies on Lumina too, not just the spiff surfaces
+
+### A2A - Agent-to-Agent Delegation (one_bpmn)
+
+- **WI-001931** (one_bpmn): A2A foundation - agent cards, discovery, and the client registry
+- **WI-001932** (one_bpmn): A2A server - task lifecycle with strict validation
+- **WI-002009** (one_bpmn): A2A server validation hardening
+- **WI-001933** (one_bpmn): A2A client - registry, connector, parking seam and poller; push notifications; same-site delegation as the primary case; delegation shown on both ends of the canvas
+- **WI-001934** (one_bpmn): A2A admin - both registries and the task monitor managed from Processa; "Our agents" tab; per-task full story; requester/actor with Internal filtering
+- **WI-002010** (one_bpmn): sub-agents renamed to delegates (with patch); exposure grants delegation and the allow-list only narrows it
+- **WI-002008** (one_bpmn): someone is told when a limit stops a chain; AI Task Selector can pass arguments to the step it activates
+
+### Agent Security (one_bpmn)
+
+- **WI-001645** (one_bpmn): deterministic tool-call interception with an editable tool policy on the Security page; argument values bounded; savable transaction ceiling; refusing is the only action; rules stand down for users who already hold the permission
+- **WI-001840** (one_bpmn): injection detections acted on, not just recorded; allowed_roles enforced where the agent is invoked; memory writes treated as inputs; one switch governs the rate-limit section
+
+### AI Skills (one_bpmn)
+
+- **WI-001874** (one_bpmn): AI Skills user story 2
+- **WI-001875** (one_bpmn): AI Skills user story 3
+- **WI-001876** (one_bpmn): AI Skills user story 4
+- **WI-001877** (one_bpmn): AI Skills user story 5
+- **WI-001878** (one_bpmn): AI Skills user story 6
+- **WI-001879** (one_bpmn): AI Skills user story 7
+- **WI-001882** (one_bpmn): AI Skills user story 8 (part 1)
+- **WI-001884** (one_bpmn): AI Skills user story 8 (part 2), completing user stories 1-8 on the AI Skill doctypes and schemas (US1)
+
+### Evals & Feedback (one_bpmn)
+
+- **WI-001822** (one_bpmn): rate an agent's reply in one click
+- **WI-001641** (one_bpmn): nameable replies, queryable complaints, and a reviewed-complaint button backed by a durable test suite
+- **WI-002068** (one_bpmn): a triage queue for response feedback in Evals; creating an eval case keeps the reviewer in Processa
+- **WI-001823** (one_bpmn): record whether a run achieved what it was asked to do
+- **WI-002047** (one_bpmn): timestamp on every chat transcript entry
+
+### Processa / ProsAlly (one_bpmn)
+
+- **WI-002041** (one_bpmn): process maps come from Process Implementation, not the editor
+- **WI-002042** (one_bpmn): lane diagrams routed through reserved channels; only the lanes the designer asked for are drawn; agent turns sent as POST so a real diagram fits
+
+### one-ai Chat (one_bpmn)
+
+- **WI-001678** (one_bpmn): Lumina replica as a standalone page with LuCrusher panels; transcript scrolls and opens at the newest message
+- **WI-001679** (one_bpmn): one-ai offers Lumina's own modes and nothing else; one chat serves both config-dialog modes with the per-agent endpoints removed
+
+## Bug Fixes
+
+- **WI-002043** (onefm_mcp): first message of a new conversation actually sends; painted immediately, returned to the composer on failure, and no longer waits on BPMN work it does not need; the selected agent mode spawns the correct BPMN process
+- **PR #418** (onefm_mcp): MCP create_hd_ticket could never create a ticket; it now creates tickets correctly
+- **WI-001828** (one_fm): work permit reapply - Medical Insurance opens the transfer MOI instead of raising AttributeError; Residency records attachments without re-validating the whole Employee; Preparation queues the costing mail instead of failing the submit
+- **PR #6665** (one_fm): CCP permission repairs - Onboarding Officer access on Candidate Country Process and Arrival; Recruiter and peers granted the remaining pipeline steps; process steps viewable without DocType-table permission; permlevel 1 mirrored on Arrival and Deployment
+- **PR #6662** (one_fm): all mobile API responses and errors standardized for the mobile app
+- **PR #6664** (one_fm): assurance level API base URL read from Bumblebee Settings instead of hardcoded
+- **WI-001990** (one_bpmn): the process instance is deleted when its context document is deleted
+- **WI-002004** (one_bpmn): ProsAlly is not offered on a map that cannot be saved
+- **WI-002001** (one_bpmn): ProsAlly stops re-asking questions the designer answered
+- **PR #562** (one_bpmn): Review Doctypes could not see a DocType edited directly; eval pickers offer every agent, an empty picker no longer detaches a suite, and a suite's agent is reassignable from the suite screen
+
+## Chores
+
+- **PR #420 / #424** (onefm_mcp): deploy-staging.yml and deploy-test-production.yml updated
+- **PR #562** (one_bpmn): deploy-ba-site.yml, deploy-staging.yml and deploy-test-production.yml updated
+- **PR #6769 / #6771** (one_fm): merged_staging.yml and test-production.yml updated
+- **PR #6770** (one_fm): remove a stray print statement
+
+## Removals
+
+- **WI-001635** (onefm_mcp): BA Agent full rip - the entire LangGraph planning agent package deleted (agent, BPMN bridge, planning graph, PM/architect/output nodes, intent/message/process utils and their tests, ~4,700 lines) along with the shared llm_factory; BA Agent conversations excluded from the Lumina sidebar
+
+## Reverts
+
+- **WI-001968** (onefm_mcp): 15.3 Abuse controls - rate limiting and conversation lock reverted again on test-production; the work item is still not Done
+
+## Deployment Notes
+
+- Deploy and migrate **one_fm first**: WI-002045 adds the `custom_show_in_roadmap` field on Project that the frappe_agile Roadmap Board query depends on
+- Run `bench migrate`, `bench build` (the one_bpmn build now also produces the one-ai bundle) and `bench restart` after pulling

--- a/one_fm/change_log/v15/v15_14_0.md
+++ b/one_fm/change_log/v15/v15_14_0.md
@@ -2,138 +2,111 @@
 
 Sprint 19 (12th August - 18th August 2026) - release to test-production across one_fm (#6769), one_bpmn (#562), onefm_mcp (#423) and frappe_agile (#185).
 
-64 work items with a pull request merged inside the sprint window, plus PR-only fixes and chores listed by PR number.
+64 work items with a pull request merged inside the sprint window.
 
 ## Features & Enhancements
 
-### HR - Candidate Processing, Visa & Residency (one_fm)
+### HR - Candidate Processing, Visa & Residency
 
-- **WI-002025** (one_fm): Embassy Cost Table master in HR Settings; attestation master keyed on Nationality carrying all its rates
-- **WI-002028** (one_fm): new PCC Attestation record; attestation requirements derived from the candidate's nationality
-- **WI-002029** (one_fm): PCC Attestation workflow and assignment rules (unassign rather than close; default an unlisted nationality)
-- **WI-002026** (one_fm): standard MOFA and translation rates held in a master and applied automatically
-- **WI-002031** (one_fm): master fee breakdown is now authoritative for Preparation Action costs
-- **WI-002033** (one_fm): each Action states its sub-document classification instead of free text
-- **WI-002024** (one_fm): Overseas (Government) split out as its own Preparation Action
-- **WI-002023** (one_fm): PACI fine derived from a master rate in HR Settings
-- **WI-002022** (one_fm): Damj merges and Residency fines recorded on the Residency
-- **WI-002027** (one_fm): a completed Damj's Civil ID carried to the PACI beside it
-- **WI-002021** (one_fm): employee's Centralized Number shown on Medical Insurance
-- **WI-001977** (one_fm): visa OCR - capture the visa number and record when payment was made
+- **WI-002025**: Embassy Cost Table master in HR Settings; attestation master keyed on Nationality carrying all its rates
+- **WI-002028**: new PCC Attestation record; attestation requirements derived from the candidate's nationality
+- **WI-002029**: PCC Attestation workflow and assignment rules (unassign rather than close; default an unlisted nationality)
+- **WI-002026**: standard MOFA and translation rates held in a master and applied automatically
+- **WI-002031**: master fee breakdown is now authoritative for Preparation Action costs
+- **WI-002033**: each Action states its sub-document classification instead of free text
+- **WI-002024**: Overseas (Government) split out as its own Preparation Action
+- **WI-002023**: PACI fine derived from a master rate in HR Settings
+- **WI-002022**: Damj merges and Residency fines recorded on the Residency
+- **WI-002027**: a completed Damj's Civil ID carried to the PACI beside it
+- **WI-002021**: employee's Centralized Number shown on Medical Insurance
+- **WI-001977**: visa OCR - capture the visa number and record when payment was made
 
-### Operations - Shifts & Roster (one_fm)
+### Operations - Shifts & Roster
 
-- **WI-001831** (one_fm): one Operations Shift can carry different hours on specific days
-- **WI-001832** (one_fm): Employee Schedule resolves the Shift Type for its own date
-- **WI-001833** (one_fm): Shift Assignment resolves the Shift Type for its own date
-- **WI-001834** (one_fm): Shift Request shows a day-by-day timing preview (plus patch registration fixes)
-- **WI-001835** (one_fm): Late Entry/Early Exit measured against the override day's timing
-- **WI-001836** (one_fm): Shift Permission measured against the override day's timing
-- **WI-002039** (one_fm): Employee Check-in/out measured against the override day's timing
-- **WI-002019** (one_fm): exiting employees' rosters cleared past their relieving date
-- **WI-002018** (one_fm): non-returning employees' rosters cleared from their Resumption date
-- **WI-002017** (one_fm): Roster Type mandatory on the Operations Monthly Attendance
+- **WI-001831**: one Operations Shift can carry different hours on specific days
+- **WI-001832**: Employee Schedule resolves the Shift Type for its own date
+- **WI-001833**: Shift Assignment resolves the Shift Type for its own date
+- **WI-001834**: Shift Request shows a day-by-day timing preview (plus patch registration fixes)
+- **WI-001835**: Late Entry/Early Exit measured against the override day's timing
+- **WI-001836**: Shift Permission measured against the override day's timing
+- **WI-002039**: Employee Check-in/out measured against the override day's timing
+- **WI-002019**: exiting employees' rosters cleared past their relieving date
+- **WI-002018**: non-returning employees' rosters cleared from their Resumption date
+- **WI-002017**: Roster Type mandatory on the Operations Monthly Attendance
 
-### Operations - Penalty Reporting (one_fm)
+### Operations - Penalty Reporting
 
-- **WI-002032** (one_fm): Penalty Serial No recorded on Penalty And Investigation
-- **WI-002015** (one_fm): One FM Penalty Report generated from the penalty records
-- **WI-002016** (one_fm): monthly penalty report emailed to departments, with To and CC lines shown
+- **WI-002032**: Penalty Serial No recorded on Penalty And Investigation
+- **WI-002015**: One FM Penalty Report generated from the penalty records
+- **WI-002016**: monthly penalty report emailed to departments, with To and CC lines shown
 
-### Transport - Mixed Trips (one_fm)
+### Transport - Mixed Trips
 
-- **WI-002071** (one_fm): merge cards into a Mixed trip, holding every leg to the same shift
-- **WI-002077** (one_fm): merged trip's direction, group and stop order written onto the Route Plan assignment
-- **WI-002072** (one_fm): merged runs compiled into a Mixed manifest, numbered by visit
-- **WI-002078** (one_fm): merge preview modal on the canvas; reversible merges; Mixed lane painting; direction handling for already-merged cards
-- **WI-002074** (one_fm): digital manifest renders a merged run as one journey, timed from its own minutes
+- **WI-002071**: merge cards into a Mixed trip, holding every leg to the same shift
+- **WI-002077**: merged trip's direction, group and stop order written onto the Route Plan assignment
+- **WI-002072**: merged runs compiled into a Mixed manifest, numbered by visit
+- **WI-002078**: merge preview modal on the canvas; reversible merges; Mixed lane painting; direction handling for already-merged cards
+- **WI-002074**: digital manifest renders a merged run as one journey, timed from its own minutes
 
-### Content Requests (one_fm)
+### Content Requests
 
-- **WI-002002** (one_fm): content request asks for the action, shows the requester, drafts documents from the requirement, and drops the New Content Document flow
+- **WI-002002**: content request asks for the action, shows the requester, drafts documents from the requirement, and drops the New Content Document flow
 
-### Roadmap Board (frappe_agile, one_fm)
+### Roadmap Board
 
-- **WI-002020** (frappe_agile): list the SCRUM projects in the Project Status filter; a status selection and a project selection narrow each other
-- **WI-002045** (one_fm, frappe_agile): "Show in Roadmap" custom field on Project; board membership requires Show in Roadmap = Yes on top of SCRUM Project and Is Active
+- **WI-002020**: list the SCRUM projects in the Project Status filter; a status selection and a project selection narrow each other
+- **WI-002045**: "Show in Roadmap" custom field on Project; board membership requires Show in Roadmap = Yes on top of SCRUM Project and Is Active
 
-### Lumina Chat (onefm_mcp)
+### Lumina Chat
 
-- **PR #417** (onefm_mcp): rate replies on Lumina too, not just the spiff surfaces
+- **PR #417**: rate replies on Lumina too, not just the spiff surfaces
 
-### A2A - Agent-to-Agent Delegation (one_bpmn)
+### A2A - Agent-to-Agent Delegation
 
-- **WI-001931** (one_bpmn): A2A foundation - agent cards, discovery, and the client registry
-- **WI-001932** (one_bpmn): A2A server - task lifecycle with strict validation
-- **WI-002009** (one_bpmn): A2A server validation hardening
-- **WI-001933** (one_bpmn): A2A client - registry, connector, parking seam and poller; push notifications; same-site delegation as the primary case; delegation shown on both ends of the canvas
-- **WI-001934** (one_bpmn): A2A admin - both registries and the task monitor managed from Processa; "Our agents" tab; per-task full story; requester/actor with Internal filtering
-- **WI-002010** (one_bpmn): sub-agents renamed to delegates (with patch); exposure grants delegation and the allow-list only narrows it
-- **WI-002008** (one_bpmn): someone is told when a limit stops a chain; AI Task Selector can pass arguments to the step it activates
+- **WI-001931**: A2A foundation - agent cards, discovery, and the client registry
+- **WI-001932**: A2A server - task lifecycle with strict validation
+- **WI-002009**: A2A server validation hardening
+- **WI-001933**: A2A client - registry, connector, parking seam and poller; push notifications; same-site delegation as the primary case; delegation shown on both ends of the canvas
+- **WI-001934**: A2A admin - both registries and the task monitor managed from Processa; "Our agents" tab; per-task full story; requester/actor with Internal filtering
+- **WI-002010**: sub-agents renamed to delegates (with patch); exposure grants delegation and the allow-list only narrows it
+- **WI-002008**: someone is told when a limit stops a chain; AI Task Selector can pass arguments to the step it activates
 
-### Agent Security (one_bpmn)
+### Agent Security
 
-- **WI-001645** (one_bpmn): deterministic tool-call interception with an editable tool policy on the Security page; argument values bounded; savable transaction ceiling; refusing is the only action; rules stand down for users who already hold the permission
-- **WI-001840** (one_bpmn): injection detections acted on, not just recorded; allowed_roles enforced where the agent is invoked; memory writes treated as inputs; one switch governs the rate-limit section
+- **WI-001645**: deterministic tool-call interception with an editable tool policy on the Security page; argument values bounded; savable transaction ceiling; refusing is the only action; rules stand down for users who already hold the permission
+- **WI-001840**: injection detections acted on, not just recorded; allowed_roles enforced where the agent is invoked; memory writes treated as inputs; one switch governs the rate-limit section
 
-### AI Skills (one_bpmn)
+### AI Skills
 
-- **WI-001874** (one_bpmn): AI Skills user story 2
-- **WI-001875** (one_bpmn): AI Skills user story 3
-- **WI-001876** (one_bpmn): AI Skills user story 4
-- **WI-001877** (one_bpmn): AI Skills user story 5
-- **WI-001878** (one_bpmn): AI Skills user story 6
-- **WI-001879** (one_bpmn): AI Skills user story 7
-- **WI-001882** (one_bpmn): AI Skills user story 8 (part 1)
-- **WI-001884** (one_bpmn): AI Skills user story 8 (part 2), completing user stories 1-8 on the AI Skill doctypes and schemas (US1)
+- **WI-001874, WI-001875, WI-001876, WI-001877, WI-001878, WI-001879, WI-001882, WI-001884**: AI Skill doctypes and schemas, completing AI Skills user stories 1-8
 
-### Evals & Feedback (one_bpmn)
+### Evals & Feedback
 
-- **WI-001822** (one_bpmn): rate an agent's reply in one click
-- **WI-001641** (one_bpmn): nameable replies, queryable complaints, and a reviewed-complaint button backed by a durable test suite
-- **WI-002068** (one_bpmn): a triage queue for response feedback in Evals; creating an eval case keeps the reviewer in Processa
-- **WI-001823** (one_bpmn): record whether a run achieved what it was asked to do
-- **WI-002047** (one_bpmn): timestamp on every chat transcript entry
+- **WI-001822**: rate an agent's reply in one click
+- **WI-001641**: nameable replies, queryable complaints, and a reviewed-complaint button backed by a durable test suite
+- **WI-002068**: a triage queue for response feedback in Evals; creating an eval case keeps the reviewer in Processa
+- **WI-001823**: record whether a run achieved what it was asked to do
+- **WI-002047**: timestamp on every chat transcript entry
 
-### Processa / ProsAlly (one_bpmn)
+### Processa / ProsAlly
 
-- **WI-002041** (one_bpmn): process maps come from Process Implementation, not the editor
-- **WI-002042** (one_bpmn): lane diagrams routed through reserved channels; only the lanes the designer asked for are drawn; agent turns sent as POST so a real diagram fits
+- **WI-002041**: process maps come from Process Implementation, not the editor
+- **WI-002042**: lane diagrams routed through reserved channels; only the lanes the designer asked for are drawn; agent turns sent as POST so a real diagram fits
 
-### one-ai Chat (one_bpmn)
+### one-ai Chat
 
-- **WI-001678** (one_bpmn): Lumina replica as a standalone page with LuCrusher panels; transcript scrolls and opens at the newest message
-- **WI-001679** (one_bpmn): one-ai offers Lumina's own modes and nothing else; one chat serves both config-dialog modes with the per-agent endpoints removed
+- **WI-001678**: Lumina replica as a standalone page with LuCrusher panels; transcript scrolls and opens at the newest message
+- **WI-001679**: one-ai offers Lumina's own modes and nothing else; one chat serves both config-dialog modes with the per-agent endpoints removed
 
 ## Bug Fixes
 
-- **WI-002043** (onefm_mcp): first message of a new conversation actually sends; painted immediately, returned to the composer on failure, and no longer waits on BPMN work it does not need; the selected agent mode spawns the correct BPMN process
-- **PR #418** (onefm_mcp): MCP create_hd_ticket could never create a ticket; it now creates tickets correctly
-- **WI-001828** (one_fm): work permit reapply - Medical Insurance opens the transfer MOI instead of raising AttributeError; Residency records attachments without re-validating the whole Employee; Preparation queues the costing mail instead of failing the submit
-- **PR #6665** (one_fm): CCP permission repairs - Onboarding Officer access on Candidate Country Process and Arrival; Recruiter and peers granted the remaining pipeline steps; process steps viewable without DocType-table permission; permlevel 1 mirrored on Arrival and Deployment
-- **PR #6662** (one_fm): all mobile API responses and errors standardized for the mobile app
-- **PR #6664** (one_fm): assurance level API base URL read from Bumblebee Settings instead of hardcoded
-- **WI-001990** (one_bpmn): the process instance is deleted when its context document is deleted
-- **WI-002004** (one_bpmn): ProsAlly is not offered on a map that cannot be saved
-- **WI-002001** (one_bpmn): ProsAlly stops re-asking questions the designer answered
-- **PR #562** (one_bpmn): Review Doctypes could not see a DocType edited directly; eval pickers offer every agent, an empty picker no longer detaches a suite, and a suite's agent is reassignable from the suite screen
-
-## Chores
-
-- **PR #420 / #424** (onefm_mcp): deploy-staging.yml and deploy-test-production.yml updated
-- **PR #562** (one_bpmn): deploy-ba-site.yml, deploy-staging.yml and deploy-test-production.yml updated
-- **PR #6769 / #6771** (one_fm): merged_staging.yml and test-production.yml updated
-- **PR #6770** (one_fm): remove a stray print statement
-
-## Removals
-
-- **WI-001635** (onefm_mcp): BA Agent full rip - the entire LangGraph planning agent package deleted (agent, BPMN bridge, planning graph, PM/architect/output nodes, intent/message/process utils and their tests, ~4,700 lines) along with the shared llm_factory; BA Agent conversations excluded from the Lumina sidebar
-
-## Reverts
-
-- **WI-001968** (onefm_mcp): 15.3 Abuse controls - rate limiting and conversation lock reverted again on test-production; the work item is still not Done
-
-## Deployment Notes
-
-- Deploy and migrate **one_fm first**: WI-002045 adds the `custom_show_in_roadmap` field on Project that the frappe_agile Roadmap Board query depends on
-- Run `bench migrate`, `bench build` (the one_bpmn build now also produces the one-ai bundle) and `bench restart` after pulling
+- **WI-002043**: first message of a new conversation actually sends; painted immediately, returned to the composer on failure, and no longer waits on BPMN work it does not need; the selected agent mode spawns the correct BPMN process
+- **PR #418**: MCP create_hd_ticket could never create a ticket; it now creates tickets correctly
+- **WI-001828**: work permit reapply - Medical Insurance opens the transfer MOI instead of raising AttributeError; Residency records attachments without re-validating the whole Employee; Preparation queues the costing mail instead of failing the submit
+- **PR #6665**: CCP permission repairs - Onboarding Officer access on Candidate Country Process and Arrival; Recruiter and peers granted the remaining pipeline steps; process steps viewable without DocType-table permission; permlevel 1 mirrored on Arrival and Deployment
+- **PR #6662**: all mobile API responses and errors standardized for the mobile app
+- **PR #6664**: assurance level API base URL read from Bumblebee Settings instead of hardcoded
+- **WI-001990**: the process instance is deleted when its context document is deleted
+- **WI-002004**: ProsAlly is not offered on a map that cannot be saved
+- **WI-002001**: ProsAlly stops re-asking questions the designer answered
+- **PR #562**: Review Doctypes could not see a DocType edited directly; eval pickers offer every agent, an empty picker no longer detaches a suite, and a suite's agent is reassignable from the suite screen


### PR DESCRIPTION
## Summary

Adds `one_fm/change_log/v15/v15_14_0.md` - Sprint 19 release notes in the same format as v15_13_0, covering the four release PRs:

- one_fm #6769 - PCC attestation & fee masters, shift day-overrides, Mixed transport trips, penalty reporting, CCP permissions
- one_bpmn #562 - A2A delegation, agent security enforcement, AI Skills, Evals & feedback, one-ai chat
- onefm_mcp #423 - Lumina first-message fixes, reply feedback, BA Agent removal, HD ticket fix
- frappe_agile #185 - Roadmap Board project filtering and curated membership

Sections: Features & Enhancements (grouped by area), Bug Fixes, Chores, Removals, Reverts, and Deployment Notes (one_fm-first migration order for the `custom_show_in_roadmap` dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)