### PR TITLE
WI-002069: bring the read-only rules over, and drop the mandatory ones the BA never wrote

### DIFF
--- a/one_fm/patches/v15_0/migrate_visa_request_visibility.py
+++ b/one_fm/patches/v15_0/migrate_visa_request_visibility.py
@@ -6,6 +6,25 @@ import frappe
 # The state names in the rules are this site's. The BA export writes the MOI state
 # "Pending by MOI" where the workflow here has "Pending By MOI", and a depends_on naming a
 # state that does not exist hides the section at exactly the step that fills it in.
+# WI-002069 (second pass): the BA site also locks each of these once the request has moved
+# past the step that fills it in. None of them came across the first time - the diff that
+# drove that pass compared a hand-picked list of attributes and read_only_depends_on was not
+# on it.
+READ_ONLY_FIELDS = (
+	"custom_pam_file",
+	"pam_reference_number",
+	"custom_visa_application_date",
+	"custom_pam_designation_list",
+	"custom_work_permit_number",
+	"moi_reference_number",
+	"visa_reference_number",
+	"visa_issue_date",
+	"visa_expiry_date",
+	"visa_document",
+	"payment_receipt",
+	"payment_date",
+)
+
 GATED_FIELDS = (
 	"pam_details_section",
 	"custom_pam_file",
@@ -41,16 +60,29 @@ def verify():
 		if not field.depends_on:
 			frappe.throw(f"WI-002069: {fieldname} did not get its visibility rule.")
 
-	# Every state a rule names has to be one the workflow actually has.
-	for fieldname in GATED_FIELDS:
+	for fieldname in READ_ONLY_FIELDS:
+		field = meta.get_field(fieldname)
+		if not field:
+			frappe.throw(f"WI-002069: Visa Request has no {fieldname} field.")
+		if not field.read_only_depends_on:
+			frappe.throw(
+				f"WI-002069: {fieldname} did not get its read-only rule, so it stays editable "
+				"after the step that fills it in."
+			)
+
+	# Every state a rule names has to be one the workflow actually has - for both kinds of
+	# rule, because a condition naming a state that does not exist simply never fires.
+	for fieldname, attribute in (
+		[(f, "depends_on") for f in GATED_FIELDS] + [(f, "read_only_depends_on") for f in READ_ONLY_FIELDS]
+	):
 		named = {
 			part.split('"')[1]
-			for part in (meta.get_field(fieldname).depends_on or "").split("||")
+			for part in (meta.get_field(fieldname).get(attribute) or "").split("||")
 			if '"' in part
 		}
 		unknown = sorted(named - states)
 		if unknown:
 			frappe.throw(
-				f"WI-002069: {fieldname} names {unknown}, which the Visa Request workflow does "
-				"not have - the section would stay hidden in those states."
+				f"WI-002069: {fieldname}.{attribute} names {unknown}, which the Visa Request "
+				"workflow does not have - the rule would never fire."
 			)

--- a/one_fm/visa_management/doctype/visa_request/test_visa_request_visibility.py
+++ b/one_fm/visa_management/doctype/visa_request/test_visa_request_visibility.py
@@ -19,6 +19,24 @@ MOI_STATE = "Pending By MOI"
 # as a fieldname and quietly treats as false.
 DISABLED_RULES = ("custom_pam_file", "pam_reference_number", "custom_pam_designation_list")
 
+# Every field the BA site locks once the request has moved past the step that fills it in.
+# A reference number still editable three states later is one an operator can quietly change
+# after the ministry has it.
+READ_ONLY_FIELDS = (
+	"custom_pam_file",
+	"pam_reference_number",
+	"custom_visa_application_date",
+	"custom_pam_designation_list",
+	"custom_work_permit_number",
+	"moi_reference_number",
+	"visa_reference_number",
+	"visa_issue_date",
+	"visa_expiry_date",
+	"visa_document",
+	"payment_receipt",
+	"payment_date",
+)
+
 
 def _states():
 	return {state.state for state in frappe.get_doc("Workflow", "Visa Request").states}
@@ -65,15 +83,47 @@ class TestVisaRequestVisibility(FrappeTestCase):
 			with self.subTest(fieldname=fieldname):
 				self.assertFalse(self.meta.get_field(fieldname).mandatory_depends_on)
 
-	def test_the_mandatory_rules_this_site_added_are_kept(self):
-		"""The BA site does not carry these. Dropping them to match it would make three
-		fields optional that the process needs."""
-		for fieldname, state in (
-			("custom_work_permit_number", MOI_STATE),
-			("visa_issue_date", "Pending Visa Issuance"),
-			("visa_expiry_date", "Pending Visa Issuance"),
-		):
+	def test_the_mandatory_rules_the_ba_site_never_had_are_gone(self):
+		"""Kept at first on the reasoning that dropping them would make three fields optional.
+		The BA confirmed she never wrote them, and the doctype is hers - so they go."""
+		for fieldname in ("custom_work_permit_number", "visa_issue_date", "visa_expiry_date"):
 			with self.subTest(fieldname=fieldname):
-				rule = self.meta.get_field(fieldname).mandatory_depends_on
-				self.assertTrue(rule, fieldname)
-				self.assertIn(state, rule)
+				self.assertFalse(self.meta.get_field(fieldname).mandatory_depends_on, fieldname)
+
+	# ── read-only rules (the second half of the migration) ────────────────────────
+
+	def test_every_field_the_ba_site_locks_is_locked_here(self):
+		for fieldname in READ_ONLY_FIELDS:
+			with self.subTest(fieldname=fieldname):
+				self.assertTrue(
+					self.meta.get_field(fieldname).read_only_depends_on,
+					f"{fieldname} stays editable after its step",
+				)
+
+	def test_every_state_a_read_only_rule_names_exists(self):
+		"""Same trap as the visibility rules: the export writes "Pending by MOI" where the
+		workflow here has "Pending By MOI", and a rule naming a state that does not exist
+		never fires - so the field stays editable at exactly the step it should be locked in."""
+		states = _states()
+		for fieldname in READ_ONLY_FIELDS:
+			with self.subTest(fieldname=fieldname):
+				unknown = _named_states(self.meta.get_field(fieldname).read_only_depends_on) - states
+				self.assertEqual(unknown, set(), f"{fieldname} names states the workflow lacks")
+
+	def test_a_pam_reference_locks_once_the_file_leaves_pam(self):
+		named = _named_states(self.meta.get_field("pam_reference_number").read_only_depends_on)
+		self.assertIn("Pending GRD Manager Approval", named)
+		self.assertIn(MOI_STATE, named)
+
+	def test_the_visa_fields_lock_on_completion(self):
+		for fieldname in ("visa_reference_number", "visa_issue_date", "visa_expiry_date", "visa_document"):
+			with self.subTest(fieldname=fieldname):
+				named = _named_states(self.meta.get_field(fieldname).read_only_depends_on)
+				self.assertIn("Completed", named)
+				# Still editable at the step that fills them in.
+				self.assertNotIn("Pending Visa Issuance", named)
+
+	def test_the_remark_fields_match_the_ba_site(self):
+		self.assertTrue(self.meta.get_field("operator_rejection_remark").read_only)
+		self.assertTrue(self.meta.get_field("pam_remarks").hidden)
+		self.assertTrue(self.meta.get_field("moi_remarks").hidden)

--- a/one_fm/visa_management/doctype/visa_request/visa_request.json
+++ b/one_fm/visa_management/doctype/visa_request/visa_request.json
@@ -183,7 +183,8 @@
   {
    "fieldname": "payment_receipt",
    "fieldtype": "Attach",
-   "label": "Payment Receipt"
+   "label": "Payment Receipt",
+   "read_only_depends_on": "eval:doc.workflow_state==\"Completed\" || doc.workflow_state==\"Rejected for Re Issue\" || doc.workflow_state==\"Awaiting Visa Cancellation\" || doc.workflow_state==\"Pending Cancel Work Permit\" || doc.workflow_state==\"Work Permit Cancelled\" || doc.workflow_state==\"Pending Recruiter Confirmation\""
   },
   {
    "fieldname": "column_break_wjxj",
@@ -192,7 +193,8 @@
   {
    "fieldname": "visa_document",
    "fieldtype": "Attach",
-   "label": "Visa Document"
+   "label": "Visa Document",
+   "read_only_depends_on": "eval:doc.workflow_state==\"Completed\" || doc.workflow_state==\"Rejected for Re Issue\" || doc.workflow_state==\"Awaiting Visa Cancellation\" || doc.workflow_state==\"Pending Cancel Work Permit\" || doc.workflow_state==\"Work Permit Cancelled\" || doc.workflow_state==\"Pending Recruiter Confirmation\""
   },
   {
    "fieldname": "column_break_jdrk",
@@ -201,7 +203,8 @@
   {
    "fieldname": "pam_reference_number",
    "fieldtype": "Data",
-   "label": "PAM Reference Number"
+   "label": "PAM Reference Number",
+   "read_only_depends_on": "eval:doc.workflow_state==\"Pending GRD Manager Approval\" || doc.workflow_state==\"Pending By MOI\"|| doc.workflow_state==\"Pending Visa Issuance\" || doc.workflow_state==\"Completed\" || doc.workflow_state==\"Rejected for Re Issue\" || doc.workflow_state==\"Awaiting Visa Cancellation\" || doc.workflow_state==\"Pending Cancel Work Permit\" || doc.workflow_state==\"Work Permit Cancelled\" || doc.workflow_state==\"Rejected By MOI\" || doc.workflow_state==\"Pending Recruiter Confirmation\" || doc.workflow_state==\"Rejected By PAM\""
   },
   {
    "fieldname": "column_break_gvey",
@@ -210,6 +213,7 @@
   {
    "fieldname": "pam_remarks",
    "fieldtype": "Data",
+   "hidden": 1,
    "label": "PAM Remarks"
   },
   {
@@ -224,7 +228,8 @@
   {
    "fieldname": "moi_reference_number",
    "fieldtype": "Data",
-   "label": "MOI Reference Number"
+   "label": "MOI Reference Number",
+   "read_only_depends_on": "eval:doc.workflow_state==\"Pending Visa Issuance\" || doc.workflow_state==\"Completed\" || doc.workflow_state==\"Rejected for Re Issue\" || doc.workflow_state==\"Awaiting Visa Cancellation\" || doc.workflow_state==\"Pending Cancel Work Permit\" || doc.workflow_state==\"Work Permit Cancelled\" || doc.workflow_state==\"Rejected By MOI\" || doc.workflow_state==\"Pending Recruiter Confirmation\""
   },
   {
    "fieldname": "column_break_jvjp",
@@ -233,6 +238,7 @@
   {
    "fieldname": "moi_remarks",
    "fieldtype": "Data",
+   "hidden": 1,
    "label": "MOI Remarks"
   },
   {
@@ -247,7 +253,8 @@
   {
    "fieldname": "visa_reference_number",
    "fieldtype": "Data",
-   "label": "Visa Reference Number"
+   "label": "Visa Reference Number",
+   "read_only_depends_on": "eval:doc.workflow_state==\"Completed\" || doc.workflow_state==\"Rejected for Re Issue\" || doc.workflow_state==\"Awaiting Visa Cancellation\" || doc.workflow_state==\"Pending Cancel Work Permit\" || doc.workflow_state==\"Work Permit Cancelled\" || doc.workflow_state==\"Pending Recruiter Confirmation\""
   },
   {
    "fieldname": "section_break_jrbe",
@@ -536,37 +543,40 @@
    "fieldname": "custom_pam_file",
    "fieldtype": "Link",
    "label": "PAM File",
-   "options": "PAM File"
+   "options": "PAM File",
+   "read_only_depends_on": "eval:doc.workflow_state==\"Pending GRD Manager Approval\" || doc.workflow_state==\"Pending By MOI\"|| doc.workflow_state==\"Pending Visa Issuance\" || doc.workflow_state==\"Completed\" || doc.workflow_state==\"Rejected for Re Issue\" || doc.workflow_state==\"Awaiting Visa Cancellation\" || doc.workflow_state==\"Pending Cancel Work Permit\" || doc.workflow_state==\"Work Permit Cancelled\" || doc.workflow_state==\"Rejected By MOI\" || doc.workflow_state==\"Pending Recruiter Confirmation\" || doc.workflow_state==\"Rejected By PAM\""
   },
   {
    "fieldname": "custom_visa_application_date",
    "fieldtype": "Datetime",
-   "label": "Visa Application Date"
+   "label": "Visa Application Date",
+   "read_only_depends_on": "eval:doc.workflow_state==\"Pending GRD Manager Approval\" || doc.workflow_state==\"Pending By MOI\"|| doc.workflow_state==\"Pending Visa Issuance\" || doc.workflow_state==\"Completed\" || doc.workflow_state==\"Rejected for Re Issue\" || doc.workflow_state==\"Awaiting Visa Cancellation\" || doc.workflow_state==\"Pending Cancel Work Permit\" || doc.workflow_state==\"Work Permit Cancelled\" || doc.workflow_state==\"Rejected By MOI\" || doc.workflow_state==\"Pending Recruiter Confirmation\" || doc.workflow_state==\"Rejected By PAM\""
   },
   {
    "fieldname": "custom_pam_designation_list",
    "fieldtype": "Link",
    "label": "PAM Designation List",
-   "options": "PAM Designation List"
+   "options": "PAM Designation List",
+   "read_only_depends_on": "eval:doc.workflow_state==\"Pending GRD Manager Approval\" || doc.workflow_state==\"Pending By MOI\"|| doc.workflow_state==\"Pending Visa Issuance\" || doc.workflow_state==\"Completed\" || doc.workflow_state==\"Rejected for Re Issue\" || doc.workflow_state==\"Awaiting Visa Cancellation\" || doc.workflow_state==\"Pending Cancel Work Permit\" || doc.workflow_state==\"Work Permit Cancelled\" || doc.workflow_state==\"Rejected By MOI\" || doc.workflow_state==\"Pending Recruiter Confirmation\" || doc.workflow_state==\"Rejected By PAM\""
   },
   {
    "depends_on": "eval:doc.workflow_state==\"Pending By PAM\" || doc.workflow_state==\"Pending By MOI\" || doc.workflow_state==\"Pending Visa Issuance\" || doc.workflow_state==\"Rejected By PAM\" || doc.workflow_state==\"Rejected By MOI\" || doc.workflow_state==\"Pending Recruiter Confirmation\" || doc.workflow_state==\"Completed\" || doc.workflow_state==\"Awaiting Visa Cancellation\" || doc.workflow_state==\"Pending Cancel Work Permit\" || doc.workflow_state==\"Work Permit Cancelled\"",
    "fieldname": "custom_work_permit_number",
    "fieldtype": "Data",
    "label": "Work Permit Number",
-   "mandatory_depends_on": "eval:doc.workflow_state==\"Pending By MOI\""
+   "read_only_depends_on": "eval:doc.workflow_state==\"Pending By MOI\"|| doc.workflow_state==\"Pending Visa Issuance\" || doc.workflow_state==\"Completed\" || doc.workflow_state==\"Rejected for Re Issue\" || doc.workflow_state==\"Awaiting Visa Cancellation\" || doc.workflow_state==\"Pending Cancel Work Permit\" || doc.workflow_state==\"Work Permit Cancelled\" || doc.workflow_state==\"Rejected By MOI\" || doc.workflow_state==\"Pending Recruiter Confirmation\" || doc.workflow_state==\"Rejected By PAM\""
   },
   {
    "fieldname": "visa_issue_date",
    "fieldtype": "Date",
    "label": "Visa Issue Date",
-   "mandatory_depends_on": "eval:doc.workflow_state==\"Pending Visa Issuance\""
+   "read_only_depends_on": "eval:doc.workflow_state==\"Completed\" || doc.workflow_state==\"Rejected for Re Issue\" || doc.workflow_state==\"Awaiting Visa Cancellation\" || doc.workflow_state==\"Pending Cancel Work Permit\" || doc.workflow_state==\"Work Permit Cancelled\" || doc.workflow_state==\"Pending Recruiter Confirmation\""
   },
   {
    "fieldname": "visa_expiry_date",
    "fieldtype": "Date",
    "label": "Visa Expiry Date",
-   "mandatory_depends_on": "eval:doc.workflow_state==\"Pending Visa Issuance\""
+   "read_only_depends_on": "eval:doc.workflow_state==\"Completed\" || doc.workflow_state==\"Rejected for Re Issue\" || doc.workflow_state==\"Awaiting Visa Cancellation\" || doc.workflow_state==\"Pending Cancel Work Permit\" || doc.workflow_state==\"Work Permit Cancelled\" || doc.workflow_state==\"Pending Recruiter Confirmation\""
   },
   {
    "fieldname": "column_break_uxnb",
@@ -575,14 +585,15 @@
   {
    "fieldname": "payment_date",
    "fieldtype": "Datetime",
-   "label": "Payment Date"
+   "label": "Payment Date",
+   "read_only_depends_on": "eval:doc.workflow_state==\"Completed\" || doc.workflow_state==\"Rejected for Re Issue\" || doc.workflow_state==\"Awaiting Visa Cancellation\" || doc.workflow_state==\"Pending Cancel Work Permit\" || doc.workflow_state==\"Work Permit Cancelled\" || doc.workflow_state==\"Pending Recruiter Confirmation\""
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-20 15:00:00.000000",
+ "modified": "2026-08-24 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Visa Management",
  "name": "Visa Request",


### PR DESCRIPTION
[WI-002069] Migrate Visa Request Doctype from BA Site to Staging — follow-up to **#6766**, which is already merged.

Both points the BA raised after testing are correct. Fixing them turned up three more.

## 1. Read Only Depends On — 12 fields, none migrated

> *"I also included the Read Only Depends On (JS) conditions, but they aren't appearing in staging."*

Correct, and this is the bigger of the two. It's the rule that **locks a reference number once the request has moved past the step that fills it in** — a PAM reference still editable three states later is one an operator can quietly change after the ministry already has it.

All twelve are here now:

| Locks from | Fields |
|---|---|
| Pending GRD Manager Approval onward | `custom_pam_file`, `pam_reference_number`, `custom_visa_application_date`, `custom_pam_designation_list` |
| Pending By MOI onward | `custom_work_permit_number` |
| Pending Visa Issuance onward | `moi_reference_number` |
| Completed onward | `visa_reference_number`, `visa_issue_date`, `visa_expiry_date`, `visa_document`, `payment_receipt`, `payment_date` |

**Why I missed it:** the diff that drove #6766 compared a hand-picked list of attributes — fieldtype, options, reqd, read_only, hidden, depends_on, mandatory_depends_on, label, default — and `read_only_depends_on` simply wasn't on it. My mistake, and the wrong method: I've re-run the comparison across **every** attribute Frappe stores on a DocField, which is what found everything below.

## 2. Mandatory Depends On the BA never wrote — removed

> *"I have not added the Mandatory Depends On (JS) condition for the visa issue and expiry date on the BA site, but it is there in staging."*

Also correct. In #6766 I deliberately **kept** these, on the reasoning that dropping them would make fields optional the process needs — and I flagged it in that PR's description as a judgement call. It was the wrong call: the doctype is the BA's and she never wrote them.

Removed from `visa_issue_date` and `visa_expiry_date`, **and also from `custom_work_permit_number`**, which was the same case and which I'd kept for the same reason. Flagging that third one explicitly since it wasn't named — say the word if it should stay.

## 3. Three more the full diff found

- `operator_rejection_remark` → read-only
- `pam_remarks` → hidden
- `moi_remarks` → hidden

## The state-name trap, again

The export writes the MOI state **"Pending by MOI"**; the workflow here has **"Pending By MOI"**. A rule naming a state that doesn't exist never fires — so a field locked by one would have stayed **editable at exactly the step it's meant to be locked in**. Every new rule uses this site's spelling, and the patch now validates the states named by *both* kinds of rule, not just the visibility ones.

## Where it stands now

After this, the local doctype is identical to the BA site apart from that deliberate MOI spelling, plus one no-op: BA's `custom_work_permit_number.depends_on` lists `Rejected By MOI` twice. Same set of states, same behaviour.

## Deploy

`bench migrate` — `migrate_visa_request_visibility` reloads the doctype and now verifies the read-only rules landed as well.

## Tests

`test_visa_request_visibility` — **12 passing** (5 new): every locked field has its rule, every state named exists, a PAM reference locks once the file leaves PAM, the visa fields lock on completion but stay editable at issuance, and the remark fields match. The mandatory-rules test is inverted to assert they're gone.

`one_fm.tests.test_visa_request_migration` (25) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)