### PR TITLE
fix(resignation): IDOR fixes + mobile-API cleanup in Employee Resignation flows

### DIFF
--- a/one_fm/api/v1/resignation.py
+++ b/one_fm/api/v1/resignation.py
@@ -202,6 +202,11 @@ def extend_resignation(
         employee_name = resolve_employee_name(input_id)
         if not employee_name:
             frappe.throw(f"Employee '{input_id}' not found", frappe.ValidationError)
+
+        employee_user = frappe.db.get_value("Employee", employee_name, "user_id")
+        if employee_user != frappe.session.user and not frappe.has_permission("Employee Resignation Date Adjustment", ptype="create"):
+            frappe.throw(_("Not authorized to submit an extension for this employee"), frappe.PermissionError)
+
         if not extended_date:
             frappe.throw("extended_date is required", frappe.ValidationError)
 
@@ -222,7 +227,8 @@ def extend_resignation(
             frappe.throw("No active resignation found to extend", frappe.ValidationError)
 
         active_doc = frappe.get_doc("Employee Resignation", resignation_id)
-        employee_user = frappe.db.get_value("Employee", employee_name, "user_id")
+        if active_doc.employee != employee_name and not frappe.has_permission("Employee Resignation Date Adjustment", ptype="create"):
+            frappe.throw(_("This resignation does not belong to the specified employee"), frappe.PermissionError)
 
         ext = frappe.new_doc("Employee Resignation Date Adjustment")
         ext.owner = employee_user or frappe.session.user
@@ -298,6 +304,10 @@ def withdraw_resignation(
         if not employee_name:
             frappe.throw(f"Employee '{input_id}' not found", frappe.ValidationError)
 
+        employee_user = frappe.db.get_value("Employee", employee_name, "user_id")
+        if employee_user != frappe.session.user and not frappe.has_permission("Employee Resignation Withdrawal", ptype="create"):
+            frappe.throw(_("Not authorized to submit a withdrawal for this employee"), frappe.PermissionError)
+
         # Find the most recent active resignation
         TERMINAL = ["Resigned", "Cancelled", "Resignation Withdrawn", "Withdrawn"]
         active_resignations = frappe.get_list(
@@ -315,7 +325,6 @@ def withdraw_resignation(
         if not active_doc:
             frappe.throw("No active resignation found to withdraw", frappe.ValidationError)
 
-        employee_user = frappe.db.get_value("Employee", employee_name, "user_id")
         withdrawal = frappe.new_doc("Employee Resignation Withdrawal")
         withdrawal.owner = employee_user or frappe.session.user
         withdrawal.employee_resignation = active_doc.name
@@ -399,6 +408,10 @@ def correct_resignation_date_app(
             frappe.throw("new_date (relieving date) is required", frappe.ValidationError)
 
         doc = frappe.get_doc("Employee Resignation", resignation_id)
+
+        employee_user = frappe.db.get_value("Employee", doc.employee, "user_id")
+        if employee_user != frappe.session.user and not frappe.has_permission("Employee Resignation", ptype="write"):
+            frappe.throw(_("Not authorized to correct this resignation's dates"), frappe.PermissionError)
 
         if doc.workflow_state != "Pending Relieving Date Correction":
             frappe.throw(

--- a/one_fm/api/v1/resignation.py
+++ b/one_fm/api/v1/resignation.py
@@ -131,10 +131,13 @@ def create_resignation(
         doc.relieving_date = rel_date
         doc.reason_for_exit = reason
         doc.supervisor = supervisor
-        doc.department = emp.get("department")
         doc.employment_type = emp.get("employment_type")
-        doc.project_allocation = emp.get("project")
-        doc.designation = emp.get("designation")
+        # department, project_allocation and designation are deliberately left unset here --
+        # Document.insert() runs check_permission("create") before before_save(), so setting
+        # them beforehand exposes their values to the create permission check and can trip a
+        # User Permission the employee doesn't hold for their own Department/Project. The
+        # controller's before_save -> set_allocations() populates them right after insert,
+        # same as a desk-created resignation.
         # Let Frappe set workflow_state to the workflow's default initial state (Draft) on insert
 
         doc.insert()

--- a/one_fm/api/v1/resignation.py
+++ b/one_fm/api/v1/resignation.py
@@ -133,11 +133,11 @@ def create_resignation(
         doc.supervisor = supervisor
         doc.employment_type = emp.get("employment_type")
         # department, project_allocation and designation are deliberately left unset here --
-        # Document.insert() runs check_permission("create") before before_save(), so setting
-        # them beforehand exposes their values to the create permission check and can trip a
-        # User Permission the employee doesn't hold for their own Department/Project. The
-        # controller's before_save -> set_allocations() populates them right after insert,
-        # same as a desk-created resignation.
+        # they're redundant with before_save -> set_allocations() / validate ->
+        # set_employee_allocation_details(), which populate them from the Employee
+        # record right after insert, same as a desk-created resignation. (Note: all of
+        # this doctype's Link fields, including these, carry ignore_user_permissions=1,
+        # so this is a redundancy cleanup, not a User Permission fix -- see PR discussion.)
         # Let Frappe set workflow_state to the workflow's default initial state (Draft) on insert
 
         doc.insert()
@@ -233,7 +233,11 @@ def extend_resignation(
         ext = frappe.new_doc("Employee Resignation Date Adjustment")
         ext.owner = employee_user or frappe.session.user
         ext.employee_resignation = resignation_id
-        ext.employee = active_doc.employee
+        # employee is deliberately left unset -- unlike Employee Resignation's own
+        # Link fields, this doctype's `employee` field has no ignore_user_permissions
+        # flag, so setting it before insert() would expose it to the create
+        # permission check. validate() -> set_approver() populates it from
+        # employee_resignation right after insert, same idea as create_resignation().
         ext.supervisor = supervisor or active_doc.supervisor
         ext.extended_relieving_date = extended_date
         ext.reason = reason or "Adjustment requested by employee"
@@ -269,6 +273,8 @@ def extend_resignation(
 
     except Exception as e:
         frappe.log_error("Extension Error", frappe.get_traceback())
+        if isinstance(e, frappe.ValidationError) or isinstance(e, frappe.PermissionError):
+            raise
         frappe.throw(str(e), frappe.ValidationError)
 
 
@@ -328,7 +334,9 @@ def withdraw_resignation(
         withdrawal = frappe.new_doc("Employee Resignation Withdrawal")
         withdrawal.owner = employee_user or frappe.session.user
         withdrawal.employee_resignation = active_doc.name
-        withdrawal.employee = active_doc.employee
+        # employee is deliberately left unset -- see the matching comment in
+        # extend_resignation(); validate() -> set_approver() populates it from
+        # employee_resignation right after insert.
         withdrawal.reason = reason or "Employee-initiated withdrawal"
         # Do NOT set workflow_state before insert — Frappe sets it to the
         # workflow's initial state ('Draft') automatically
@@ -371,6 +379,8 @@ def withdraw_resignation(
 
     except Exception as e:
         frappe.log_error("Withdrawal Error", frappe.get_traceback())
+        if isinstance(e, frappe.ValidationError) or isinstance(e, frappe.PermissionError):
+            raise
         frappe.throw(str(e), frappe.ValidationError)
 
 
@@ -454,6 +464,8 @@ def correct_resignation_date_app(
 
     except Exception as e:
         frappe.log_error("Correction Error", frappe.get_traceback())
+        if isinstance(e, frappe.ValidationError) or isinstance(e, frappe.PermissionError):
+            raise
         frappe.throw(str(e), frappe.ValidationError)
 
 
@@ -511,17 +523,18 @@ def get_all_my_resignations(employee_id=None, **kwargs):
     if not employee_name:
         return []
 
+    employee_user = frappe.db.get_value("Employee", employee_name, "user_id")
+    if employee_user != frappe.session.user and not frappe.has_permission("Employee Resignation", ptype="read"):
+        frappe.throw(_("Not authorized to view this employee's resignations"), frappe.PermissionError)
+
     TERMINAL_STATES = {"Resigned", "Cancelled", "Resignation Withdrawn", "Withdrawn"}
-    EMPLOYEE_ACTION_STATES = ["Pending Relieving Date Correction", "Draft"]
 
     resignations = frappe.get_list(
         "Employee Resignation",
-        filters={"employee": employee_name},
+        filters={"employee": employee_name, "workflow_state": ["not in", list(TERMINAL_STATES)]},
         fields=["name", "workflow_state", "resignation_initiation_date", "relieving_date", "creation"],
         order_by="creation desc"
     )
-
-
 
     return resignations
 
@@ -533,6 +546,10 @@ def get_employee_supervisor(employee_id: str = None, **kwargs):
     employee_name = resolve_employee_name(input_id)
     if not employee_name:
         return {}
+
+    employee_user = frappe.db.get_value("Employee", employee_name, "user_id")
+    if employee_user != frappe.session.user and not frappe.has_permission("Employee Resignation", ptype="read"):
+        frappe.throw(_("Not authorized to view this employee's supervisor"), frappe.PermissionError)
 
     # Corporate hires have no Operations Manager step -- their "Supervisor" is
     # really their Line Manager (matches the ERP desk's own relabeling on


### PR DESCRIPTION
## Important correction on this PR's original premise

The first commit claimed `create_resignation()`'s `PermissionError` was caused by pre-setting `department`/`project_allocation`/`designation` before `doc.insert()`, exposing them to a User Permission check. **That mechanism does not actually apply**: every Link field on `Employee Resignation` (including those three) has `ignore_user_permissions: 1` set in its JSON, so Frappe's `has_user_permission()` skips them entirely regardless of insert timing. I found this while re-auditing the file for the same bug class in `extend_resignation`/`withdraw_resignation`, as asked.

**What this means:**
- Commit 1 (`doc.department`/`project_allocation`/`designation` pre-set removal) is still a valid, harmless cleanup — it makes `create_resignation()` populate those fields the same way (and same time) a desk-created resignation does, removing redundant code. But it is **not confirmed to fix the originally reported PermissionError**.
- The true root cause of that PermissionError is still open. Given `check_doctype_permission` (the coarser, no-doc, role-only check) also failed in the traceback, and User Permissions are ruled out for these fields, the most likely explanations are: (a) the tested employee's User account doesn't actually have the `Employee` role assigned, or (b) a live Custom DocPerm override differs from the DocType JSON in this repo. Neither is verifiable from a local checkout — **someone needs to check that employee's actual assigned roles on the live site**, or reproduce with `frappe.has_permission(..., debug=True)` to get the real denial reason logged.
- Commit 2's ownership-check fixes (`extend_resignation`, `withdraw_resignation`, `correct_resignation_date_app`) are unaffected by this correction — those are plain missing-authorization-check bugs (IDOR), confirmed by direct code inspection, independent of the User Permission question.

## Commit 3: more of the same bug classes, found by auditing further per request

- `extend_resignation()` / `withdraw_resignation()`: were still pre-setting `employee` before `insert()`. Unlike `Employee Resignation`, neither `Employee Resignation Date Adjustment` nor `Employee Resignation Withdrawal` has `ignore_user_permissions` set on this field — so on these two doctypes, that pre-set pattern **can** actually trip a User Permission scoping an employee to their own `Employee` record. Removed; `validate() -> set_approver()` already populates it after the permission check.
- `get_all_my_resignations()` and `get_employee_supervisor()`: had no ownership check at all (unlike `get_my_active_resignation()`, which does) — any authenticated user could pass another employee's `employee_id` and read their full resignation history or supervisor identity. Added the same guard used elsewhere in the file. Also fixed `get_all_my_resignations()` to actually apply the `TERMINAL_STATES` filter it declared but never used, matching its own docstring.
- Exception handlers in `extend_resignation`/`withdraw_resignation`/`correct_resignation_date_app` were unconditionally rewrapping every exception — including the `PermissionError` from the ownership checks above — as generic `ValidationError`, masking authorization denials. Now re-raise as-is, matching `create_resignation()`'s existing handler.

## Found but NOT included in this PR — needs a decision before implementing

These are real, but bigger in scope/blast-radius than the API-layer fixes above, so flagging rather than unilaterally implementing:

1. **No `permission_query_conditions`/`has_permission` hook on `Employee Resignation`, `Employee Resignation Withdrawal`, or `Employee Resignation Date Adjustment`.** `validate_employee_permissions()` on `Employee Resignation` only runs on write/submit, never on reads, and the other two doctypes have no equivalent check at all. Any user with the `Employee` role can use Frappe's generic `frappe.client.get_list`/`get`/`save`/`delete` (not even the mobile API) to read, edit, or delete *any other employee's* resignation/withdrawal/extension record, including HR remarks fields. Fixing this properly needs a `has_permission`/`permission_query_conditions` hook in `hooks.py` for all three doctypes — a site-wide change affecting desk access too, not just mobile, so it deserves its own review rather than riding in here.
2. **No guard against duplicate active resignations.** `extend_resignation`/`withdraw_resignation` both assume "one active resignation at a time," but `create_resignation()` never enforces it — nothing stops a double-submit from creating two independent resignation workflows for the same employee, each able to independently reach `Approved` and spawn its own `Project Manpower Request`.
3. **`Employee Resignation Date Adjustment.validate_extended_relieving_date()` never checks the new date is actually later than the current relieving/initiation date**, and the eventual `resignation.db_set("relieving_date", ...)` on approval bypasses `EmployeeResignation.validate_dates()` entirely (`db_set` doesn't run `validate()`). An out-of-order date could get approved with no server-side check anywhere in the chain.
4. **`get_supervisor_dropdown()` returns every enabled System User in the instance** to any authenticated caller, not just plausible supervisors — broader disclosure than a supervisor picker needs.

## Test plan
- [ ] **Before merging:** confirm the tested employee's account actually has the `Employee` role, and/or reproduce the original `create_resignation` PermissionError with `debug=True` to identify the real cause — this PR does not conclusively fix it
- [ ] Verify a real employee (not System Manager/Administrator) can submit a resignation via the mobile app
- [ ] Confirm `department`, `project_allocation`, `designation`, and `employee` are still correctly populated on resulting records after submission (create, extend, withdraw)
- [ ] Confirm `create_pmr()` still receives correct `employment_type`/`department`/`project_allocation` downstream
- [ ] Verify employee A cannot extend/withdraw/correct-date/read-resignations/read-supervisor for employee B via the mobile API (as a non-HR employee account)
- [ ] Verify HR/Offboarding-type roles can still act on behalf of employees where that's an intended flow