### PR TITLE
Revert "WI-001687: Shift dropdown for OT slots shows all active shifts" on test-production

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -2987,20 +2987,14 @@ function change_ot_schedule(page) {
 				"label": "Shift", "fieldname": "shift", "fieldtype": "Link", "options": "Operations Shift", "reqd": 1, onchange: function () {
 					let name = d.get_value("shift");
 					if (name) {
-						frappe.db.get_value("Operations Shift", name, ["site", "project", "double_shift_ot_allowed"])
+						frappe.db.get_value("Operations Shift", name, ["site", "project"])
 							.then(res => {
-								let { site, project, double_shift_ot_allowed } = res.message;
+								let { site, project } = res.message;
 								d.set_value("site", site);
 								d.set_value("project", project);
-								// WI-001687: non-blocking warning when the chosen shift disallows Double Shift OT.
-								if (!cint(double_shift_ot_allowed)) {
-									frappe.show_alert({ message: __("Warning: The selected shift does not allow Double Shift OT. A Double Shift OT Checker will be generated."), indicator: "orange" }, 7);
-								}
 							});
 					}
 				}, get_query: function () {
-					// WI-001687: show ALL active shifts for an OT slot; non-DSOT shifts are
-					// allowed with a soft warning and tracked via a checker rather than blocked.
 					return {
 						"filters": { "status": "Active" },
 						"page_length": 9999

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -853,14 +853,10 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
 	operations_shift_doc = frappe.get_doc("Operations Shift", shift, ignore_permissions=True)
 	operations_role_doc = frappe.get_doc("Operations Role", operations_role, ignore_permissions=True)
 	day_off_ot = cint(day_off_ot)
-	# roster_type is driven solely by whether the OT (second-shift) dialog was used.
-	# day_off_ot is an independent flag: a Day Off OT first shift is still "Basic".
-	roster_type = "Over-Time" if otRoster == "true" else "Basic"
-
-	# WI-001687: OT scheduling is no longer blocked for shifts without
-	# 'Double Shift OT Allowed'. Selection is unrestricted (a soft warning is
-	# shown client-side); non-compliant OT is tracked via the Roster Double
-	# Shift OT Checker (WI-001688) rather than blocked here.
+	if otRoster == "false":
+		roster_type = "Basic"
+	elif otRoster == "true" or day_off_ot == 1:
+		roster_type = "Over-Time"
 
 	# check for end date
 	if end_date:


### PR DESCRIPTION
Mirrors #6723 onto test-production (cherry-pick of `b93593e37`).

## Why

`double_shift_ot_allowed` was defined on Operations Shift by WI-001425 (#6413), which was reverted out of version-15 on 21 Jul. WI-001687 still queries the field:

```js
frappe.db.get_value("Operations Shift", name, ["site", "project", "double_shift_ot_allowed"])
```

so every OT shift selection in the roster throws `Field not permitted in query: double_shift_ot_allowed`.

#6723 fixed this on version-15 on Aug 17, but the big test-production merge happened Aug 16 - one day earlier - so test-production received the feature and never received the revert. Verified the consumer is still present on the current test-production head; this PR removes it the same way #6723 did.

One of three mirror reverts (with WI-001688 and WI-001689). This one fixes the user-facing roster error and is safe to merge before Sprint 19 UAT of the roster/shift chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)