### PR TITLE
WI-001686: create the Attendance Event Staff column when meta drops it

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -587,7 +587,7 @@ one_fm.patches.v15_0.add_pcc_processing_fees_to_hr_settings #2026-08-12 WI-00202
 one_fm.patches.v15_0.add_shift_request_shift_preview #2026-08-12 WI-001834
 one_fm.patches.v15_0.restore_stranded_mixed_shipments #2026-08-17 WI-002071
 one_fm.patches.v15_0.update_sales_invoice_property_setter
-one_fm.patches.v15_0.add_attendance_event_staff_field #2026-08-01
+one_fm.patches.v15_0.add_attendance_event_staff_field #2026-08-22 rerun for the missing custom_event_staff column
 one_fm.patches.v15_0.update_penalty_and_investigation_workflow #2026-08-02 rerun for employee_response
 one_fm.patches.v15_0.update_penalty_assignment_rules_process_task_based
 one_fm.patches.v15_0.update_visa_request_workflow_and_rules #2026-08-18 WI-001773 rerun after the sprint revert restored only the patch

--- a/one_fm/patches/v15_0/add_attendance_event_staff_field.py
+++ b/one_fm/patches/v15_0/add_attendance_event_staff_field.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from frappe.database.schema import add_column
 
 from one_fm.custom.custom_field.attendance import get_attendance_custom_fields
 
@@ -17,6 +18,13 @@ def execute():
 	and skips anything already set.
 	"""
 	create_custom_fields(get_attendance_custom_fields(), update=True)
+
+	# create_custom_fields builds its ALTER TABLE from the *sorted* field list, and a
+	# custom field whose insert_after anchor cannot be resolved against the doctype's
+	# field_order is dropped from that list - the Custom Field row lands, the column
+	# does not. On Attendance the anchor is eight custom fields deep, so make sure.
+	if not frappe.db.has_column("Attendance", "custom_event_staff"):
+		add_column("Attendance", "custom_event_staff", "Link")
 
 	# Attendance -> Shift Assignment -> Event Staff, for rows that have not got there yet.
 	assignments = {


### PR DESCRIPTION
## Problem

`bench migrate` on production dies in `add_attendance_event_staff_field`:

```
pymysql.err.OperationalError: (1054, "Unknown column 'tabAttendance.custom_event_staff' in 'WHERE'")
```

`create_custom_fields()` ran on the line above, so the field is there — the column is not.

## Cause

`create_custom_fields` ends with `frappe.db.updatedb(doctype)`, which builds its `ALTER TABLE` from `meta.get("fields")` — the **sorted** field list. `Meta.sort_fields()` rebuilds that list from `field_order`, and a custom field whose `insert_after` anchor cannot be resolved is silently discarded (leftovers in `insert_after_map` are dropped). So the Custom Field row lands and the column does not.

`meta.get_field()` still finds the field, because `_fields` is built *before* the sort — which is why the backfill happily emits `tabAttendance.custom_event_staff` into SQL and only fails at the DB.

`custom_event_staff` is eight custom fields deep:

```
custom_event_staff → custom_client_event → timesheet → project → site
  → operations_shift → shift_assignment → section_break_17 → early_exit (standard)
```

One broken link on a site takes out everything below it. Production's `field_order` property setter on Attendance is a different snapshot from dev's, which is why dev never saw this.

## Fix

- Add the column directly when it is missing. `frappe.database.schema.add_column` is `add column if not exists`, so it is idempotent.
- Bump the patch entry in `patches.txt` so it re-runs. Needed because `updatedb` commits before migrate's `@atomic` rollback: the failed run left the Custom Field row behind, so on the next run `create_custom_fields` sees no change, never calls `updatedb`, and the column would stay missing.

## Note for the deploy

This unblocks migrate and lands the backfill data. It does not repair the field ordering — while `custom_event_staff` is dropped from `meta.fields` on that site, the field will not render on the Attendance form and `fetch_from` will not populate new records. That repair is deleting the stale `field_order` Property Setter on Attendance, after which ordering is derived purely from `insert_after` and the whole chain resolves off `early_exit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)