### PR TITLE
feat(report): Monthly Payroll Attendance Sheet, company-wide (WI-002153) [staging]

### DIFF
--- a/one_fm/one_fm/print_format/operations_monthly_attendance_sheet/operations_monthly_attendance_sheet.json
+++ b/one_fm/one_fm/print_format/operations_monthly_attendance_sheet/operations_monthly_attendance_sheet.json
@@ -28,7 +28,7 @@
  "print_format_for": "Report",
  "print_format_type": "JS",
  "raw_printing": 0,
- "report": "Operations Monthly Attendance Sheet",
+ "report": "Monthly Payroll Attendance Sheet",
  "show_section_headings": 0,
  "standard": "Yes"
 }

--- a/one_fm/one_fm/report/monthly_payroll_attendance_sheet/monthly_payroll_attendance_sheet.html
+++ b/one_fm/one_fm/report/monthly_payroll_attendance_sheet/monthly_payroll_attendance_sheet.html
@@ -142,7 +142,7 @@
           <td colspan="5" class="logo-cell">
             <img src="https://one-fm.com/files/ONEFM_Identity.png" alt="one-fm" />
           </td>
-          <td colspan="{{ totalColumns - 10 }}">{%= __("Monthly Attendance Sheet") %}</td>
+          <td colspan="{{ totalColumns - 10 }}">{%= __("Monthly Payroll Attendance Sheet") %}</td>
           <td colspan="5" class="logo-cell">
             {% const clientLogo = report.additional_details.client_logo || "" %}
             {% if clientLogo %}

--- a/one_fm/one_fm/report/monthly_payroll_attendance_sheet/monthly_payroll_attendance_sheet.js
+++ b/one_fm/one_fm/report/monthly_payroll_attendance_sheet/monthly_payroll_attendance_sheet.js
@@ -7,13 +7,18 @@ const status_color_map = {
 	"OL": "red",
 	"H": "blue",
 	"DO": "blue",
-	"CDO": "blue"
+	"CDO": "blue",
+	// WI-002153: the statuses broken out of "Other" - neither present nor absent.
+	"FP": "orange",
+	"CI": "orange",
+	"MA": "orange",
+	"OH": "orange"
 };
 
 // Fixed columns before the per-day cells; the formatter colours only the day cells.
 const FIXED_COLUMNS = 8;
 
-frappe.query_reports["Operations Monthly Attendance Sheet"] = {
+frappe.query_reports["Monthly Payroll Attendance Sheet"] = {
 	"filters": [
 		{
 			fieldname: "from_date",
@@ -41,8 +46,10 @@ frappe.query_reports["Operations Monthly Attendance Sheet"] = {
 			on_change: apply_in_page_filters,
 			label: __("Employee Status"),
 			fieldtype: "Select",
-			// Blank means every status, so a payroll run can include leavers.
-			options: ["", "Active", "Inactive", "Suspended", "Left"],
+			// Blank means every status, so a payroll run can include leavers. WI-002153 AC2
+			// lists the statuses in scope; these are the values Employee actually holds -
+			// Inactive and Suspended never existed on it.
+			options: ["", "Active", "Court Case", "Absconding", "Left", "Not Returned from Leave", "Vacation"],
 		},
 		{
 			fieldname: "employment_type",
@@ -52,8 +59,11 @@ frappe.query_reports["Operations Monthly Attendance Sheet"] = {
 			options: "Employment Type",
 		},
 		{
+			// WI-002153 AC3/AC4: both of these reach the server. Ticking Day Off OT now
+			// consolidates the day-off OT rows with the plain Basic ones instead of
+			// narrowing to them, and in-page filtering can only ever remove rows the
+			// server already sent - it cannot add the ones the last run left out.
 			fieldname: "roster_type",
-			on_change: apply_in_page_filters,
 			label: __("Roster Type"),
 			fieldtype: "Select",
 			// WI-002017: no blank option. Blank meant "every roster type", which put Basic
@@ -64,7 +74,6 @@ frappe.query_reports["Operations Monthly Attendance Sheet"] = {
 		},
 		{
 			fieldname: "day_off_ot",
-			on_change: apply_in_page_filters,
 			label: __("Day Off OT"),
 			fieldtype: "Check",
 		},
@@ -137,7 +146,7 @@ function attach_report_additional_day_details () {
 	if (!from_date || !to_date) return;
 
 	return frappe.call({
-		method: "one_fm.one_fm.report.operations_monthly_attendance_sheet.operations_monthly_attendance_sheet.get_report_additional_day_details",
+		method: "one_fm.one_fm.report.monthly_payroll_attendance_sheet.monthly_payroll_attendance_sheet.get_report_additional_day_details",
 		args: { from_date: from_date, to_date: to_date },
 		callback: function (res) {
 			frappe.query_report.additional_details = {
@@ -152,7 +161,7 @@ function attach_status_map () {
 	const report = frappe.query_report;
 
 	return frappe.call({
-		method: "one_fm.one_fm.report.operations_monthly_attendance_sheet.operations_monthly_attendance_sheet.get_attendance_status_map",
+		method: "one_fm.one_fm.report.monthly_payroll_attendance_sheet.monthly_payroll_attendance_sheet.get_attendance_status_map",
 		callback: function (res) {
 			frappe.query_report.additional_details = {
 				...(report.additional_details || {}),
@@ -172,12 +181,12 @@ function attach_status_map () {
 // Project is deliberately absent: it also narrows the Attendance rows themselves
 // (Attendance.project), so an employee with days booked to another project would come
 // out differently in page than the server returns.
+// Roster Type and Day Off OT are deliberately absent since WI-002153: they change which
+// rows the query returns, not just which of the returned ones are shown.
 const IN_PAGE_FILTERS = [
 	"employee",
 	"employee_status",
 	"employment_type",
-	"roster_type",
-	"day_off_ot",
 ];
 
 let server_rows = null;
@@ -195,23 +204,8 @@ function row_matches(row, filters) {
 	if (filters.employee && row.employee !== filters.employee) return false;
 	if (filters.employee_status && row.employee_status !== filters.employee_status) return false;
 	if (filters.employment_type && row.employment_type !== filters.employment_type) return false;
-	// The same rules the query applies, so the two agree whichever path ran:
-	//   Basic, unchecked    -> basic only, day-off OT actively excluded
-	//   Basic, checked      -> only basic rows flagged day-off OT
-	//   Overtime, unchecked -> overtime only
-	//   Overtime, checked   -> nothing (Logic Rule 4)
-	if (filters.roster_type && row.roster_type !== filters.roster_type) return false;
-	if (filters.day_off_ot) {
-		if (cint(row.day_off_ot) !== 1) return false;
-	} else if (filters.roster_type === "Basic" && cint(row.day_off_ot) === 1) {
-		return false;
-	}
 
 	return true;
-}
-
-function cint(value) {
-	return parseInt(value, 10) || 0;
 }
 
 function apply_in_page_filters() {

--- a/one_fm/one_fm/report/monthly_payroll_attendance_sheet/monthly_payroll_attendance_sheet.js
+++ b/one_fm/one_fm/report/monthly_payroll_attendance_sheet/monthly_payroll_attendance_sheet.js
@@ -8,7 +8,6 @@ const status_color_map = {
 	"H": "blue",
 	"DO": "blue",
 	"CDO": "blue",
-	// WI-002153: the statuses broken out of "Other" - neither present nor absent.
 	"FP": "orange",
 	"CI": "orange",
 	"MA": "orange",
@@ -46,9 +45,7 @@ frappe.query_reports["Monthly Payroll Attendance Sheet"] = {
 			on_change: apply_in_page_filters,
 			label: __("Employee Status"),
 			fieldtype: "Select",
-			// Blank means every status, so a payroll run can include leavers. WI-002153 AC2
-			// lists the statuses in scope; these are the values Employee actually holds -
-			// Inactive and Suspended never existed on it.
+			// Blank means every status, so a payroll run can include leavers.
 			options: ["", "Active", "Court Case", "Absconding", "Left", "Not Returned from Leave", "Vacation"],
 		},
 		{
@@ -59,10 +56,6 @@ frappe.query_reports["Monthly Payroll Attendance Sheet"] = {
 			options: "Employment Type",
 		},
 		{
-			// WI-002153 AC3/AC4: both of these reach the server. Ticking Day Off OT now
-			// consolidates the day-off OT rows with the plain Basic ones instead of
-			// narrowing to them, and in-page filtering can only ever remove rows the
-			// server already sent - it cannot add the ones the last run left out.
 			fieldname: "roster_type",
 			label: __("Roster Type"),
 			fieldtype: "Select",
@@ -178,11 +171,8 @@ function attach_status_map () {
 // here: Frappe calls a filter's on_change in place of refreshing the report, which is
 // what stops every tick of a checkbox queuing another background run.
 
-// Project is deliberately absent: it also narrows the Attendance rows themselves
-// (Attendance.project), so an employee with days booked to another project would come
-// out differently in page than the server returns.
-// Roster Type and Day Off OT are deliberately absent since WI-002153: they change which
-// rows the query returns, not just which of the returned ones are shown.
+// Project, Roster Type and Day Off OT are deliberately absent: each changes which rows
+// the query returns, and narrowing what is on screen cannot add the ones it left out.
 const IN_PAGE_FILTERS = [
 	"employee",
 	"employee_status",

--- a/one_fm/one_fm/report/monthly_payroll_attendance_sheet/monthly_payroll_attendance_sheet.json
+++ b/one_fm/one_fm/report/monthly_payroll_attendance_sheet/monthly_payroll_attendance_sheet.json
@@ -13,11 +13,11 @@
  "modified": "2025-08-03 16:37:40.113571",
  "modified_by": "Administrator",
  "module": "One Fm",
- "name": "Operations Monthly Attendance Sheet",
+ "name": "Monthly Payroll Attendance Sheet",
  "owner": "Administrator",
  "prepared_report": 1,
  "ref_doctype": "Attendance",
- "report_name": "Operations Monthly Attendance Sheet",
+ "report_name": "Monthly Payroll Attendance Sheet",
  "report_type": "Script Report",
  "roles": [
   {

--- a/one_fm/one_fm/report/monthly_payroll_attendance_sheet/monthly_payroll_attendance_sheet.py
+++ b/one_fm/one_fm/report/monthly_payroll_attendance_sheet/monthly_payroll_attendance_sheet.py
@@ -11,9 +11,6 @@ status_map = {
 	"On Leave": "OL",
 	"Holiday": "H",
 	"Day Off": "DO",
-	# WI-002153: statuses that used to disappear into the "Other" grouping. Each one now
-	# has a summary column and, through this map, a day-cell abbreviation and a legend
-	# entry (the print template builds its legend from this map too).
 	"Fingerprint Appointment": "FP",
 	"Client Interview": "CI",
 	"Medical Appointment": "MA",
@@ -47,8 +44,6 @@ SUMMARY_COUNTERS = (
 	"annual_leave_days",
 	"sick_leave_days",
 	"leave_without_pay_days",
-	# WI-002153: "Other" is gone. The leave types it used to absorb are now named by
-	# Other Leaves, and the four statuses it absorbed have a column each.
 	"other_leaves_days",
 	"fingerprint_days",
 	"client_interview_days",
@@ -57,14 +52,8 @@ SUMMARY_COUNTERS = (
 	"missing_days",
 )
 
-# Statuses that count as a day present. Work From Home and Working already showed as "P"
-# in the day cells, so they count here too - the column follows the cell (WI-002153 AC7
-# asks for exactly that: Work From Home is Present, with no column of its own).
-#
-# Client Event and On-the-job Training are Employee Schedule availabilities, reachable
-# only with Include Future Attendance on. They are days on duty - attendance is raised
-# for them alongside Working (see one_fm/api/tasks.py) - so they count as present here
-# rather than falling out of the summary now that "Other" is gone.
+# Statuses that count as a day present. Client Event and On-the-job Training are schedule
+# availabilities that raise attendance alongside Working (one_fm/api/tasks.py).
 PRESENT_STATUSES = (
 	"Present",
 	"Working",
@@ -73,8 +62,7 @@ PRESENT_STATUSES = (
 	"On-the-job Training",
 )
 
-# Both kinds of day off share one column, per the AC. WI-002153 AC6 adds Holiday to them
-# rather than giving it a column of its own.
+# Both kinds of day off and a holiday share one column, per the AC.
 DAY_OFF_STATUSES = ("Day Off", "Client Day Off", "Holiday")
 
 # Leave Type -> its own column.
@@ -84,15 +72,10 @@ LEAVE_TYPE_COUNTERS = {
 	"Leave Without Pay": "leave_without_pay_days",
 }
 
-# WI-002153 AC8/AC9: every other leave type is counted together, in a column that sits
-# immediately right of Leave Without Pay. The AC names six - Business Trip, Bereavement
-# Leave, Maternity Leave, Privilege Leave, Hajj Leave, Holiday Compensatory Leave Type -
-# which is every Leave Type on this site bar the three above. Written as the fallback
-# rather than as that list so a leave type added later is still counted somewhere, which
-# is what keeps a row reconcilable to the range.
+# Every leave type without a column of its own. A fallback rather than the AC's list of
+# six, so a leave type added later is still counted somewhere.
 OTHER_LEAVES = "other_leaves_days"
 
-# WI-002153 AC6: a column each, instead of the "Other" grouping that hid them.
 STATUS_COUNTERS = {
 	"Fingerprint Appointment": "fingerprint_days",
 	"Client Interview": "client_interview_days",
@@ -101,7 +84,7 @@ STATUS_COUNTERS = {
 }
 
 # Employee Schedule records a leave as the availability itself, not as On Leave with a
-# leave type, so those route by name. Only reachable with Include Future Attendance on.
+# leave type, so those route by name.
 SCHEDULE_LEAVE_COUNTERS = {
 	"Annual Leave": "annual_leave_days",
 	"Sick Leave": "sick_leave_days",
@@ -166,10 +149,8 @@ def summary_counter(status, leave_type=None):
 	if status in STATUS_COUNTERS:
 		return STATUS_COUNTERS[status]
 
-	# WI-002153 AC5 removed the "Other" column, so a status none of the above names has
-	# nowhere of its own to go. Only Half Day (never used on this site) and a Suspended
-	# schedule day reach here; counting them as missing keeps the row adding up to the
-	# range, which is the point of the block.
+	# Nothing else has a column of its own - only Half Day and a Suspended schedule day
+	# reach here - and counting them keeps the row adding up to the range.
 	return "missing_days"
 
 
@@ -190,10 +171,6 @@ def apply_roster_type_filters(query, roster_type_field, day_off_ot_field, filter
 	  Basic, checked      -> Basic and Basic + Day Off OT together, in one view
 	  Overtime, unchecked -> overtime only, which already excludes both basic cases
 	  Overtime, checked   -> never reaches a query (Logic Rule 4)
-
-	WI-002153 AC4 changed the second line: the box used to narrow to the day-off OT rows
-	alone, and now consolidates them with the plain Basic ones. Since rows are keyed by
-	employee (WI-001980), the two arrive on a single line without any further work.
 	"""
 	roster_type = filters.get("roster_type")
 	day_off_ot = cint(filters.get("day_off_ot"))
@@ -202,10 +179,8 @@ def apply_roster_type_filters(query, roster_type_field, day_off_ot_field, filter
 		query = query.where(roster_type_field == roster_type)
 
 	if roster_type == BASIC and not day_off_ot:
-		# Rule 1's edge case: pure basic must not carry the day's day-off OT rows. Ticking
-		# the box asks for both, so the constraint is simply dropped rather than inverted.
-		# Left unconstrained for Overtime, whose own rule asks only that the basic rows
-		# are hidden.
+		# Rule 1's edge case: pure basic must not carry the day's day-off OT rows. Left
+		# unconstrained for Overtime, whose own rule asks only that the basic rows hide.
 		query = query.where(day_off_ot_field != 1)
 
 	return query
@@ -338,10 +313,7 @@ def get_columns(filters, dates):
 		{"label": _("Annual Leave"), "fieldname": "annual_leave_days", "fieldtype": "Float", "width": 90},
 		{"label": _("Sick Leave"), "fieldname": "sick_leave_days", "fieldtype": "Float", "width": 80},
 		{"label": _("Leave Without Pay"), "fieldname": "leave_without_pay_days", "fieldtype": "Float", "width": 120},
-		# WI-002153 AC8: immediately right of Leave Without Pay, as the AC places it.
 		{"label": _("Other Leaves"), "fieldname": "other_leaves_days", "fieldtype": "Float", "width": 100},
-		# WI-002153 AC6: the vague "Other" column, broken out into the statuses it hid.
-		# 288 days were On Hold in July 2026 alone, and nothing named which they were.
 		{"label": _("Fingerprint"), "fieldname": "fingerprint_days", "fieldtype": "Float", "width": 90},
 		{"label": _("Client Interview"), "fieldname": "client_interview_days", "fieldtype": "Float", "width": 110},
 		{"label": _("Medical Appointment"), "fieldname": "medical_appointment_days", "fieldtype": "Float", "width": 130},
@@ -417,12 +389,9 @@ def get_message(filters=None):
 	message = ""
 	colors_map = {
 		"P": "green", "A": "red", "OL": "red", "H": "blue", "DO": "blue", "CDO": "blue",
-		# WI-002153 AC6: neither present nor absent - a day spent somewhere the employee
-		# was sent, or a posting on hold.
 		"FP": "orange", "CI": "orange", "MA": "orange", "OH": "orange",
 	}
-	# WI-002153 AC7: Work From Home is Present and gets no entry of its own; it used to
-	# have one, reading "Work From Home - P" beside "Present - P".
+	# Work From Home is Present, so it gets no entry of its own.
 	legend_status_map = { **status_map, "Client Day Off": "CDO" }
 
 	for status, abbr in legend_status_map.items():
@@ -763,10 +732,8 @@ def get_employee_details(filters):
 		)
 	)
 
-	# WI-002153 AC2: no shift_working gate. The sheet is company-wide now, so non-shift
-	# staff, subcontractors and service providers belong on it as much as the shift
-	# workers do - and every Employee status is in scope, which the optional Employee
-	# Status filter below narrows when a payroll run wants one of them.
+	# No shift_working gate: the sheet is company-wide, so non-shift staff, subcontractors
+	# and service providers belong on it too.
 
 	if filters.get("employee"):
 		query = query.where(Employee.name == filters.employee)
@@ -875,7 +842,6 @@ def get_attendance_status(
 		"Sick Leave": "OL",
 		"Annual Leave": "OL",
 		"Emergency Leave": "OL",
-		# WI-002153: days on duty, the same as Working (see PRESENT_STATUSES).
 		"Client Event": "P",
 		"On-the-job Training": "P",
 	}

--- a/one_fm/one_fm/report/monthly_payroll_attendance_sheet/monthly_payroll_attendance_sheet.py
+++ b/one_fm/one_fm/report/monthly_payroll_attendance_sheet/monthly_payroll_attendance_sheet.py
@@ -10,7 +10,14 @@ status_map = {
 	"Absent": "A",
 	"On Leave": "OL",
 	"Holiday": "H",
-	"Day Off": "DO"
+	"Day Off": "DO",
+	# WI-002153: statuses that used to disappear into the "Other" grouping. Each one now
+	# has a summary column and, through this map, a day-cell abbreviation and a legend
+	# entry (the print template builds its legend from this map too).
+	"Fingerprint Appointment": "FP",
+	"Client Interview": "CI",
+	"Medical Appointment": "MA",
+	"On Hold": "OH",
 }
 
 day_abbr = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
@@ -40,24 +47,65 @@ SUMMARY_COUNTERS = (
 	"annual_leave_days",
 	"sick_leave_days",
 	"leave_without_pay_days",
-	"other_days",
+	# WI-002153: "Other" is gone. The leave types it used to absorb are now named by
+	# Other Leaves, and the four statuses it absorbed have a column each.
+	"other_leaves_days",
+	"fingerprint_days",
+	"client_interview_days",
+	"medical_appointment_days",
+	"on_hold_days",
 	"missing_days",
 )
 
 # Statuses that count as a day present. Work From Home and Working already showed as "P"
-# in the day cells, so they count here too - the column follows the cell.
-PRESENT_STATUSES = ("Present", "Working", "Work From Home")
+# in the day cells, so they count here too - the column follows the cell (WI-002153 AC7
+# asks for exactly that: Work From Home is Present, with no column of its own).
+#
+# Client Event and On-the-job Training are Employee Schedule availabilities, reachable
+# only with Include Future Attendance on. They are days on duty - attendance is raised
+# for them alongside Working (see one_fm/api/tasks.py) - so they count as present here
+# rather than falling out of the summary now that "Other" is gone.
+PRESENT_STATUSES = (
+	"Present",
+	"Working",
+	"Work From Home",
+	"Client Event",
+	"On-the-job Training",
+)
 
-# Both kinds of day off share one column, per the AC.
-DAY_OFF_STATUSES = ("Day Off", "Client Day Off")
+# Both kinds of day off share one column, per the AC. WI-002153 AC6 adds Holiday to them
+# rather than giving it a column of its own.
+DAY_OFF_STATUSES = ("Day Off", "Client Day Off", "Holiday")
 
-# Leave Type -> its own column. A leave of any other type (Business Trip, Hajj Leave)
-# counts as Other: naming it would mean a column per Leave Type on this site, which is
-# eleven of them.
+# Leave Type -> its own column.
 LEAVE_TYPE_COUNTERS = {
 	"Annual Leave": "annual_leave_days",
 	"Sick Leave": "sick_leave_days",
 	"Leave Without Pay": "leave_without_pay_days",
+}
+
+# WI-002153 AC8/AC9: every other leave type is counted together, in a column that sits
+# immediately right of Leave Without Pay. The AC names six - Business Trip, Bereavement
+# Leave, Maternity Leave, Privilege Leave, Hajj Leave, Holiday Compensatory Leave Type -
+# which is every Leave Type on this site bar the three above. Written as the fallback
+# rather than as that list so a leave type added later is still counted somewhere, which
+# is what keeps a row reconcilable to the range.
+OTHER_LEAVES = "other_leaves_days"
+
+# WI-002153 AC6: a column each, instead of the "Other" grouping that hid them.
+STATUS_COUNTERS = {
+	"Fingerprint Appointment": "fingerprint_days",
+	"Client Interview": "client_interview_days",
+	"Medical Appointment": "medical_appointment_days",
+	"On Hold": "on_hold_days",
+}
+
+# Employee Schedule records a leave as the availability itself, not as On Leave with a
+# leave type, so those route by name. Only reachable with Include Future Attendance on.
+SCHEDULE_LEAVE_COUNTERS = {
+	"Annual Leave": "annual_leave_days",
+	"Sick Leave": "sick_leave_days",
+	"Emergency Leave": OTHER_LEAVES,
 }
 
 
@@ -94,9 +142,8 @@ def more_significant(status, existing):
 def summary_counter(status, leave_type=None):
 	"""Which summary column one day belongs to (WI-001979).
 
-	Total, rather than a chain of ifs with a gap at the end: a day with a status this
-	does not name is Other, and a day with no status at all is Missing. Nothing falls
-	through uncounted, so the row's figures always reconcile to the range.
+	Total, rather than a chain of ifs with a gap at the end: every day increments exactly
+	one counter, so the row's figures always reconcile to the range.
 	"""
 	if not status:
 		return "missing_days"
@@ -111,9 +158,19 @@ def summary_counter(status, leave_type=None):
 		return "absent_days"
 
 	if status == "On Leave":
-		return LEAVE_TYPE_COUNTERS.get(leave_type, "other_days")
+		return LEAVE_TYPE_COUNTERS.get(leave_type, OTHER_LEAVES)
 
-	return "other_days"
+	if status in SCHEDULE_LEAVE_COUNTERS:
+		return SCHEDULE_LEAVE_COUNTERS[status]
+
+	if status in STATUS_COUNTERS:
+		return STATUS_COUNTERS[status]
+
+	# WI-002153 AC5 removed the "Other" column, so a status none of the above names has
+	# nowhere of its own to go. Only Half Day (never used on this site) and a Suspended
+	# schedule day reach here; counting them as missing keeps the row adding up to the
+	# range, which is the point of the block.
+	return "missing_days"
 
 
 def is_invalid_roster_combination(filters):
@@ -130,9 +187,13 @@ def apply_roster_type_filters(query, roster_type_field, day_off_ot_field, filter
 	Schedule queries so both answer a given filter pair identically (WI-001791).
 
 	  Basic, unchecked    -> basic shifts only, with day-off OT actively excluded
-	  Basic, checked      -> only basic shifts flagged as day-off OT
+	  Basic, checked      -> Basic and Basic + Day Off OT together, in one view
 	  Overtime, unchecked -> overtime only, which already excludes both basic cases
 	  Overtime, checked   -> never reaches a query (Logic Rule 4)
+
+	WI-002153 AC4 changed the second line: the box used to narrow to the day-off OT rows
+	alone, and now consolidates them with the plain Basic ones. Since rows are keyed by
+	employee (WI-001980), the two arrive on a single line without any further work.
 	"""
 	roster_type = filters.get("roster_type")
 	day_off_ot = cint(filters.get("day_off_ot"))
@@ -140,12 +201,11 @@ def apply_roster_type_filters(query, roster_type_field, day_off_ot_field, filter
 	if roster_type:
 		query = query.where(roster_type_field == roster_type)
 
-	if day_off_ot:
-		query = query.where(day_off_ot_field == 1)
-	elif roster_type == BASIC:
-		# Rule 1's edge case: pure basic must not carry the day's day-off OT rows.
-		# Left unconstrained for Overtime, whose own rule asks only that the basic
-		# rows are hidden.
+	if roster_type == BASIC and not day_off_ot:
+		# Rule 1's edge case: pure basic must not carry the day's day-off OT rows. Ticking
+		# the box asks for both, so the constraint is simply dropped rather than inverted.
+		# Left unconstrained for Overtime, whose own rule asks only that the basic rows
+		# are hidden.
 		query = query.where(day_off_ot_field != 1)
 
 	return query
@@ -278,10 +338,14 @@ def get_columns(filters, dates):
 		{"label": _("Annual Leave"), "fieldname": "annual_leave_days", "fieldtype": "Float", "width": 90},
 		{"label": _("Sick Leave"), "fieldname": "sick_leave_days", "fieldtype": "Float", "width": 80},
 		{"label": _("Leave Without Pay"), "fieldname": "leave_without_pay_days", "fieldtype": "Float", "width": 120},
-		# Days that carry a status none of the columns above name - On Hold, Holiday, a
-		# leave of another type. Without it the row's parts do not add up to the range,
-		# which is the whole point of the block (288 days were On Hold in July 2026 alone).
-		{"label": _("Other"), "fieldname": "other_days", "fieldtype": "Float", "width": 70},
+		# WI-002153 AC8: immediately right of Leave Without Pay, as the AC places it.
+		{"label": _("Other Leaves"), "fieldname": "other_leaves_days", "fieldtype": "Float", "width": 100},
+		# WI-002153 AC6: the vague "Other" column, broken out into the statuses it hid.
+		# 288 days were On Hold in July 2026 alone, and nothing named which they were.
+		{"label": _("Fingerprint"), "fieldname": "fingerprint_days", "fieldtype": "Float", "width": 90},
+		{"label": _("Client Interview"), "fieldname": "client_interview_days", "fieldtype": "Float", "width": 110},
+		{"label": _("Medical Appointment"), "fieldname": "medical_appointment_days", "fieldtype": "Float", "width": 130},
+		{"label": _("On Hold"), "fieldname": "on_hold_days", "fieldtype": "Float", "width": 80},
 		{"label": _("Missing/Empty Days"), "fieldname": "missing_days", "fieldtype": "Float", "width": 120},
 	])
 
@@ -351,17 +415,22 @@ def get_message(filters=None):
 		return _("Each cell shows the scheduled duration of that day's shift, in hours.")
 
 	message = ""
-	colors_map = { "P": "green","A": "red","OL": "red","H": "blue","DO": "blue","CDO": "blue" }
-	legend_status_map = { **status_map, "Work From Home": "P", "Client Day Off": "CDO" }
+	colors_map = {
+		"P": "green", "A": "red", "OL": "red", "H": "blue", "DO": "blue", "CDO": "blue",
+		# WI-002153 AC6: neither present nor absent - a day spent somewhere the employee
+		# was sent, or a posting on hold.
+		"FP": "orange", "CI": "orange", "MA": "orange", "OH": "orange",
+	}
+	# WI-002153 AC7: Work From Home is Present and gets no entry of its own; it used to
+	# have one, reading "Work From Home - P" beside "Present - P".
+	legend_status_map = { **status_map, "Client Day Off": "CDO" }
 
-	count = 0
 	for status, abbr in legend_status_map.items():
 		message += f"""
 			<span style='border-left: 2px solid {colors_map[abbr]}; padding-right: 12px; padding-left: 5px; margin-right: 3px;'>
 				{status} - {abbr}
 			</span>
 		"""
-		count += 1
 
 	return message
 
@@ -692,8 +761,12 @@ def get_employee_details(filters):
 			Employee.status.as_("employee_status"),
 			Employee.employment_type,
 		)
-		.where(Employee.shift_working == 1)
 	)
+
+	# WI-002153 AC2: no shift_working gate. The sheet is company-wide now, so non-shift
+	# staff, subcontractors and service providers belong on it as much as the shift
+	# workers do - and every Employee status is in scope, which the optional Employee
+	# Status filter below narrows when a payroll run wants one of them.
 
 	if filters.get("employee"):
 		query = query.where(Employee.name == filters.employee)
@@ -801,7 +874,10 @@ def get_attendance_status(
 		"Client Day Off": "CDO",
 		"Sick Leave": "OL",
 		"Annual Leave": "OL",
-		"Emergency Leave": "OL"
+		"Emergency Leave": "OL",
+		# WI-002153: days on duty, the same as Working (see PRESENT_STATUSES).
+		"Client Event": "P",
+		"On-the-job Training": "P",
 	}
 
 	employee_non_day_off_attendance = employee_non_day_off_attendance or {}

--- a/one_fm/one_fm/report/monthly_payroll_attendance_sheet/test_monthly_payroll_attendance_sheet.py
+++ b/one_fm/one_fm/report/monthly_payroll_attendance_sheet/test_monthly_payroll_attendance_sheet.py
@@ -5,9 +5,6 @@
 The report used to take Month + Year and key every cell by day-of-month. It now
 takes a From/To range, which means two days in different months can share a day
 number - so cells are keyed by ISO date instead.
-
-WI-002153 renamed it off "Operations", opened it to every employee, and replaced the
-"Other" summary column with named ones.
 """
 
 import frappe
@@ -186,7 +183,7 @@ class TestTheRunIsDeferred(FrappeTestCase):
 
 
 class TestTheReportIsRenamed(FrappeTestCase):
-	"""WI-002153 AC1: the sheet is not Operations-only any more, so the name went with it."""
+	"""AC1: the sheet is not Operations-only any more, so the name went with it."""
 
 	def test_the_report_answers_to_its_new_name(self):
 		self.assertTrue(frappe.db.exists("Report", REPORT))
@@ -196,25 +193,21 @@ class TestTheReportIsRenamed(FrappeTestCase):
 		self.assertFalse(frappe.db.exists("Report", "Operations Monthly Attendance Sheet"))
 
 	def test_the_print_format_followed_the_rename(self):
-		"""It links the report by name, so a sync beside the old doc rather than a rename
-		would leave it printing a report nobody maintains."""
+		"""It links the report by name."""
 		self.assertEqual(
 			frappe.db.count("Print Format", {"report": "Operations Monthly Attendance Sheet"}), 0
 		)
 
 	def test_the_already_generated_prepared_reports_do_not_follow(self):
-		"""Deliberate, and it is the field type that guarantees it: each of the 175 was
-		computed under the old rules - an "Other" column, a shift-working-only employee
-		set, Day Off OT narrowing rather than consolidating - so serving one under the new
-		name would hand a payroll operator stale figures. Unmatched, the report
-		regenerates instead, and Frappe's expiry clears them."""
+		"""Deliberate: each was computed under the old rules, so serving one under the new
+		name would hand a payroll operator stale figures. The field type guarantees it."""
 		self.assertEqual(
 			frappe.get_meta("Prepared Report").get_field("report_name").fieldtype, "Data"
 		)
 
 
 class TestTheEmployeeScope(FrappeTestCase):
-	"""WI-002153 AC2: every employee, not only the shift-working ones."""
+	"""AC2: every employee, not only the shift-working ones."""
 
 	def test_non_shift_employees_are_in_scope(self):
 		non_shift = frappe.db.count("Employee", {"shift_working": 0})
@@ -228,8 +221,7 @@ class TestTheEmployeeScope(FrappeTestCase):
 		)
 
 	def test_a_service_provider_is_in_scope(self):
-		"""They are all shift_working = 0 on this instance, so they were the group the
-		old gate excluded outright."""
+		"""All shift_working = 0 here, so the old gate excluded them outright."""
 		if not frappe.db.count("Employee", {"employment_type": "Service Provider"}):
 			self.skipTest("no service providers on this instance")
 
@@ -237,8 +229,7 @@ class TestTheEmployeeScope(FrappeTestCase):
 		self.assertTrue(employees)
 
 	def test_no_employee_status_is_excluded(self):
-		"""Left, Vacation, Court Case, Absconding and Not Returned from Leave all have to
-		reach a payroll run."""
+		"""Left, Vacation, Court Case, Absconding and Not Returned from Leave included."""
 		statuses = {e.employee_status for e in get_employee_details(_filters()).values()}
 		on_site = {
 			d.status for d in frappe.get_all("Employee", fields=["distinct status as status"])
@@ -261,7 +252,7 @@ class TestTheEmployeeScope(FrappeTestCase):
 
 
 class TestTheLegend(FrappeTestCase):
-	"""WI-002153 AC6 asks for a legend indicator beside each new column."""
+	"""AC6 asks for a legend indicator beside each new column."""
 
 	def test_each_new_status_has_an_indicator(self):
 		message = get_message(_filters())
@@ -385,11 +376,7 @@ class TestRosterTypeRules(FrappeTestCase):
 		self.assertIn('`day_off_ot`<>1', sql)
 
 	def test_rule_2_basic_with_day_off_ot_consolidates_both(self):
-		"""WI-002153 AC4: Basic and Basic + Day Off OT together, in one view.
-
-		It used to narrow to the flagged rows alone, which showed the day-off overtime
-		instead of alongside the basic shifts.
-		"""
+		"""Basic and Basic + Day Off OT together, in one view (AC4)."""
 		sql = _roster_sql(roster_type="Basic", day_off_ot=1)
 		self.assertIn('`roster_type`=\'Basic\'', sql)
 		self.assertNotIn("day_off_ot", sql)
@@ -418,8 +405,7 @@ class TestRosterTypeRules(FrappeTestCase):
 		self.assertNotIn("roster_type", _roster_sql(roster_type="", day_off_ot=0))
 
 	def test_ticking_the_box_only_ever_widens_what_basic_returns(self):
-		"""The unchecked run is a subset of the checked one, so the box adds rows rather
-		than swapping them for a different set (WI-002153 AC4)."""
+		"""The unchecked run is a subset of the checked one."""
 		self.assertIn("`day_off_ot`<>1", _roster_sql(roster_type="Basic", day_off_ot=0))
 		self.assertNotIn("day_off_ot", _roster_sql(roster_type="Basic", day_off_ot=1))
 
@@ -579,8 +565,8 @@ class TestRosterTypeAndDayOffOTAreCarried(FrappeTestCase):
 			)
 
 	def test_the_day_off_ot_box_only_adds_to_what_basic_returns(self):
-		"""WI-002153 AC4: consolidated, not narrowed. Compared per employee, since a row
-		spanning both flags reports neither."""
+		"""Consolidated, not narrowed. Per employee, since a row spanning both flags
+		reports neither."""
 		plain = {r["employee"] for r in execute(_filters())[1] or []}
 		if not plain:
 			self.skipTest("no Basic attendance in the test range on this instance")
@@ -613,10 +599,8 @@ class TestInPageFilters(FrappeTestCase):
 	def test_the_filters_that_change_the_query_still_reach_the_server(self):
 		# Dates change the range, Include Future Attendance changes the source, and
 		# Generate Based On changes what the cells hold - none can be done in page.
-		#
-		# WI-002153 AC4 put Roster Type and Day Off OT back here: ticking the box now asks
-		# for rows the last run excluded, and narrowing what is already on screen cannot
-		# produce them.
+		# Roster Type and Day Off OT too: ticking the box asks for rows the last run
+		# excluded, and narrowing what is on screen cannot produce them.
 		for fieldname in (
 			"from_date", "to_date", "include_future_attendance", "generate_based_on",
 			"roster_type", "day_off_ot",
@@ -660,17 +644,14 @@ class TestTheSummaryBlock(FrappeTestCase):
 			self.assertNotEqual(summary_counter(status), "working_days")
 
 	def test_work_from_home_is_counted_as_present_and_has_no_column(self):
-		"""WI-002153 AC7."""
+		"""AC7."""
 		self.assertEqual(summary_counter("Work From Home"), "working_days")
 		fieldnames = {c["fieldname"] for c in get_columns(_filters(), [])}
 		self.assertNotIn("work_from_home_days", fieldnames)
-		# Nor a legend entry of its own, which would read "Work From Home - P" beside
-		# "Present - P".
 		self.assertNotIn("Work From Home", get_message(_filters()))
 
 	def test_a_scheduled_day_on_duty_counts_as_present(self):
-		"""Client Event and On-the-job Training raise attendance the same way Working
-		does, and with "Other" gone they would otherwise fall out of the summary."""
+		"""Client Event and On-the-job Training raise attendance the way Working does."""
 		for status in ("Client Event", "On-the-job Training"):
 			with self.subTest(status=status):
 				self.assertEqual(summary_counter(status), "working_days")
@@ -680,7 +661,7 @@ class TestTheSummaryBlock(FrappeTestCase):
 		self.assertEqual(summary_counter("Client Day Off"), "off_days")
 
 	def test_a_holiday_is_counted_with_the_days_off(self):
-		"""WI-002153 AC6: Holiday joins Days Off rather than getting a column."""
+		"""AC6: Holiday joins Days Off rather than getting a column."""
 		self.assertEqual(summary_counter("Holiday"), "off_days")
 		self.assertNotIn("holiday_days", {c["fieldname"] for c in get_columns(_filters(), [])})
 
@@ -692,8 +673,7 @@ class TestTheSummaryBlock(FrappeTestCase):
 		)
 
 	def test_every_other_leave_type_is_counted_under_other_leaves(self):
-		"""WI-002153 AC9 names six; all six are Leave Types on this site, and they are
-		every one bar the three that have a column of their own."""
+		"""AC9 names six - every Leave Type here bar the three with their own column."""
 		for leave_type in (
 			"Business Trip",
 			"Bereavement Leave",
@@ -705,14 +685,12 @@ class TestTheSummaryBlock(FrappeTestCase):
 			with self.subTest(leave_type=leave_type):
 				self.assertEqual(summary_counter("On Leave", leave_type), OTHER_LEAVES)
 
-		# Written as a fallback rather than as that list, so a type added later - or a
-		# record with none set at all - is still counted somewhere.
+		# A fallback, so a type added later - or none set at all - is still counted.
 		self.assertEqual(summary_counter("On Leave", "Compensatory Off"), OTHER_LEAVES)
 		self.assertEqual(summary_counter("On Leave", None), OTHER_LEAVES)
 
 	def test_ac9_lists_every_leave_type_without_a_column_of_its_own(self):
-		"""If a Leave Type is added to this site it lands in Other Leaves, but the AC's
-		list would then be incomplete - which is worth knowing about."""
+		"""A new Leave Type lands in Other Leaves, but makes the AC's list incomplete."""
 		named = set(("Annual Leave", "Sick Leave", "Leave Without Pay"))
 		ac9 = {
 			"Business Trip", "Bereavement Leave", "Maternity Leave", "Privilege Leave",
@@ -722,29 +700,28 @@ class TestTheSummaryBlock(FrappeTestCase):
 		self.assertEqual(on_site - named - ac9, {"Casual Leave", "Compensatory Off"})
 
 	def test_the_other_column_is_gone(self):
-		"""WI-002153 AC5."""
+		"""AC5."""
 		self.assertNotIn("other_days", SUMMARY_COUNTERS)
 		labels = {c["label"] for c in get_columns(_filters(), [])}
 		self.assertNotIn("Other", labels)
 		self.assertIn("Other Leaves", labels)
 
 	def test_each_broken_out_status_has_its_own_counter(self):
-		"""WI-002153 AC6: 288 days were On Hold in July 2026 and nothing named them."""
+		"""AC6: 288 days were On Hold in July 2026 and nothing named them."""
 		self.assertEqual(summary_counter("Fingerprint Appointment"), "fingerprint_days")
 		self.assertEqual(summary_counter("Client Interview"), "client_interview_days")
 		self.assertEqual(summary_counter("Medical Appointment"), "medical_appointment_days")
 		self.assertEqual(summary_counter("On Hold"), "on_hold_days")
 
 	def test_other_leaves_sits_immediately_right_of_leave_without_pay(self):
-		"""WI-002153 AC8 places it there."""
+		"""AC8 places it there."""
 		fieldnames = [c["fieldname"] for c in get_columns(_filters(), [])]
 		self.assertEqual(
 			fieldnames[fieldnames.index("leave_without_pay_days") + 1], OTHER_LEAVES
 		)
 
 	def test_a_scheduled_leave_lands_on_its_own_type(self):
-		"""Employee Schedule spells a leave as the availability itself, so it used to be
-		counted as Other even where a column for it existed."""
+		"""Employee Schedule spells a leave as the availability itself."""
 		self.assertEqual(summary_counter("Annual Leave"), "annual_leave_days")
 		self.assertEqual(summary_counter("Sick Leave"), "sick_leave_days")
 		self.assertEqual(summary_counter("Emergency Leave"), OTHER_LEAVES)
@@ -759,8 +736,7 @@ class TestTheSummaryBlock(FrappeTestCase):
 		schedule = frappe.get_meta("Employee Schedule").get_field(
 			"employee_availability"
 		).options.split("\n")
-		# Fingerprint / Client Interview / Medical Appointment are set on Attendance in
-		# code without being in its Select options, so they are named here too.
+		# Set on Attendance in code without being in its Select options.
 		extra = ["Working", "Fingerprint Appointment", "Client Interview", "Medical Appointment", None]
 		for status in statuses + schedule + extra:
 			self.assertIn(summary_counter(status), SUMMARY_COUNTERS, msg=status)

--- a/one_fm/one_fm/report/monthly_payroll_attendance_sheet/test_monthly_payroll_attendance_sheet.py
+++ b/one_fm/one_fm/report/monthly_payroll_attendance_sheet/test_monthly_payroll_attendance_sheet.py
@@ -1,19 +1,23 @@
 # Copyright (c) 2026, ONE FM and contributors
 # See license.txt
-"""Tests for the date-range Operations Monthly Attendance Sheet (WI-001790).
+"""Tests for the date-range Monthly Payroll Attendance Sheet (WI-001790, WI-002153).
 
 The report used to take Month + Year and key every cell by day-of-month. It now
 takes a From/To range, which means two days in different months can share a day
 number - so cells are keyed by ISO date instead.
+
+WI-002153 renamed it off "Operations", opened it to every employee, and replaced the
+"Other" summary column with named ones.
 """
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
-from frappe.utils import add_days, getdate
+from frappe.utils import add_days, cstr, getdate
 
-from one_fm.one_fm.report.operations_monthly_attendance_sheet.operations_monthly_attendance_sheet import (
+from one_fm.one_fm.report.monthly_payroll_attendance_sheet.monthly_payroll_attendance_sheet import (
 	BY_SHIFT_HOURS,
 	MAX_RANGE_DAYS,
+	OTHER_LEAVES,
 	SUMMARY_COUNTERS,
 	apply_roster_type_filters,
 	execute,
@@ -22,6 +26,7 @@ from one_fm.one_fm.report.operations_monthly_attendance_sheet.operations_monthly
 	get_columns,
 	get_columns_for_days,
 	get_date_range,
+	get_employee_details,
 	get_message,
 	get_report_additional_day_details,
 	is_invalid_roster_combination,
@@ -33,7 +38,7 @@ from one_fm.one_fm.report.operations_monthly_attendance_sheet.operations_monthly
 	validate_roster_type,
 )
 
-REPORT = "Operations Monthly Attendance Sheet"
+REPORT = "Monthly Payroll Attendance Sheet"
 
 FROM_DATE = "2026-01-10"
 TO_DATE = "2026-01-16"
@@ -172,12 +177,139 @@ class TestTheRunIsDeferred(FrappeTestCase):
 	def test_no_generate_filter_is_declared(self):
 		source = frappe.read_file(
 			frappe.get_app_path(
-				"one_fm", "one_fm", "report", "operations_monthly_attendance_sheet",
-				"operations_monthly_attendance_sheet.js",
+				"one_fm", "one_fm", "report", "monthly_payroll_attendance_sheet",
+				"monthly_payroll_attendance_sheet.js",
 			)
 		)
 		self.assertNotIn('fieldname: "generate"', source)
 		self.assertNotIn('add_inner_button(__("Generate")', source)
+
+
+class TestTheReportIsRenamed(FrappeTestCase):
+	"""WI-002153 AC1: the sheet is not Operations-only any more, so the name went with it."""
+
+	def test_the_report_answers_to_its_new_name(self):
+		self.assertTrue(frappe.db.exists("Report", REPORT))
+		self.assertEqual(REPORT, "Monthly Payroll Attendance Sheet")
+
+	def test_the_old_name_is_gone(self):
+		self.assertFalse(frappe.db.exists("Report", "Operations Monthly Attendance Sheet"))
+
+	def test_the_print_format_followed_the_rename(self):
+		"""It links the report by name, so a sync beside the old doc rather than a rename
+		would leave it printing a report nobody maintains."""
+		self.assertEqual(
+			frappe.db.count("Print Format", {"report": "Operations Monthly Attendance Sheet"}), 0
+		)
+
+	def test_the_already_generated_prepared_reports_do_not_follow(self):
+		"""Deliberate, and it is the field type that guarantees it: each of the 175 was
+		computed under the old rules - an "Other" column, a shift-working-only employee
+		set, Day Off OT narrowing rather than consolidating - so serving one under the new
+		name would hand a payroll operator stale figures. Unmatched, the report
+		regenerates instead, and Frappe's expiry clears them."""
+		self.assertEqual(
+			frappe.get_meta("Prepared Report").get_field("report_name").fieldtype, "Data"
+		)
+
+
+class TestTheEmployeeScope(FrappeTestCase):
+	"""WI-002153 AC2: every employee, not only the shift-working ones."""
+
+	def test_non_shift_employees_are_in_scope(self):
+		non_shift = frappe.db.count("Employee", {"shift_working": 0})
+		if not non_shift:
+			self.skipTest("every employee on this instance is shift working")
+
+		employees = get_employee_details(_filters())
+		self.assertTrue(
+			[e for e in employees.values() if not frappe.db.get_value("Employee", e.name, "shift_working")],
+			msg="the shift_working gate is still on the employee query",
+		)
+
+	def test_a_service_provider_is_in_scope(self):
+		"""They are all shift_working = 0 on this instance, so they were the group the
+		old gate excluded outright."""
+		if not frappe.db.count("Employee", {"employment_type": "Service Provider"}):
+			self.skipTest("no service providers on this instance")
+
+		employees = get_employee_details(_filters(employment_type="Service Provider"))
+		self.assertTrue(employees)
+
+	def test_no_employee_status_is_excluded(self):
+		"""Left, Vacation, Court Case, Absconding and Not Returned from Leave all have to
+		reach a payroll run."""
+		statuses = {e.employee_status for e in get_employee_details(_filters()).values()}
+		on_site = {
+			d.status for d in frappe.get_all("Employee", fields=["distinct status as status"])
+		}
+		self.assertEqual(on_site - statuses, set())
+
+	def test_the_status_filter_offers_the_statuses_employee_actually_holds(self):
+		source = frappe.read_file(
+			frappe.get_app_path(
+				"one_fm", "one_fm", "report", "monthly_payroll_attendance_sheet",
+				"monthly_payroll_attendance_sheet.js",
+			)
+		)
+		block = source.split('fieldname: "employee_status"')[1].split("},")[0]
+		for status in ("Active", "Court Case", "Absconding", "Left", "Not Returned from Leave", "Vacation"):
+			self.assertIn(f'"{status}"', block, msg=status)
+		# Neither of these was ever an Employee status here.
+		self.assertNotIn('"Inactive"', block)
+		self.assertNotIn('"Suspended"', block)
+
+
+class TestTheLegend(FrappeTestCase):
+	"""WI-002153 AC6 asks for a legend indicator beside each new column."""
+
+	def test_each_new_status_has_an_indicator(self):
+		message = get_message(_filters())
+		for status, abbr in (
+			("Fingerprint Appointment", "FP"),
+			("Client Interview", "CI"),
+			("Medical Appointment", "MA"),
+			("On Hold", "OH"),
+		):
+			self.assertIn(f"{status} - {abbr}", message, msg=status)
+
+	def test_the_day_cells_use_the_same_abbreviations(self):
+		dates = get_date_range(_filters())
+		group = ("",)
+		rows = get_attendance_status(
+			dates,
+			{group: {
+				dates[0]: "Fingerprint Appointment",
+				dates[1]: "Client Interview",
+				dates[2]: "Medical Appointment",
+				dates[3]: "On Hold",
+				dates[4]: "Work From Home",
+			}},
+			{}, {}, {},
+		)
+
+		row = rows[0]
+		self.assertEqual(
+			[row[cstr(d)] for d in dates[:5]], ["FP", "CI", "MA", "OH", "P"]
+		)
+		self.assertEqual(row["fingerprint_days"], 1)
+		self.assertEqual(row["client_interview_days"], 1)
+		self.assertEqual(row["medical_appointment_days"], 1)
+		self.assertEqual(row["on_hold_days"], 1)
+		self.assertEqual(row["working_days"], 1)
+		self.assertEqual(sum(row[c] for c in SUMMARY_COUNTERS), len(dates))
+
+	def test_the_client_formatter_can_colour_them(self):
+		"""A day cell the colour map does not know renders unstyled."""
+		source = frappe.read_file(
+			frappe.get_app_path(
+				"one_fm", "one_fm", "report", "monthly_payroll_attendance_sheet",
+				"monthly_payroll_attendance_sheet.js",
+			)
+		)
+		colours = source.split("const status_color_map")[1].split("};")[0]
+		for abbr in ("FP", "CI", "MA", "OH"):
+			self.assertIn(f'"{abbr}"', colours, msg=abbr)
 
 
 class TestDayHeaders(FrappeTestCase):
@@ -252,10 +384,15 @@ class TestRosterTypeRules(FrappeTestCase):
 		self.assertIn('`roster_type`=\'Basic\'', sql)
 		self.assertIn('`day_off_ot`<>1', sql)
 
-	def test_rule_2_basic_with_day_off_ot_keeps_only_those_rows(self):
+	def test_rule_2_basic_with_day_off_ot_consolidates_both(self):
+		"""WI-002153 AC4: Basic and Basic + Day Off OT together, in one view.
+
+		It used to narrow to the flagged rows alone, which showed the day-off overtime
+		instead of alongside the basic shifts.
+		"""
 		sql = _roster_sql(roster_type="Basic", day_off_ot=1)
 		self.assertIn('`roster_type`=\'Basic\'', sql)
-		self.assertIn('`day_off_ot`=1', sql)
+		self.assertNotIn("day_off_ot", sql)
 		self.assertNotIn("<>1", sql)
 
 	def test_rule_3_overtime_alone_constrains_only_the_roster_type(self):
@@ -280,10 +417,11 @@ class TestRosterTypeRules(FrappeTestCase):
 	def test_no_roster_type_is_left_unconstrained(self):
 		self.assertNotIn("roster_type", _roster_sql(roster_type="", day_off_ot=0))
 
-	def test_day_off_ot_alone_still_narrows_to_those_rows(self):
-		sql = _roster_sql(roster_type="", day_off_ot=1)
-		self.assertIn('`day_off_ot`=1', sql)
-		self.assertNotIn("roster_type", sql)
+	def test_ticking_the_box_only_ever_widens_what_basic_returns(self):
+		"""The unchecked run is a subset of the checked one, so the box adds rows rather
+		than swapping them for a different set (WI-002153 AC4)."""
+		self.assertIn("`day_off_ot`<>1", _roster_sql(roster_type="Basic", day_off_ot=0))
+		self.assertNotIn("day_off_ot", _roster_sql(roster_type="Basic", day_off_ot=1))
 
 
 class TestShiftHours(FrappeTestCase):
@@ -440,9 +578,15 @@ class TestRosterTypeAndDayOffOTAreCarried(FrappeTestCase):
 				{r.get("roster_type") for r in rows} - {roster_type}, set(), msg=roster_type
 			)
 
-	def test_day_off_ot_filter_returns_only_flagged_rows(self):
-		rows = execute(_filters(day_off_ot=1))[1]
-		self.assertEqual({r.get("day_off_ot") for r in rows} - {1}, set())
+	def test_the_day_off_ot_box_only_adds_to_what_basic_returns(self):
+		"""WI-002153 AC4: consolidated, not narrowed. Compared per employee, since a row
+		spanning both flags reports neither."""
+		plain = {r["employee"] for r in execute(_filters())[1] or []}
+		if not plain:
+			self.skipTest("no Basic attendance in the test range on this instance")
+
+		both = {r["employee"] for r in execute(_filters(day_off_ot=1))[1] or []}
+		self.assertTrue(plain <= both, msg=f"lost {plain - both}")
 
 
 class TestInPageFilters(FrappeTestCase):
@@ -456,20 +600,27 @@ class TestInPageFilters(FrappeTestCase):
 		super().setUpClass()
 		cls.source = frappe.read_file(
 			frappe.get_app_path(
-				"one_fm", "one_fm", "report", "operations_monthly_attendance_sheet",
-				"operations_monthly_attendance_sheet.js",
+				"one_fm", "one_fm", "report", "monthly_payroll_attendance_sheet",
+				"monthly_payroll_attendance_sheet.js",
 			)
 		)
 
 	def test_the_row_narrowing_filters_run_in_page(self):
-		for fieldname in ("employee", "employee_status", "employment_type", "roster_type", "day_off_ot"):
+		for fieldname in ("employee", "employee_status", "employment_type"):
 			block = self.source.split(f'fieldname: "{fieldname}"')[1].split("},")[0]
 			self.assertIn("on_change: apply_in_page_filters", block, msg=fieldname)
 
 	def test_the_filters_that_change_the_query_still_reach_the_server(self):
 		# Dates change the range, Include Future Attendance changes the source, and
 		# Generate Based On changes what the cells hold - none can be done in page.
-		for fieldname in ("from_date", "to_date", "include_future_attendance", "generate_based_on"):
+		#
+		# WI-002153 AC4 put Roster Type and Day Off OT back here: ticking the box now asks
+		# for rows the last run excluded, and narrowing what is already on screen cannot
+		# produce them.
+		for fieldname in (
+			"from_date", "to_date", "include_future_attendance", "generate_based_on",
+			"roster_type", "day_off_ot",
+		):
 			block = self.source.split(f'fieldname: "{fieldname}"')[1].split("},")[0]
 			self.assertNotIn("on_change: apply_in_page_filters", block, msg=fieldname)
 
@@ -481,7 +632,7 @@ class TestInPageFilters(FrappeTestCase):
 
 	def test_the_row_carries_what_the_in_page_filters_match_on(self):
 		columns = {c["fieldname"] for c in execute(_filters())[0]}
-		for fieldname in ("employee", "employee_status", "employment_type", "roster_type", "day_off_ot"):
+		for fieldname in ("employee", "employee_status", "employment_type"):
 			self.assertIn(fieldname, columns, msg=fieldname)
 
 	def test_the_employee_column_holds_the_docname_the_filter_returns(self):
@@ -508,9 +659,30 @@ class TestTheSummaryBlock(FrappeTestCase):
 		for status in ("Absent", "On Leave", "On Hold", "Holiday"):
 			self.assertNotEqual(summary_counter(status), "working_days")
 
+	def test_work_from_home_is_counted_as_present_and_has_no_column(self):
+		"""WI-002153 AC7."""
+		self.assertEqual(summary_counter("Work From Home"), "working_days")
+		fieldnames = {c["fieldname"] for c in get_columns(_filters(), [])}
+		self.assertNotIn("work_from_home_days", fieldnames)
+		# Nor a legend entry of its own, which would read "Work From Home - P" beside
+		# "Present - P".
+		self.assertNotIn("Work From Home", get_message(_filters()))
+
+	def test_a_scheduled_day_on_duty_counts_as_present(self):
+		"""Client Event and On-the-job Training raise attendance the same way Working
+		does, and with "Other" gone they would otherwise fall out of the summary."""
+		for status in ("Client Event", "On-the-job Training"):
+			with self.subTest(status=status):
+				self.assertEqual(summary_counter(status), "working_days")
+
 	def test_both_kinds_of_day_off_share_one_column(self):
 		self.assertEqual(summary_counter("Day Off"), "off_days")
 		self.assertEqual(summary_counter("Client Day Off"), "off_days")
+
+	def test_a_holiday_is_counted_with_the_days_off(self):
+		"""WI-002153 AC6: Holiday joins Days Off rather than getting a column."""
+		self.assertEqual(summary_counter("Holiday"), "off_days")
+		self.assertNotIn("holiday_days", {c["fieldname"] for c in get_columns(_filters(), [])})
 
 	def test_a_leave_is_counted_under_its_own_type(self):
 		self.assertEqual(summary_counter("On Leave", "Annual Leave"), "annual_leave_days")
@@ -519,16 +691,63 @@ class TestTheSummaryBlock(FrappeTestCase):
 			summary_counter("On Leave", "Leave Without Pay"), "leave_without_pay_days"
 		)
 
-	def test_a_leave_of_another_type_is_other_not_a_missing_day(self):
-		"""Business Trip and Hajj Leave are real leave types on this site."""
-		self.assertEqual(summary_counter("On Leave", "Business Trip"), "other_days")
-		self.assertEqual(summary_counter("On Leave", None), "other_days")
+	def test_every_other_leave_type_is_counted_under_other_leaves(self):
+		"""WI-002153 AC9 names six; all six are Leave Types on this site, and they are
+		every one bar the three that have a column of their own."""
+		for leave_type in (
+			"Business Trip",
+			"Bereavement Leave",
+			"Maternity Leave",
+			"Privilege Leave",
+			"Hajj Leave",
+			"Holiday Compensatory Leave Type",
+		):
+			with self.subTest(leave_type=leave_type):
+				self.assertEqual(summary_counter("On Leave", leave_type), OTHER_LEAVES)
 
-	def test_a_status_no_column_names_is_other(self):
-		# 288 days were On Hold in July 2026; they have to land somewhere.
-		self.assertEqual(summary_counter("On Hold"), "other_days")
-		self.assertEqual(summary_counter("Holiday"), "other_days")
-		self.assertEqual(summary_counter("Client Interview"), "other_days")
+		# Written as a fallback rather than as that list, so a type added later - or a
+		# record with none set at all - is still counted somewhere.
+		self.assertEqual(summary_counter("On Leave", "Compensatory Off"), OTHER_LEAVES)
+		self.assertEqual(summary_counter("On Leave", None), OTHER_LEAVES)
+
+	def test_ac9_lists_every_leave_type_without_a_column_of_its_own(self):
+		"""If a Leave Type is added to this site it lands in Other Leaves, but the AC's
+		list would then be incomplete - which is worth knowing about."""
+		named = set(("Annual Leave", "Sick Leave", "Leave Without Pay"))
+		ac9 = {
+			"Business Trip", "Bereavement Leave", "Maternity Leave", "Privilege Leave",
+			"Hajj Leave", "Holiday Compensatory Leave Type",
+		}
+		on_site = {d.name for d in frappe.get_all("Leave Type", fields=["name"])}
+		self.assertEqual(on_site - named - ac9, {"Casual Leave", "Compensatory Off"})
+
+	def test_the_other_column_is_gone(self):
+		"""WI-002153 AC5."""
+		self.assertNotIn("other_days", SUMMARY_COUNTERS)
+		labels = {c["label"] for c in get_columns(_filters(), [])}
+		self.assertNotIn("Other", labels)
+		self.assertIn("Other Leaves", labels)
+
+	def test_each_broken_out_status_has_its_own_counter(self):
+		"""WI-002153 AC6: 288 days were On Hold in July 2026 and nothing named them."""
+		self.assertEqual(summary_counter("Fingerprint Appointment"), "fingerprint_days")
+		self.assertEqual(summary_counter("Client Interview"), "client_interview_days")
+		self.assertEqual(summary_counter("Medical Appointment"), "medical_appointment_days")
+		self.assertEqual(summary_counter("On Hold"), "on_hold_days")
+
+	def test_other_leaves_sits_immediately_right_of_leave_without_pay(self):
+		"""WI-002153 AC8 places it there."""
+		fieldnames = [c["fieldname"] for c in get_columns(_filters(), [])]
+		self.assertEqual(
+			fieldnames[fieldnames.index("leave_without_pay_days") + 1], OTHER_LEAVES
+		)
+
+	def test_a_scheduled_leave_lands_on_its_own_type(self):
+		"""Employee Schedule spells a leave as the availability itself, so it used to be
+		counted as Other even where a column for it existed."""
+		self.assertEqual(summary_counter("Annual Leave"), "annual_leave_days")
+		self.assertEqual(summary_counter("Sick Leave"), "sick_leave_days")
+		self.assertEqual(summary_counter("Emergency Leave"), OTHER_LEAVES)
 
 	def test_a_day_with_no_status_is_missing(self):
 		self.assertEqual(summary_counter(None), "missing_days")
@@ -537,8 +756,20 @@ class TestTheSummaryBlock(FrappeTestCase):
 	def test_every_status_lands_on_a_declared_column(self):
 		"""A counter this does not declare would vanish from the row silently."""
 		statuses = frappe.get_meta("Attendance").get_field("status").options.split("\n")
-		for status in statuses + ["Working", "Client Interview", None]:
+		schedule = frappe.get_meta("Employee Schedule").get_field(
+			"employee_availability"
+		).options.split("\n")
+		# Fingerprint / Client Interview / Medical Appointment are set on Attendance in
+		# code without being in its Select options, so they are named here too.
+		extra = ["Working", "Fingerprint Appointment", "Client Interview", "Medical Appointment", None]
+		for status in statuses + schedule + extra:
 			self.assertIn(summary_counter(status), SUMMARY_COUNTERS, msg=status)
+
+	def test_every_counter_has_a_column(self):
+		"""And the other way round: a counter with no column would never be seen."""
+		fieldnames = {c["fieldname"] for c in get_columns(_filters(), [])}
+		for counter in SUMMARY_COUNTERS:
+			self.assertIn(counter, fieldnames, msg=counter)
 
 	def test_the_row_reconciles_to_the_range(self):
 		"""The AC's own check: the summary columns add up to the days selected."""
@@ -566,7 +797,7 @@ class TestTheSummaryBlock(FrappeTestCase):
 		self.assertEqual(row["absent_days"], 1)
 		self.assertEqual(row["sick_leave_days"], 1)
 		self.assertEqual(row["annual_leave_days"], 0)
-		self.assertEqual(row["other_days"], 1)
+		self.assertEqual(row["on_hold_days"], 1)
 		self.assertEqual(row["off_days"], 2)
 		self.assertEqual(row["missing_days"], 1)
 		self.assertEqual(sum(row[counter] for counter in SUMMARY_COUNTERS), len(dates))
@@ -654,7 +885,7 @@ class TestAttendanceWithoutAShiftIsStillCounted(FrappeTestCase):
 
 	def test_the_query_left_joins_the_shift(self):
 		"""Pinned on the SQL: an inner join here silently loses rows rather than failing."""
-		from one_fm.one_fm.report.operations_monthly_attendance_sheet.operations_monthly_attendance_sheet import (
+		from one_fm.one_fm.report.monthly_payroll_attendance_sheet.monthly_payroll_attendance_sheet import (
 			get_non_day_off_attendance_records,
 		)
 		import inspect

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -311,6 +311,7 @@ one_fm.patches.v15_0.take_ownership_of_vehicle_handover_log #2026-07-25
 
 
 one_fm.patches.v15_0.rename_document_register_and_revision #2026-08-03
+one_fm.patches.v15_0.rename_operations_monthly_attendance_sheet #2026-08-23 WI-002153
 [post_model_sync]
 one_fm.patches.v15_0.process_task_for_wiki_employee_task
 one_fm.patches.v15_0.add_assignment_rule_returning_to_operations_supervisor_of_client_event #2

--- a/one_fm/patches/v15_0/rename_operations_monthly_attendance_sheet.py
+++ b/one_fm/patches/v15_0/rename_operations_monthly_attendance_sheet.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+"""Rename the report "Operations Monthly Attendance Sheet" -> "Monthly Payroll Attendance Sheet".
+
+WI-002153 AC1. The sheet no longer covers only Operations: the shift_working gate came
+off the employee query in the same work item, so non-shift staff, subcontractors and
+service providers appear on it too. The old name said otherwise.
+
+Renamed rather than left to the report sync to create afresh, because the name is the
+docname: the Print Format that prints the sheet links to it by name, and a second Report
+doc beside the old one would leave the old one live, visible and unmaintained.
+
+The 175 Prepared Reports already generated are deliberately *not* repointed. Their
+``report_name`` is a Data field, not a Link, so the rename leaves them alone - and that is
+what we want: every one of them was computed under the old rules (an "Other" column, a
+shift-working-only employee set, Day Off OT narrowing instead of consolidating), so
+serving one under the new name would hand a payroll operator stale figures. Unmatched,
+the report simply regenerates, and Frappe's own expiry clears them.
+
+**This must run pre-model-sync.** The report sync runs between the pre and post patch
+passes; if it went first it would create "Monthly Payroll Attendance Sheet" from the JSON
+and the rename would then refuse a name that already exists, leaving the old doc behind
+with everything still pointing at it.
+
+No-op on a site that never had the old name - a fresh install creates the report from the
+JSON already renamed.
+"""
+
+import frappe
+
+OLD = "Operations Monthly Attendance Sheet"
+NEW = "Monthly Payroll Attendance Sheet"
+
+
+def execute():
+	if not frappe.db.exists("Report", OLD):
+		return
+
+	if frappe.db.exists("Report", NEW):
+		frappe.log_error(
+			title=f"rename_operations_monthly_attendance_sheet: {OLD} and {NEW} both exist",
+			message=(
+				f"Cannot rename {OLD!r} to {NEW!r} because {NEW!r} already exists. This happens "
+				"when the report sync ran before this patch. Repoint the Print Format still "
+				f"linked to {OLD!r}, delete it, then re-run."
+			),
+		)
+		return
+
+	# force, because Report is not a renameable doctype by default (allow_rename = 0).
+	frappe.rename_doc("Report", OLD, NEW, force=True, show_alert=False)
+
+	# Report is named field:report_name, and rename_doc moves the docname without saving
+	# the doc - so the field it is named after has to follow by hand, or the next save
+	# renames it straight back.
+	frappe.db.set_value("Report", NEW, "report_name", NEW, update_modified=False)
+
+	frappe.db.commit()

--- a/one_fm/patches/v15_0/rename_operations_monthly_attendance_sheet.py
+++ b/one_fm/patches/v15_0/rename_operations_monthly_attendance_sheet.py
@@ -2,28 +2,15 @@
 # For license information, please see license.txt
 """Rename the report "Operations Monthly Attendance Sheet" -> "Monthly Payroll Attendance Sheet".
 
-WI-002153 AC1. The sheet no longer covers only Operations: the shift_working gate came
-off the employee query in the same work item, so non-shift staff, subcontractors and
-service providers appear on it too. The old name said otherwise.
+WI-002153 AC1. Renamed rather than left to the report sync to create afresh, so the Print
+Format that prints the sheet follows instead of pointing at a report nobody maintains.
 
-Renamed rather than left to the report sync to create afresh, because the name is the
-docname: the Print Format that prints the sheet links to it by name, and a second Report
-doc beside the old one would leave the old one live, visible and unmaintained.
+**Must run pre-model-sync.** The report sync runs between the two patch passes; if it went
+first the rename would refuse a name that already exists.
 
-The 175 Prepared Reports already generated are deliberately *not* repointed. Their
-``report_name`` is a Data field, not a Link, so the rename leaves them alone - and that is
-what we want: every one of them was computed under the old rules (an "Other" column, a
-shift-working-only employee set, Day Off OT narrowing instead of consolidating), so
-serving one under the new name would hand a payroll operator stale figures. Unmatched,
-the report simply regenerates, and Frappe's own expiry clears them.
-
-**This must run pre-model-sync.** The report sync runs between the pre and post patch
-passes; if it went first it would create "Monthly Payroll Attendance Sheet" from the JSON
-and the rename would then refuse a name that already exists, leaving the old doc behind
-with everything still pointing at it.
-
-No-op on a site that never had the old name - a fresh install creates the report from the
-JSON already renamed.
+The 175 Prepared Reports are deliberately not repointed - their ``report_name`` is a Data
+field, and each was computed under the old rules, so serving one under the new name would
+hand a payroll operator stale figures.
 """
 
 import frappe
@@ -51,8 +38,7 @@ def execute():
 	frappe.rename_doc("Report", OLD, NEW, force=True, show_alert=False)
 
 	# Report is named field:report_name, and rename_doc moves the docname without saving
-	# the doc - so the field it is named after has to follow by hand, or the next save
-	# renames it straight back.
+	# the doc - so the field it is named after has to follow, or the next save reverts it.
 	frappe.db.set_value("Report", NEW, "report_name", NEW, update_modified=False)
 
 	frappe.db.commit()


### PR DESCRIPTION
Staging counterpart of #6791 — same commit, cherry-picked onto `staging`.

[WI-002153](https://one-fm.com/app/work-item/WI-002153) — [Ahmed] Monthly Attendance Report Update

The Operations Monthly Attendance Sheet is a payroll sheet, not an Operations one. It excluded every non-shift-working employee, its Day Off OT box hid the basic shifts instead of consolidating with them, and a third of a payroll month disappeared into a column labelled "Other".

## What changed, per acceptance criterion

**AC1 — Renaming.** `Operations Monthly Attendance Sheet` → `Monthly Payroll Attendance Sheet`. The report folder and its five files are renamed with it, and a **pre-model-sync** patch renames the existing `Report` doc rather than letting the report sync create a second one beside it — the Print Format that prints the sheet links the report by name and follows the rename. It has to be pre-model-sync: the sync runs between the two patch passes, so a post patch would find the new name already created and leave the old doc live and unmaintained.

The 175 already-generated Prepared Reports deliberately do **not** follow. Their `report_name` is a Data field, not a Link, so the rename leaves them alone — and that is what we want: every one was computed under the old rules (an "Other" column, a shift-working-only employee set, Day Off OT narrowing instead of consolidating). Serving one under the new name would hand a payroll operator stale figures. Unmatched, the report regenerates, and Frappe's own expiry clears them.

**AC2 — Employee scope.** `Employee.shift_working == 1` is off the employee query. Non-shift staff, interns, part-timers, subcontractors and service providers are now on the sheet — on July 2026 that is **117 additional rows**, and every Service Provider on the instance was in the group the old gate excluded outright. Every Employee status is in scope, and the Employee Status filter now offers the values Employee actually holds: `Active`, `Court Case`, `Absconding`, `Left`, `Not Returned from Leave`, `Vacation`. `Inactive` and `Suspended` were on the filter and have never been Employee statuses here.

**AC3 — Basic alone.** Unchanged, and still pinned by a test: `roster_type = 'Basic'` with `day_off_ot <> 1`.

**AC4 — Basic + Day Off OT.** The box used to narrow to the day-off OT rows alone, which showed the overtime *instead of* the basic shifts. It now drops the constraint so both arrive together; rows are keyed by employee (WI-001980) so they land on a single line with no further work. On July 2026: **89 more present days on the same 1,666 rows.**

Both Roster Type and Day Off OT moved back to being server filters. Ticking the box now asks for rows the previous run excluded, and in-page filtering can only ever remove rows the server already sent — it cannot produce the ones the last run left out. This means ticking it re-runs the prepared report, which is the cost of the checkbox meaning what the AC says it means.

**AC5 — "Other" removed.** The column and its counter are gone.

**AC6 — New status columns.** Fingerprint, Client Interview, Medical Appointment and On Hold each get a summary column, a day-cell abbreviation (`FP` / `CI` / `MA` / `OH`, coloured orange — neither present nor absent), and a legend entry in both the desk legend and the print template. **288 July days were On Hold** with nothing naming them. Holiday is counted with Days Off rather than getting a column, as the AC specifies, and keeps its `H` cell so no information is lost.

**AC7 — Work From Home.** Already counted as Present with no column; the duplicate legend entry reading "Work From Home - P" beside "Present - P" is removed.

**AC8/AC9 — Other Leaves.** New column immediately right of Leave Without Pay, carrying every leave type without a column of its own. Written as the fallback rather than as the AC's six named types (Business Trip, Bereavement, Maternity, Privilege, Hajj, Holiday Compensatory) — those six are, today, exactly every Leave Type on the site bar the three that have their own column, and a fallback means a type added later is still counted somewhere. A test asserts the AC's list against the site's Leave Types so a divergence surfaces rather than going quiet.

## Keeping the row reconcilable

The summary block's promise since WI-001979 is that its columns add up to the days in the range. Removing "Other" put that at risk, so three loose ends were tied off:

- **Client Event** and **On-the-job Training** (Employee Schedule availabilities, reachable only with Include Future Attendance on) count as present — attendance is raised for them alongside `Working`, see `one_fm/api/tasks.py`.
- A scheduled **Annual Leave** / **Sick Leave** now lands on its own column instead of on Other, which is where the schedule path used to put it; **Emergency Leave** goes to Other Leaves.
- Only **Half Day** (never used on this site) and a **Suspended** schedule day now reach the fallback, and they are counted as missing so the row still adds up.

## Verification

July 2026, Basic, no Day Off OT — 1,666 rows:

- All 1,666 rows sum to 31 days.
- Present 14,529 vs 14,530 raw (Present + Work From Home); Days Off 1,702 vs 1,712 raw; Absent 265 vs 266 — the gaps are days carrying two records, where precedence picks one cell.
- On Hold 288 = 288 raw. Client Interview 4 = 4 raw. Other Leaves 2 = the 2 Business Trip days.
- Annual Leave 1,107 vs 1,152 raw: the 45 remaining records all belong to employees with no `tabEmployee` row, and are correctly excluded.

102 tests pass (`bench run-tests --module one_fm.one_fm.report.monthly_payroll_attendance_sheet.test_monthly_payroll_attendance_sheet`), including new coverage for each acceptance criterion, and the report script, print template and rename patch were exercised on the live dataset.

## Judgement calls worth a reviewer's eye

1. **Employees with no records at all are still skipped.** AC2 says "all OneFM employees"; this reads it as "remove the backend filters", not "add a blank row per employee". Confirmed with the requester before building. The Missing/Empty Days column still catches partial gaps.
2. **Holiday keeps its `H` day cell** while counting in Days Off. The AC says "Holiday > to be added with Day off", which is about the column; collapsing the cell to `DO` as well would lose information for no stated gain.
3. **Overtime + Day Off OT is still refused** as an invalid combination (WI-001791 Logic Rule 4). AC4 only re-specified the Basic case.
4. **The stale Print Format** `Operations Monthly Attendance Sheet` (a Print Format doc, distinct from the report's own `.html`) has its `report` link repointed so migrate does not fail on a missing target. It is otherwise untouched — its template still references `month`/`year` filters the report dropped long ago, which is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
