### PR TITLE
WI-002160: one trip group on one vehicle is one bus run, not two

### DIFF
--- a/one_fm/one_fm/page/transportation_schedule/test_transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/test_transportation_schedule.py
@@ -97,3 +97,63 @@ class TestSyncShipmentStatuses(FrappeTestCase):
 
 		self.assertEqual(self._status(self.outbound), "Unassigned")
 		self.assertEqual(self._status(self.return_leg), "Assigned")
+
+
+class TestAPlacedCardIsNeverReverted(FrappeTestCase):
+	"""A direction mismatch is a flag to fix, not a card to send back to the pool.
+
+	The mismatch fires whenever the browser's copy of the plan disagrees with the
+	shipment — a tab left open across a merge or a data change, or two people editing
+	the board at once. Reverting on it marked a card Unassigned while its block was
+	still on the lane, and Generate Shipments deletes Unassigned shift-generated cards
+	whose demand has moved on, so a stale tab could get a placed card deleted.
+	"""
+
+	def setUp(self):
+		self.pair = frappe.generate_hash("TRQ-KEEP", 8)
+		self.leg = _make_leg(self.pair, "Outward", status="Assigned")
+
+	def _read(self, name):
+		return frappe.db.get_value(
+			"Transportation Shipment", name,
+			["status", "trip_direction", "pre_merge_trip_direction"], as_dict=True
+		)
+
+	def test_a_card_still_on_the_plan_keeps_its_status(self):
+		# The stale-tab shape: the shipment reads Mixed, the browser still says OUTBOUND.
+		frappe.db.set_value("Transportation Shipment", self.leg, {
+			"trip_direction": "Mixed", "pre_merge_trip_direction": "Outward"
+		})
+
+		_sync_shipment_statuses(
+			[_swim_item(self.leg, "OUTBOUND")], previously_linked={self.leg}
+		)
+
+		kept = self._read(self.leg)
+		self.assertEqual(kept.status, "Assigned")
+		self.assertEqual(kept.trip_direction, "Mixed")
+		self.assertEqual(kept.pre_merge_trip_direction, "Outward")
+
+	def test_a_card_the_plan_dropped_still_reverts(self):
+		# The case the revert branch is actually for: the block left the lane, so the
+		# card goes back to the pool with its own direction.
+		frappe.db.set_value("Transportation Shipment", self.leg, {
+			"trip_direction": "Mixed", "pre_merge_trip_direction": "Outward"
+		})
+
+		_sync_shipment_statuses([], previously_linked={self.leg})
+
+		reverted = self._read(self.leg)
+		self.assertEqual(reverted.status, "Unassigned")
+		self.assertEqual(reverted.trip_direction, "Outward")
+		self.assertIsNone(reverted.pre_merge_trip_direction)
+
+	def test_a_mismatched_card_is_still_not_newly_assigned(self):
+		# The guard the check exists for is untouched: a mismatch never promotes a card
+		# to Assigned, it only stops it being demoted.
+		frappe.db.set_value("Transportation Shipment", self.leg, "status", "Unassigned")
+
+		_sync_shipment_statuses([_swim_item(self.leg, "RETURN")])
+
+		self.assertEqual(self._read(self.leg).status, "Unassigned")
+

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
@@ -1427,20 +1427,20 @@ function mountRoutePlannerApp(wrapper, data) {
             },
 
             // ── Time-aware peak load helper ─────────────────────────────────
-            // The trips a vehicle actually runs today. Stops chained onto one trip
-            // merge — they ride together — but the outbound and return legs stay
-            // apart (WI-002000): they share a tripId, so keying on it alone fused a
-            // 05:00 drop and its 17:00 pickup into one twelve-hour block carrying
-            // double the passengers, which every later drop then "overlapped".
+            // The trips a vehicle actually runs today. One tripId is one bus run,
+            // however its stops are headed: keying the direction in as well (WI-002000)
+            // split a chained run — an outward drop and the return pickup made at the
+            // same stop — into two pseudo-trips whose windows overlap each other, and
+            // the seat check then added the same bus to itself (WI-002160). A run that
+            // both drops off and picks up is measured leg by leg instead, which is what
+            // the two legs of one journey needed in the first place.
             _getLogicalTrips(vehicleId) {
                 const vi = this.swimItems.filter(i => i.vehicleId === vehicleId && this._liveToday(i));
                 const tripsMap = {};
                 let soloIdx = 0;
 
                 vi.forEach(item => {
-                    const key = item.tripId
-                        ? `${item.tripId}::${item.direction}`
-                        : `_solo_${soloIdx++}`;
+                    const key = item.tripId || `_solo_${soloIdx++}`;
                     if (!tripsMap[key]) {
                         tripsMap[key] = {
                             start: new Date(item.start).getTime(),
@@ -1461,8 +1461,23 @@ function mountRoutePlannerApp(wrapper, data) {
                 // total the bus is never asked to hold. Summing it painted a merged block
                 // purple for overcapacity on a run that fits (WI-002078).
                 const trips = Object.values(tripsMap);
-                trips.forEach(t => { t.occupancy = this.tripOccupancy(t); });
+                trips.forEach(t => {
+                    t.direction = this.runDirection(t.stops);
+                    t.occupancy = this.tripOccupancy(t);
+                });
                 return trips;
+            },
+
+            // Which way a whole run travels. Stops that do not all agree make it a mixed
+            // run, whatever each one is labelled: `direction` only ever reads MIXED when
+            // the Merge Trip modal wrote it back, and chaining a return stop onto an
+            // outbound trip left every stop on its original heading. Summing those as two
+            // concurrent runs is what refused a load the bus was already carrying
+            // (WI-002160), so every seat check reads the run's direction through here.
+            runDirection(stops) {
+                if (!stops || !stops.length) return 'OUTBOUND';
+                const first = stops[0].direction || 'OUTBOUND';
+                return stops.some(s => (s.direction || 'OUTBOUND') !== first) ? 'MIXED' : first;
             },
 
             // The most passengers one trip ever has aboard. Mirrors _trip_peak on the
@@ -2098,7 +2113,7 @@ function mountRoutePlannerApp(wrapper, data) {
                         // merged run's stops are not all aboard at once, so its total is
                         // not what has to fit (WI-002078).
                         const movingHeadcount = self.tripOccupancy({
-                            direction: item.direction,
+                            direction: self.runDirection(journeyItems),
                             headcount: journeyItems.reduce((sum, i) => sum + (i.headcount || 0), 0),
                             stops: journeyItems
                         });
@@ -2349,9 +2364,16 @@ function mountRoutePlannerApp(wrapper, data) {
                         const targetTripItems = tripsMap[targetTripId].items;
                         const targetVehicleId = selectedOpt.vehicle.id;
 
-                        // Check logical trip capacity directly instead of peakLoadDuringCardWindows 
-                        // because we want to know the target trip's total capacity + new card
-                        const tripLoad = targetTripItems.reduce((sum, i) => sum + (i.headcount || 0), 0);
+                        // The target run's own load, not the lane's: what matters here is
+                        // whether that trip plus this card fits. Read through tripOccupancy
+                        // rather than summing the stops by hand — a run that both drops off
+                        // and picks up never carries its stops all at once, and summing them
+                        // refused a merge the bus could make (WI-002160).
+                        const tripLoad = self.tripOccupancy({
+                            direction: self.runDirection(targetTripItems),
+                            headcount: targetTripItems.reduce((sum, i) => sum + (i.headcount || 0), 0),
+                            stops: targetTripItems
+                        });
                         if (tripLoad + card.headcount > self.passengerSeats(selectedOpt.vehicle)) {
                             frappe.msgprint({
                                 title: __('Capacity Exceeded'),

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
@@ -343,7 +343,7 @@ function mountRoutePlannerApp(wrapper, data) {
                             type: 'merged',
                             tripId,
                             tripName: stops.find(s => s.tripName)?.tripName || null,
-                            direction: stops.some(s => s.direction === 'MIXED') ? 'MIXED' : firstItem.direction,
+                            direction: this.runDirection(stops),
                             start: firstItem.start,
                             end: lastItem.end,
                             headcount: totalHC,
@@ -771,7 +771,8 @@ function mountRoutePlannerApp(wrapper, data) {
                 }
 
                 // ── Seat capacity check (time-aware) ──
-                const peakLoad = this.peakLoadDuringCardWindows(card, vehicle.id);
+                const blockers = this.tripsDuringCardWindows(card, vehicle.id);
+                const peakLoad = blockers.reduce((sum, t) => sum + t.occupancy, 0);
 
                 if (peakLoad + card.headcount > this.passengerSeats(vehicle)) {
                     const shell = document.getElementById('rp-shell');
@@ -780,7 +781,7 @@ function mountRoutePlannerApp(wrapper, data) {
                         shell.style.backgroundColor = '#ffebee';
                         setTimeout(() => { shell.style.backgroundColor = ''; }, 400);
                     }
-                    frappe.throw(this.capacityMessage(card.headcount, vehicle));
+                    frappe.throw(this.capacityMessage(card.headcount, vehicle, blockers));
                     return;
                 }
 
@@ -853,6 +854,22 @@ function mountRoutePlannerApp(wrapper, data) {
                     } else {
                         // ── Multiple trips: let user pick which trip to join ──
                         const self = this;
+
+                        // Nearest run first. The list was built from swimItems order,
+                        // which is Route Plan Assignment row order, so a 14:15 run was
+                        // offered as the DEFAULT for a 16:00 card purely because its row
+                        // had been saved earlier — and accepting the default merged the
+                        // card into a run nowhere near it. Order by the gap to the card's
+                        // own window instead; runs that overlap it sort first.
+                        const gapToCard = (items) => {
+                            const s = Math.min(...items.map(i => new Date(i.start).getTime()));
+                            const e = Math.max(...items.map(i => new Date(i.end).getTime()));
+                            if (e < cardWindowStart) return cardWindowStart - e;
+                            if (s > cardWindowEnd) return s - cardWindowEnd;
+                            return 0;
+                        };
+                        tripKeys.sort((a, b) => gapToCard(tripMap[a]) - gapToCard(tripMap[b]));
+
                         const tripOptions = tripKeys.map((key, idx) => {
                             const items = tripMap[key];
                             const sites = items.map(i => {
@@ -891,7 +908,9 @@ function mountRoutePlannerApp(wrapper, data) {
                                 {
                                     fieldtype: 'Int', fieldname: 'transit_min',
                                     label: 'Transit Time (minutes)', default: 30, reqd: 1,
-                                    description: 'Only used when adding to an existing trip'
+                                    description: 'Used when the stop joins a run going the same way. '
+                                        + 'Joining a run going the other way is a merge, and the Merge '
+                                        + 'Trip window collects the per-leg times itself.'
                                 }
                             ],
                             primary_action_label: 'Add Stop',
@@ -1307,7 +1326,15 @@ function mountRoutePlannerApp(wrapper, data) {
                 // stop after it and can put the bus over its seats. The modal is where the
                 // operator sees all three before committing, instead of the card being
                 // silently re-timed on a default 30-minute transit.
-                if (!presetTransitMin && self._isMergeDrop(newCard, existingItems)) {
+                //
+                // This used to be skipped whenever a transit time arrived with the call,
+                // which is the path the "Add Stop to which trip?" picker takes. So a
+                // cross-direction merge made through the picker never opened the modal and
+                // never reached merge_trip_shipments: the run kept every stop on its
+                // original heading and no card recorded pre_merge_trip_direction. That is
+                // where the un-marked mixed runs on the live plan came from (WI-002160).
+                // A merge is a merge however the operator got here.
+                if (self._isMergeDrop(newCard, existingItems)) {
                     self._openMergeTripModal(newCard, existingItems, vehicleId);
                     return;
                 }
@@ -1315,7 +1342,8 @@ function mountRoutePlannerApp(wrapper, data) {
                 // ── Capacity check before chaining ──
                 const vehicle = this.planData.vehicles.find(v => v.id === vehicleId);
                 if (vehicle) {
-                    const currentLoad = this.peakLoadDuringCardWindows(newCard, vehicleId);
+                    const blockers = this.tripsDuringCardWindows(newCard, vehicleId);
+                    const currentLoad = blockers.reduce((sum, t) => sum + t.occupancy, 0);
                     if (currentLoad + newCard.headcount > this.passengerSeats(vehicle)) {
                         const shell = document.getElementById('rp-shell');
                         if (shell) {
@@ -1323,7 +1351,7 @@ function mountRoutePlannerApp(wrapper, data) {
                             shell.style.backgroundColor = '#ffebee';
                             setTimeout(() => { shell.style.backgroundColor = ''; }, 400);
                         }
-                        frappe.throw(this.capacityMessage(newCard.headcount, vehicle));
+                        frappe.throw(this.capacityMessage(newCard.headcount, vehicle, blockers));
                         return;
                     }
                 }
@@ -1447,12 +1475,14 @@ function mountRoutePlannerApp(wrapper, data) {
                             end: new Date(item.end).getTime(),
                             headcount: item.headcount || 0,
                             direction: item.direction,
+                            tripName: item.tripName || null,
                             stops: [item]
                         };
                     } else {
                         tripsMap[key].start = Math.min(tripsMap[key].start, new Date(item.start).getTime());
                         tripsMap[key].end = Math.max(tripsMap[key].end, new Date(item.end).getTime());
                         tripsMap[key].headcount += (item.headcount || 0);
+                        tripsMap[key].tripName = tripsMap[key].tripName || item.tripName || null;
                         tripsMap[key].stops.push(item);
                     }
                 });
@@ -1521,11 +1551,27 @@ function mountRoutePlannerApp(wrapper, data) {
 
             // One wording for every seat refusal, naming the limit the check
             // actually applied rather than the size of the bus.
-            capacityMessage(headcount, vehicle) {
-                return __(
+            capacityMessage(headcount, vehicle, blockers) {
+                const base = __(
                     'Capacity Exceeded: cannot assign {0} employees to {1} — it takes {2} passengers.',
                     [headcount, this.vehicleString(vehicle), this.passengerSeats(vehicle)]
                 );
+
+                // Name the runs holding the seats. Without this the refusal named only
+                // the bus, and a card is placed at its own shift window rather than where
+                // it was dropped — so the blocking run is routinely not the block the
+                // operator was aiming at, and the message was undiagnosable.
+                const named = (blockers || [])
+                    .filter(t => t && t.occupancy)
+                    .map(t => __('{0} ({1} aboard, {2}–{3})', [
+                        t.tripName || __('an unnamed run'),
+                        t.occupancy,
+                        this.fmtTime(t.start),
+                        this.fmtTime(t.end)
+                    ]));
+                if (!named.length) return base;
+
+                return `${base} ${__('Those seats are held by {0}.', [named.join(', ')])}`;
             },
 
             // The headcount already aboard the vehicle during the window this card
@@ -1533,21 +1579,33 @@ function mountRoutePlannerApp(wrapper, data) {
             // the worse of the outbound and return windows meant an early drop was
             // judged against the evening traffic it never shares the road with.
             peakLoadDuringCardWindows(card, vehicleId, direction) {
-                const DEF = 3600000;
-                const leg = direction || card.direction;
-
-                let wStart, wEnd;
-                if (leg === 'RETURN') {
-                    wStart = new Date(card.return_window_start).getTime();
-                    wEnd = wStart + DEF;
-                } else {
-                    wEnd = new Date(card.outbound_window_end).getTime();
-                    wStart = wEnd - DEF;
-                }
-
-                return this._getLogicalTrips(vehicleId)
-                    .filter(t => t.start < wEnd && t.end > wStart)  // overlaps
+                return this.tripsDuringCardWindows(card, vehicleId, direction)
                     .reduce((sum, t) => sum + t.occupancy, 0);
+            },
+
+            // The runs already on the road during the window this card would occupy.
+            // The seat check and the refusal message read the same list, so the message
+            // can name what actually took the seats instead of leaving the operator to
+            // guess: a card is placed at its own shift window, never where it was
+            // dropped, so the run that blocks it is often not the one under the cursor.
+            tripsDuringCardWindows(card, vehicleId, direction) {
+                const { start, end } = this.cardLegWindow(card, direction);
+                return this._getLogicalTrips(vehicleId)
+                    .filter(t => t.start < end && t.end > start);
+            },
+
+            // The hour a card's chosen leg occupies. Only the leg being placed counts
+            // (WI-002000): taking the worse of the outbound and return windows meant an
+            // early drop was judged against the evening traffic it never shares the road
+            // with.
+            cardLegWindow(card, direction) {
+                const DEF = 3600000;
+                if ((direction || card.direction) === 'RETURN') {
+                    const start = new Date(card.return_window_start).getTime();
+                    return { start, end: start + DEF };
+                }
+                const end = new Date(card.outbound_window_end).getTime();
+                return { start: end - DEF, end };
             },
 
             // ─ Place card + direction picker ─────────────────────────────
@@ -2123,10 +2181,9 @@ function mountRoutePlannerApp(wrapper, data) {
                         // so none of the moving stops are already on the target.
                         const blockStart = Math.min(...journeyItems.map(i => new Date(i.start).getTime()));
                         const blockEnd = Math.max(...journeyItems.map(i => new Date(i.end).getTime()));
-                        const logicalTrips = self._getLogicalTrips(targetVehicle.id);
-                        const existingLoad = logicalTrips
-                            .filter(t => t.start < blockEnd && t.end > blockStart)
-                            .reduce((sum, t) => sum + t.occupancy, 0);
+                        const blockers = self._getLogicalTrips(targetVehicle.id)
+                            .filter(t => t.start < blockEnd && t.end > blockStart);
+                        const existingLoad = blockers.reduce((sum, t) => sum + t.occupancy, 0);
 
                         if (existingLoad + movingHeadcount > self.passengerSeats(targetVehicle)) {
                             const shell = document.getElementById('rp-shell');
@@ -2135,7 +2192,7 @@ function mountRoutePlannerApp(wrapper, data) {
                                 shell.style.backgroundColor = '#ffebee';
                                 setTimeout(() => { shell.style.backgroundColor = ''; }, 400);
                             }
-                            frappe.throw(self.capacityMessage(movingHeadcount, targetVehicle));
+                            frappe.throw(self.capacityMessage(movingHeadcount, targetVehicle, blockers));
                             return;
                         }
 
@@ -2378,7 +2435,12 @@ function mountRoutePlannerApp(wrapper, data) {
                             frappe.msgprint({
                                 title: __('Capacity Exceeded'),
                                 indicator: 'red',
-                                message: self.capacityMessage(card.headcount, selectedOpt.vehicle)
+                                message: self.capacityMessage(card.headcount, selectedOpt.vehicle, [{
+                                    tripName: targetTripItems.find(i => i.tripName)?.tripName || null,
+                                    occupancy: tripLoad,
+                                    start: Math.min(...targetTripItems.map(i => new Date(i.start).getTime())),
+                                    end: Math.max(...targetTripItems.map(i => new Date(i.end).getTime()))
+                                }])
                             });
                             return;
                         }
@@ -2474,25 +2536,23 @@ function mountRoutePlannerApp(wrapper, data) {
                     vehicleNumber = idx >= 0 ? idx + 1 : 1;
                 }
 
-                // Count existing unique trips on this vehicle
-                const existingTripIds = new Set();
-                this.swimItems.forEach(item => {
-                    if (item.vehicleId !== vehicleId) return;
-                    if (item.tripId) {
-                        existingTripIds.add(item.tripId);
-                    } else {
-                        existingTripIds.add(item.id);
-                    }
-                });
-                const nextSeq = existingTripIds.size + 1;
-
-                // Format: vehicleNumber + 2-digit sequence (e.g., 15 + 01 = "1501")
-                const seqStr = String(nextSeq).padStart(2, '0');
-                const tripName = `${vehicleNumber}${seqStr}`;
-
-                // Leased vehicles get "S-" prefix
+                // Format: vehicleNumber + 2-digit sequence (e.g., 15 + 01 = "1501").
+                // Leased vehicles get an "S-" prefix.
                 const prefix = vehicle.is_leased ? 'S-' : '';
-                return `${prefix}${tripName}`;
+                const name = (seq) => `${prefix}${vehicleNumber}${String(seq).padStart(2, '0')}`;
+
+                // The next FREE number, not the number of trips there are. Counting
+                // re-issued a name the moment any trip but the last was removed: a lane
+                // holding S-201, S-202, S-204, S-205 counted four and offered S-205
+                // again, so two unrelated runs ended up sharing one name on the block,
+                // in the trip picker and on the manifest.
+                const taken = new Set();
+                this.swimItems.forEach(item => {
+                    if (item.vehicleId === vehicleId && item.tripName) taken.add(item.tripName);
+                });
+                let seq = 1;
+                while (taken.has(name(seq))) seq++;
+                return name(seq);
             },
 
             // ─ Persistence (save/load to Route Plan DocType) ──────────────

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -1040,6 +1040,7 @@ def _sync_shipment_statuses(items, previously_linked=None):
                 fields=["name", "trip_direction"],
             )
         }
+        mismatched = []
         for name, placed_dirs in placed_dirs_by_shipment.items():
             own_dir = shipment_dir.get(name)
             if own_dir is None:
@@ -1047,11 +1048,22 @@ def _sync_shipment_statuses(items, previously_linked=None):
             if own_dir in placed_dirs:
                 assigned.add(name)
             else:
-                frappe.log_error(
-                    f"Skipped assigning {name}: placed as {sorted(placed_dirs)} but "
-                    f"shipment direction is {own_dir}.",
-                    "Transportation Shipment Direction Mismatch",
+                mismatched.append(
+                    f"{name}: placed as {sorted(placed_dirs)}, shipment says {own_dir}"
                 )
+
+        if mismatched:
+            # One entry per save rather than one per card. A browser holding a stale copy
+            # of the plan disagrees about every card it carries, and a hundred rows of the
+            # same fact is not a better signal than one.
+            frappe.log_error(
+                title="Transportation Shipment Direction Mismatch",
+                message=(
+                    "Left as they are - the plan still places these cards, so what needs "
+                    "looking at is the direction flag, not the status:\n\n"
+                    + "\n".join(mismatched)
+                ),
+            )
 
     for name in assigned:
         if frappe.db.get_value("Transportation Shipment", name, "status") != "Assigned":
@@ -1063,8 +1075,19 @@ def _sync_shipment_statuses(items, previously_linked=None):
         unmerge_trip_shipment,
     )
 
+    # A card the plan still places is never reverted, whatever its direction flag says.
+    # `status` answers "is this shipment on a plan", and a direction mismatch does not
+    # change that answer - it means the two sides disagree about which leg, which is a
+    # flag to fix rather than a card to send back to the pool. Reverting one that is
+    # still on a lane marked it Unassigned while its block sat there, and Generate
+    # Shipments deletes Unassigned shift-generated cards whose demand has moved on - so a
+    # browser left open across a data change could get a placed card deleted.
+    still_placed = set(placed_dirs_by_shipment)
+
     for name in (previously_linked or set()):
-        if name and name not in assigned and frappe.db.exists("Transportation Shipment", name):
+        if not name or name in assigned or name in still_placed:
+            continue
+        if frappe.db.exists("Transportation Shipment", name):
             frappe.db.set_value("Transportation Shipment", name, "status", "Unassigned")
             # A card returning to the pool takes its own direction back with it. Being
             # merged is a property of the block it was in, not of the journey the shipment

--- a/one_fm/operations/doctype/route_plan/route_plan.py
+++ b/one_fm/operations/doctype/route_plan/route_plan.py
@@ -236,8 +236,9 @@ class RoutePlan(Document):
 		(WI-002000). Two levels are enforced against the same limit:
 
 		* **Each trip on its own** — the accommodation cards merged onto one
-		  ``(vehicle, trip_group, direction)`` ride together even though their
-		  stops are sequential, so their headcounts still sum (MA4-13).
+		  ``(vehicle, trip_group)`` ride together even though their stops are
+		  sequential, so their headcounts still sum (MA4-13) — unless the run
+		  both drops off and picks up, which is walked leg by leg.
 		* **Trips that run at the same time** — when two trips' windows overlap,
 		  their passengers are on the bus together and the totals add up.
 
@@ -289,10 +290,11 @@ class RoutePlan(Document):
 	def _logical_trips(self) -> list:
 		"""Collapse the assignment rows into the trips a vehicle actually runs.
 
-		Rows sharing a ``(vehicle, trip_group, direction)`` are the stops of one
-		run: their headcounts sum and the trip spans from its first stop's start
-		to its last stop's end. A row with no ``trip_group`` is a standalone drop
-		and becomes a trip of its own, so it is weighed like any other.
+		Rows sharing a ``(vehicle, trip_group)`` are the stops of one run: their
+		headcounts sum and the trip spans from its first stop's start to its last
+		stop's end. A run whose stops do not all travel the same way is a mixed one
+		and is measured leg by leg instead. A row with no ``trip_group`` is a
+		standalone drop and becomes a trip of its own, so it is weighed like any other.
 
 		Each trip carries the daily time window its stops cover and the calendar
 		lifespan they are live for — the two halves of the timestamps a Route Plan
@@ -306,7 +308,12 @@ class RoutePlan(Document):
 			direction = _row_direction(row)
 			# Standalone rows are keyed by position so two of them never merge.
 			group = row.trip_group or f"\0row-{idx}"
-			key = (row.vehicle, group, direction)
+			# One trip group on one vehicle is one bus run, whichever way its stops
+			# travel. Keying the direction in as well split a chained run - an outward
+			# drop and the return pickup made at the same stop - into two pseudo-trips
+			# whose windows overlap each other, so the concurrency check added the same
+			# bus to itself and refused a load it was already carrying (WI-002160).
+			key = (row.vehicle, group)
 			start, end = _row_time_window(row)
 			live_from, live_to = _row_date_range(row)
 
@@ -328,6 +335,12 @@ class RoutePlan(Document):
 				continue
 
 			trip.rows.append(row)
+			# Stops that do not all travel the same way make this a mixed run, walked leg
+			# by leg instead of summed. The row's own ``direction`` only ever said MIXED
+			# when the Merge Trip modal wrote it back; chaining a return stop onto an
+			# outbound trip left every row on its original heading (WI-002160).
+			if direction != trip.direction:
+				trip.direction = MIXED_DIRECTION
 			trip.headcount += cint(row.headcount)
 			trip.start = min(trip.start, start)
 			trip.end = max(trip.end, end)
@@ -602,12 +615,24 @@ def _trip_peak(trip):
 	if trip.direction != MIXED_DIRECTION:
 		return cint(trip.headcount), 1
 
-	by_index = sorted(trip.rows, key=lambda row: (cint(row.stop_index), row.name or ""))
+	# Stop order decides the answer — the same two loads read 3 or 6 depending on
+	# whether the return riders board before or after the outward ones get off — so the
+	# order has to be the run's, not the order the rows happen to sit in. Rows carrying
+	# no stop_index fall back to when they run; the child-row name is only a last tie
+	# break, and on its own it is a random hash.
+	by_index = sorted(
+		trip.rows,
+		key=lambda row: (cint(row.stop_index), str(row.start_time or ""), row.name or ""),
+	)
 	directions = _shipment_directions([row.transportation_shipment for row in by_index])
 	stops = [
 		{
 			"headcount": cint(row.headcount),
-			"boards": directions.get(row.transportation_shipment) == "RETURN",
+			# The shipment is the authority on which way a card's own riders travel, but a
+			# row carrying no shipment still knows its own leg - read that rather than
+			# silently calling everyone outward.
+			"boards": (directions.get(row.transportation_shipment) or _row_direction(row))
+			== "RETURN",
 		}
 		for row in by_index
 	]

--- a/one_fm/operations/doctype/route_plan/test_route_plan.py
+++ b/one_fm/operations/doctype/route_plan/test_route_plan.py
@@ -397,7 +397,7 @@ class TestRoutePlanCapacitySave(FrappeTestCase):
 		doc.flags.ignore_links = True
 		return doc
 
-	def _row(self, vehicle, *, trip, direction="OUTBOUND", headcount, card=None):
+	def _row(self, vehicle, *, trip, direction="OUTBOUND", headcount, card=None, stop=None):
 		return {
 			"card_id": card or frappe.generate_hash("CARD", 8),
 			"vehicle": vehicle,
@@ -405,6 +405,10 @@ class TestRoutePlanCapacitySave(FrappeTestCase):
 			"trip_group": trip,
 			"trip_name": trip,
 			"headcount": headcount,
+			# Stop order is what the leg walk reads: the same two loads peak at 3 or at 6
+			# depending on whether the return riders board before or after the outward
+			# ones get off, so a test about a mixed run has to say which run it means.
+			"stop_index": stop,
 		}
 
 	def test_merged_camps_exceeding_seats_are_blocked(self):
@@ -428,12 +432,50 @@ class TestRoutePlanCapacitySave(FrappeTestCase):
 		plan.insert(ignore_permissions=True)
 		self.assertTrue(frappe.db.exists("Route Plan", plan.name))
 
-	def test_outbound_and_return_of_one_trip_are_counted_separately(self):
-		# Same trip_group but opposite directions are two physical runs, so each
-		# 3-seat leg is fine even though they'd overflow if summed together.
+	def test_outbound_and_return_of_one_trip_are_walked_leg_by_leg(self):
+		"""WI-002160: one trip_group on one vehicle is one bus run, not two.
+
+		A return pickup chained onto an outward drop is the same bus turning around at
+		the stop: the riders it dropped are off before the boarders get on, so 3 out
+		then 3 back fits three seats. Summing the two legs — which is what keying the
+		direction into the trip did — refused a run the bus really makes.
+		"""
 		plan = self._make_plan([
-			self._row(self.VEHICLE, trip="TRIP-BOTH", direction="OUTBOUND", headcount=3),
-			self._row(self.VEHICLE, trip="TRIP-BOTH", direction="RETURN", headcount=3),
+			self._row(self.VEHICLE, trip="TRIP-BOTH", direction="OUTBOUND", headcount=3, stop=1),
+			self._row(self.VEHICLE, trip="TRIP-BOTH", direction="RETURN", headcount=3, stop=2),
+		])
+		plan.insert(ignore_permissions=True)
+		self.assertTrue(frappe.db.exists("Route Plan", plan.name))
+
+	def test_a_return_boarding_before_the_outward_drop_still_overloads(self):
+		"""The other stop order genuinely does overload the bus, and is still refused.
+
+		Boarding the return riders at stop 1 puts them aboard alongside the outward
+		ones, who have not been dropped yet — six people on three seats.
+		"""
+		plan = self._make_plan([
+			self._row(self.VEHICLE, trip="TRIP-STACK", direction="RETURN", headcount=3, stop=1),
+			self._row(self.VEHICLE, trip="TRIP-STACK", direction="OUTBOUND", headcount=3, stop=2),
+		])
+		with self.assertRaises(frappe.ValidationError) as cm:
+			plan.insert(ignore_permissions=True)
+		self.assertIn("Capacity Exceeded on leg", str(cm.exception))
+
+	def test_a_chained_run_is_not_counted_against_itself(self):
+		"""WI-002160, the shape the dispatcher actually hit: S-204 on a 3-seat RAIZE.
+
+		One outward drop followed by two return pickups is a run that peaks at two
+		aboard, never three. Splitting it by direction made an outbound pseudo-trip of
+		1 and a return one of 2 whose windows overlapped each other, so a further
+		1-passenger run in the same window was told the bus was already full.
+		"""
+		plan = self._make_plan([
+			self._row(self.VEHICLE, trip="S-204", direction="OUTBOUND", headcount=1, stop=1),
+			self._row(self.VEHICLE, trip="S-204", direction="RETURN", headcount=1, stop=2),
+			self._row(self.VEHICLE, trip="S-204", direction="RETURN", headcount=1, stop=3),
+			# No times recorded, so every trip here spans the whole day and they all
+			# overlap — the harshest reading of "running at the same time".
+			self._row(self.VEHICLE, trip="EU-RESIDENCE", direction="RETURN", headcount=1, stop=1),
 		])
 		plan.insert(ignore_permissions=True)
 		self.assertTrue(frappe.db.exists("Route Plan", plan.name))

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -600,3 +600,4 @@ one_fm.patches.v15_0.rename_work_permit_supervisor_state #2026-08-20 WI-002097
 one_fm.patches.v15_0.add_medical_insurance_draft_state #2026-08-19 WI-002098
 one_fm.patches.v15_0.update_paci_no_payment_workflow #2026-08-19 WI-002136
 one_fm.patches.v15_0.add_paci_damj_fields #2026-08-20 WI-002109
+one_fm.patches.v15_0.mark_unflagged_mixed_trips #2026-08-25 WI-002160

--- a/one_fm/patches/v15_0/mark_unflagged_mixed_trips.py
+++ b/one_fm/patches/v15_0/mark_unflagged_mixed_trips.py
@@ -1,0 +1,94 @@
+import frappe
+from collections import defaultdict
+
+MIXED = "Mixed"
+
+# WI-002160: a run that both drops off and picks up is a Mixed trip, but only the Merge
+# Trip modal ever wrote that down. Chaining a return stop onto an outbound run through the
+# "Add Stop to which trip?" picker skipped the modal entirely, so the run kept every stop
+# on its original heading and no card recorded pre_merge_trip_direction. The canvas now
+# reads a run's direction from its stops rather than from the flag, so the seat maths is
+# right either way — but the stored data still says two things at once: the block draws in
+# the first stop's colour, and the shipments describe journeys the plan is no longer
+# running them on.
+#
+# This brings those runs up to what a real merge would have written:
+#
+#   * every assignment row of the run reads MIXED;
+#   * every shipment on it reads Mixed, with its own leg preserved in
+#     pre_merge_trip_direction so unmerge_trip_shipment can put it back when the card
+#     leaves the run.
+#
+# Only runs whose rows genuinely disagree about direction are touched. A single-direction
+# multi-stop run is not a merge and is left exactly as it is.
+#
+# `trip_group` on the shipment is deliberately not written. A real merge fills it with
+# merge_key()'s hash of the shipment names, which is a different thing from the canvas
+# trip id these rows carry, and nothing reads the shipment's copy for logic — only the
+# merge endpoint's return value is consumed, and that is not in play here.
+#
+# Rows are written with db.set_value rather than by saving the Route Plan: saving would
+# re-run the whole plan's capacity validation, and a patch must not fail because some
+# unrelated lane on a months-old plan no longer passes.
+
+
+def execute():
+	if not frappe.db.exists("DocType", "Route Plan Assignment"):
+		return
+
+	rows = frappe.get_all(
+		"Route Plan Assignment",
+		filters={"trip_group": ["!=", ""]},
+		fields=["name", "parent", "vehicle", "trip_group", "direction", "transportation_shipment"],
+	)
+
+	runs = defaultdict(list)
+	for row in rows:
+		if row.vehicle and row.trip_group:
+			runs[(row.parent, row.vehicle, row.trip_group)].append(row)
+
+	repaired = 0
+	for run in runs.values():
+		directions = {(row.direction or "").upper() for row in run}
+		# One heading means one plain run; already all MIXED means nothing to do.
+		if len(directions) < 2:
+			continue
+
+		for row in run:
+			if (row.direction or "").upper() != "MIXED":
+				frappe.db.set_value(
+					"Route Plan Assignment", row.name, "direction", "MIXED", update_modified=False
+				)
+			_mark_shipment_mixed(row.transportation_shipment)
+		repaired += 1
+
+	if repaired:
+		# No commit here: the patch runner commits, and committing inside would break
+		# the transaction a test wraps this in.
+		print(f"WI-002160: marked {repaired} un-flagged mixed run(s) as Mixed")
+
+
+def _mark_shipment_mixed(name):
+	"""Record the card's own leg, then flag it Mixed — the order a real merge uses.
+
+	Writing Mixed without first remembering the original is what stranded cards as Mixed
+	for good in WI-002071, so the remembered direction is set first and never overwritten:
+	a card already carrying one was merged before and its original is the one to keep.
+	"""
+	if not name:
+		return
+
+	shipment = frappe.db.get_value(
+		"Transportation Shipment",
+		name,
+		["trip_direction", "pre_merge_trip_direction"],
+		as_dict=True,
+	)
+	if not shipment or shipment.trip_direction == MIXED:
+		return
+
+	values = {"trip_direction": MIXED}
+	if not shipment.pre_merge_trip_direction:
+		values["pre_merge_trip_direction"] = shipment.trip_direction
+
+	frappe.db.set_value("Transportation Shipment", name, values, update_modified=False)

--- a/one_fm/tests/test_merge_preview.py
+++ b/one_fm/tests/test_merge_preview.py
@@ -264,8 +264,16 @@ class TestTheMergedBlockPaintsMixed(FrappeTestCase):
 
 	def test_a_run_is_mixed_once_any_stop_is(self):
 		# Taking the first stop's direction left a merged run reading as whatever leg
-		# happened to be placed first.
-		self.assertIn("stops.some(s => s.direction === 'MIXED') ? 'MIXED'", self.source)
+		# happened to be placed first. The block now asks runDirection, which answers
+		# MIXED whenever the stops do not all agree - so a run holding one MIXED stop is
+		# still Mixed, and so is one whose stops merely disagree, which is the shape a
+		# run chained through the trip picker has (WI-002160).
+		self.assertIn("direction: this.runDirection(stops),", self.source)
+		self.assertIn("runDirection(stops) {", self.source)
+		self.assertIn(
+			"return stops.some(s => (s.direction || 'OUTBOUND') !== first) ? 'MIXED' : first;",
+			self.source,
+		)
 
 	def test_both_block_shapes_still_show_conflict_and_overcapacity(self):
 		self.assertIn("conflict: entry.conflict", self.source)

--- a/one_fm/tests/test_one_trip_group_is_one_run.py
+++ b/one_fm/tests/test_one_trip_group_is_one_run.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002160: one trip group on one vehicle is one bus run, not two.
+
+A run that both drops off and picks up was split by direction into two pseudo-trips
+whose windows overlap each other, so the seat check added the same bus to itself: a
+1-passenger drop onto a bus carrying 2 of its 3 seats was refused as "Capacity
+Exceeded".
+
+The lane refuses a drop before the save ever sees it, so the canvas and the Route Plan
+have to read a run the same way — otherwise the operator is stopped by a rule the plan
+would have accepted, or promised a merge the save then refuses.
+"""
+
+import pathlib
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+CANVAS = pathlib.Path(frappe.get_app_path(
+	"one_fm", "one_fm", "page", "transportation_schedule", "transportation_schedule.js"
+))
+ROUTE_PLAN = pathlib.Path(frappe.get_app_path(
+	"one_fm", "operations", "doctype", "route_plan", "route_plan.py"
+))
+
+
+class TestOneTripGroupIsOneRun(FrappeTestCase):
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_the_lane_groups_a_run_by_its_trip_alone(self):
+		self.assertIn("const key = item.tripId || `_solo_${soloIdx++}`;", self.source)
+		self.assertNotIn("`${item.tripId}::${item.direction}`", self.source)
+
+	def test_stops_that_disagree_make_the_run_mixed(self):
+		self.assertIn("runDirection(stops) {", self.source)
+		self.assertIn(
+			"return stops.some(s => (s.direction || 'OUTBOUND') !== first) ? 'MIXED' : first;",
+			self.source,
+		)
+
+	def test_every_seat_check_reads_the_run_through_that_one_rule(self):
+		# The "merge this block into that trip" action re-summed the stops by hand, so
+		# it refused merges the lane and the save both accept.
+		self.assertNotIn(
+			"const tripLoad = targetTripItems.reduce((sum, i) => sum + (i.headcount || 0), 0);",
+			self.source,
+		)
+		# The three places a run is weighed against the seats: the lane's own reading,
+		# reassigning a journey to another vehicle, and merging a block into a trip.
+		self.assertIn("t.direction = this.runDirection(t.stops);", self.source)
+		self.assertIn("direction: self.runDirection(journeyItems),", self.source)
+		self.assertIn("direction: self.runDirection(targetTripItems),", self.source)
+
+	def test_the_save_reads_it_the_same_way(self):
+		source = ROUTE_PLAN.read_text()
+
+		self.assertIn("key = (row.vehicle, group)", source)
+		self.assertIn("trip.direction = MIXED_DIRECTION", source)
+
+	def test_the_leg_walk_reads_a_row_that_has_no_shipment(self):
+		# A row carrying no shipment still knows its own leg. Reading only the
+		# shipment called those riders outward and doubled the run's peak.
+		from one_fm.operations.doctype.route_plan.route_plan import _trip_peak
+
+		trip = frappe._dict(
+			direction="MIXED",
+			headcount=6,
+			rows=[
+				frappe._dict(direction="OUTBOUND", headcount=3, stop_index=1,
+							 start_time=None, name=None, transportation_shipment=None),
+				frappe._dict(direction="RETURN", headcount=3, stop_index=2,
+							 start_time=None, name=None, transportation_shipment=None),
+			],
+		)
+
+		self.assertEqual(_trip_peak(trip), (3, 1))
+
+	def test_the_leg_walk_is_not_left_to_chance(self):
+		# Stop order decides the answer — the same two loads read 3 or 6 depending on
+		# whether the return riders board before or after the outward ones get off. The
+		# child-row name is a random hash, so ordering on it alone made the check
+		# non-deterministic once a run held both directions.
+		self.assertIn('str(row.start_time or "")', ROUTE_PLAN.read_text())

--- a/one_fm/tests/test_one_trip_group_is_one_run.py
+++ b/one_fm/tests/test_one_trip_group_is_one_run.py
@@ -16,6 +16,9 @@ import pathlib
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils import today
+
+from one_fm.patches.v15_0.mark_unflagged_mixed_trips import execute as execute_mixed_patch
 
 CANVAS = pathlib.Path(frappe.get_app_path(
 	"one_fm", "one_fm", "page", "transportation_schedule", "transportation_schedule.js"
@@ -83,3 +86,185 @@ class TestOneTripGroupIsOneRun(FrappeTestCase):
 		# child-row name is a random hash, so ordering on it alone made the check
 		# non-deterministic once a run held both directions.
 		self.assertIn('str(row.start_time or "")', ROUTE_PLAN.read_text())
+
+
+class TestARunIsDrawnAsWhatItIs(FrappeTestCase):
+	"""A run reading MIXED for the seat check must not still draw as an outbound one."""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_the_block_colour_comes_from_the_same_rule(self):
+		self.assertIn("direction: this.runDirection(stops),", self.source)
+		self.assertNotIn(
+			"stops.some(s => s.direction === 'MIXED') ? 'MIXED' : firstItem.direction",
+			self.source,
+		)
+
+
+class TestARefusalNamesTheRunThatTookTheSeats(FrappeTestCase):
+	"""A card is placed at its own shift window, never where it was dropped.
+
+	So the run that blocks a drop is routinely not the block the operator was aiming at
+	— naming only the vehicle made the refusal impossible to diagnose from the screen.
+	"""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_the_message_can_name_the_blocking_runs(self):
+		self.assertIn("capacityMessage(headcount, vehicle, blockers) {", self.source)
+		self.assertIn("Those seats are held by {0}.", self.source)
+
+	def test_the_check_and_the_message_read_one_list(self):
+		# If they were computed separately they would drift, and the message would name
+		# runs the check did not actually count.
+		self.assertIn("tripsDuringCardWindows(card, vehicleId, direction) {", self.source)
+		self.assertIn(
+			"return this.tripsDuringCardWindows(card, vehicleId, direction)", self.source
+		)
+
+	def test_a_logical_trip_carries_its_name(self):
+		self.assertIn("tripName: item.tripName || null,", self.source)
+
+
+class TestTripNamesAreNotReissued(FrappeTestCase):
+	"""Removing a trip that is not the last used to hand its successor a taken name."""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_the_next_free_number_is_used_not_the_count(self):
+		self.assertIn("while (taken.has(name(seq))) seq++;", self.source)
+		self.assertNotIn("const nextSeq = existingTripIds.size + 1;", self.source)
+
+
+class TestEveryMergeGoesThroughTheMergeWindow(FrappeTestCase):
+	"""The picker used to chain a cross-direction stop without ever showing the modal."""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_a_transit_time_no_longer_skips_the_merge_window(self):
+		self.assertIn("if (self._isMergeDrop(newCard, existingItems)) {", self.source)
+		self.assertNotIn(
+			"if (!presetTransitMin && self._isMergeDrop(newCard, existingItems)) {", self.source
+		)
+
+	def test_the_picker_offers_the_nearest_run_first(self):
+		# Options were built in Route Plan Assignment row order, so a 14:15 run was the
+		# default for a 16:00 card purely because its row had been saved earlier.
+		self.assertIn("tripKeys.sort((a, b) => gapToCard(tripMap[a]) - gapToCard(tripMap[b]));", self.source)
+
+
+class TestMarkUnflaggedMixedTripsPatch(FrappeTestCase):
+	"""The runs already on the plan that were merged before the picker was fixed.
+
+	They were built by chaining a return stop onto an outbound run through the trip
+	picker, which never reached merge_trip_shipments — so the rows kept their original
+	headings and no card recorded pre_merge_trip_direction.
+	"""
+
+	VEHICLE = "VHL-L-0022"  # 4 seats -> 3 legal passenger seats
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		if not frappe.db.exists("Vehicle", cls.VEHICLE):
+			raise cls.skipTest(cls, f"Fixture vehicle {cls.VEHICLE} missing on this site")
+
+	def _shipment(self, direction):
+		doc = frappe.new_doc("Transportation Shipment")
+		doc.status = "Assigned"
+		doc.trip_direction = direction
+		doc.headcount = 1
+		doc.generation_key = frappe.generate_hash("TS-MIX", 10)
+		doc.insert(ignore_permissions=True)
+		return doc.name
+
+	def _plan(self, *legs):
+		"""One run on one vehicle; each leg is (direction, shipment)."""
+		group = frappe.generate_hash("RUN", 8)
+		doc = frappe.new_doc("Route Plan")
+		doc.title = frappe.generate_hash("RP-MIX", 8)
+		doc.status = "Draft"
+		doc.effective_from = today()
+		for index, (direction, shipment) in enumerate(legs, start=1):
+			doc.append("assignments", {
+				"card_id": f"TSHIP-{shipment}",
+				"transportation_shipment": shipment,
+				"vehicle": self.VEHICLE,
+				"direction": direction,
+				"trip_group": group,
+				"trip_name": group,
+				"stop_index": index,
+				"headcount": 1,
+			})
+		doc.flags.ignore_mandatory = True
+		doc.flags.ignore_links = True
+		doc.insert(ignore_permissions=True)
+		return doc
+
+	def _read(self, name):
+		return frappe.db.get_value(
+			"Transportation Shipment", name,
+			["trip_direction", "pre_merge_trip_direction"], as_dict=True
+		)
+
+	def test_a_run_whose_stops_disagree_is_marked_mixed(self):
+		out, ret = self._shipment("Outward"), self._shipment("Return")
+		plan = self._plan(("OUTBOUND", out), ("RETURN", ret))
+
+		execute_mixed_patch()
+
+		plan.reload()
+		self.assertEqual({row.direction for row in plan.assignments}, {"MIXED"})
+		self.assertEqual(self._read(out).trip_direction, "Mixed")
+		self.assertEqual(self._read(ret).trip_direction, "Mixed")
+
+	def test_each_card_keeps_a_record_of_the_leg_it_was_generated_for(self):
+		out, ret = self._shipment("Outward"), self._shipment("Return")
+		self._plan(("OUTBOUND", out), ("RETURN", ret))
+
+		execute_mixed_patch()
+
+		self.assertEqual(self._read(out).pre_merge_trip_direction, "Outward")
+		self.assertEqual(self._read(ret).pre_merge_trip_direction, "Return")
+
+	def test_the_repair_is_reversible(self):
+		# The card leaving the run is what calls this, and without a remembered
+		# direction it has nothing to restore from — which is how WI-002071 stranded
+		# cards as Mixed for good.
+		from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
+			unmerge_trip_shipment,
+		)
+
+		out, ret = self._shipment("Outward"), self._shipment("Return")
+		self._plan(("OUTBOUND", out), ("RETURN", ret))
+		execute_mixed_patch()
+
+		self.assertTrue(unmerge_trip_shipment(out))
+		self.assertEqual(self._read(out).trip_direction, "Outward")
+		self.assertIsNone(self._read(out).pre_merge_trip_direction)
+
+	def test_a_single_direction_run_is_left_alone(self):
+		# Several camps on one outbound run is not a merge.
+		a, b = self._shipment("Outward"), self._shipment("Outward")
+		plan = self._plan(("OUTBOUND", a), ("OUTBOUND", b))
+
+		execute_mixed_patch()
+
+		plan.reload()
+		self.assertEqual({row.direction for row in plan.assignments}, {"OUTBOUND"})
+		self.assertEqual(self._read(a).trip_direction, "Outward")
+		self.assertFalse(self._read(a).pre_merge_trip_direction)
+
+	def test_running_it_twice_does_not_overwrite_the_original_with_mixed(self):
+		out, ret = self._shipment("Outward"), self._shipment("Return")
+		self._plan(("OUTBOUND", out), ("RETURN", ret))
+
+		execute_mixed_patch()
+		execute_mixed_patch()
+
+		self.assertEqual(self._read(out).pre_merge_trip_direction, "Outward")
+		self.assertEqual(self._read(out).trip_direction, "Mixed")


### PR DESCRIPTION
Fixes [WI-002160](https://one-fm.com/app/work-item/WI-002160) — *[Irfan] Overcapacity Issues in Transportation Scheduling*.

> When adding a new trip, the system shows a capacity-exceeded error because the count is being calculated based on the previous trip. Even if there is space left in the vehicle, it is showing over-capacity error.

Two commits: the seat-reading fix, then everything that came out of testing it against a production restore with the reporter.

---

## 1. The seat reading

Dropping a 1-passenger **EU Residence Salwa** return card onto **22/32135 RAIZE** (4 seats, 3 passengers) was refused:

> Capacity Exceeded: cannot assign 1 employees to 22/32135, RAIZE — it takes 3 passengers.

The run it collided with — **S-204**, an outward drop of 1 at TAQA Kabd then two return pickups of 1 — never holds more than **2**. There was a seat for the third.

Both the canvas and the Route Plan keyed a logical trip on `(vehicle, trip_group, direction)`. That splits a run which both drops off and picks up into two pseudo-trips **whose windows overlap each other**, and the concurrency check then adds the same bus to itself:

```
S-204 outbound  1 pax  15:50–16:50   ┐ counted as
S-204 return    2 pax  16:50–17:05   ┘ two buses
new card        1 pax  16:00–17:00
                ─────
                4 > 3  →  refused
```

Only the Merge Trip modal ever wrote `MIXED` onto a row, so a return stop chained onto an outbound run left every row on its original heading. **Twenty-two runs** on the live plan have that shape.

A trip group on one vehicle is now one run whichever way its stops are headed, and a run whose stops disagree is **mixed** — walked leg by leg rather than summed. The canvas reads it through a single `runDirection()` so the places that weigh a run cannot drift; one of them was re-summing the stops by hand.

Two supporting corrections: the leg walk falls back to a row's own direction when it carries no shipment, and it orders stops by `(stop_index, start_time)` rather than by the child-row name, which is a random hash. Stop order changes the answer — the same two loads peak at 3 or at 6 depending on whether the return riders board before or after the outward ones get off — so it cannot be left to chance. That was making an existing test flaky.

## 2. What testing it turned up

**The block still drew blue.** A run reading MIXED for the seat check was drawn from its first stop's direction, because the block built its own answer instead of asking `runDirection`. That is the outbound-coloured S-204 the operator was looking at while being told the bus was full.

**The refusal named only the bus.** A card is placed at its **own shift window**, never where it was dropped — `onLaneDrop(e, vehicle)` reads nothing from the event. So the blocking run is routinely not the block being aimed at: here a 16:00 return card was refused by a 15:50 run while the operator was dropping it beside a 14:15 one, and the message gave no way to tell. It now names the runs holding the seats and when they hold them, and the check and the message read one list so they cannot disagree.

**Trip names were re-issued.** `generateTripName` used the *count* of trips plus one, so removing any trip but the last handed its successor a name already in use — a lane holding S-201, S-202, S-204, S-205 counted four and offered S-205 again. Two unrelated runs then shared a name on the block, in the trip picker and on the manifest. Already true three times over for S-106 on 60/59220. Now the next free number.

**The trip picker skipped the Merge Trip modal.** `_chainToTrip` bailed out of the merge check whenever a transit time came with the call — which is always, on the picker's path. So a cross-direction merge made through "Add Stop to which trip?" never reached `merge_trip_shipments`: the run kept every stop on its original heading and no card recorded `pre_merge_trip_direction`. **That is where the un-flagged mixed runs came from.** A merge is a merge however the operator got there.

**The picker offered the wrong default.** Options were listed in Route Plan Assignment row order, so a 14:15 run was the default for a 16:00 card purely because its row had been saved earlier — accepting the default merged the card into a run nowhere near it. Nearest run first now.

## 3. Repair patch

`mark_unflagged_mixed_trips` brings the runs already on the plan up to what a real merge would have written: every assignment row `MIXED`, every shipment `Mixed` with its own leg kept in `pre_merge_trip_direction` so `unmerge_trip_shipment` can still put it back when the card leaves the run.

Only runs whose rows genuinely disagree are touched; a single-direction multi-stop run is not a merge. `trip_group` on the shipment is deliberately left alone — a real merge fills it with `merge_key()`'s hash, which is a different thing from the canvas trip id these rows carry, and nothing reads the shipment's copy for logic.

Rows are written with `db.set_value` rather than by saving the plan: saving would re-run the whole plan's capacity validation, and a patch must not fail because some unrelated lane on a months-old plan no longer passes.

Measured against the restore before shipping:

```
runs to repair: 22    rows to flip: 101    shipments to mark Mixed: 101
shipments that would get pre_merge_trip_direction recorded: 101
would fail the leg-by-leg seat check afterwards: 0
```

Two of those pass *only* because of the leg walk — 14/95833 carries 60 riders through a 54-seat bus on trips 2801/2802, peaking at 35.

## Verification

Replayed the canvas pipeline over the live Route Plan (`RP-2026-06-1754678`, 25 lanes): the reported drop is accepted at `peakLoad 2 + 1 = 3` of 3 seats, and no lane gains a false refusal.

`test_route_plan` 64 green (run repeatedly, for the ordering fix), 18 new tests including behavioural coverage of the patch — that it is reversible through `unmerge_trip_shipment`, that it leaves single-direction runs alone, and that re-running it never overwrites a remembered direction with "Mixed". `test_merge_preview`, `test_vehicle_passenger_capacity`, `test_transportation_schedule`, `test_transportation_shipment` and `test_manifest_mixed_compiler` all green.

`test_a_run_is_mixed_once_any_stop_is` (WI-002078) pinned the exact source line this replaces. The rule it protects still holds — `runDirection` answers MIXED whenever the stops do not all agree, which covers "one stop is MIXED" and the picker-built shape as well — so it is re-pointed at the new implementation rather than dropped.

## Merge notes

- Conflicts with **#6796** on the last line of `patches.txt` — both append a patch. Resolution is to keep both lines.
- Touches `transportation_schedule.js` alongside **#6797**, about 1,000 lines apart. Test-merged: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 4. A direction mismatch no longer unassigns a placed card

Added after walking the deploy risk through with the reporter, who cannot ask every
dispatcher to reload their browser during a migrate.

`_sync_shipment_statuses` matches the direction the canvas placed a card in against the
shipment's own `trip_direction`. On a mismatch the card dropped out of `assigned` — and
the revert branch treats anything not in `assigned` as **dropped from the plan**, so a
card still sitting on its lane was marked Unassigned and unmerged.

That fires whenever the browser's copy of the plan disagrees with the shipment: a tab
left open across this patch, a tab left open across someone else's merge, or two people
editing the board at once. It is not cosmetic, because the generator prunes on exactly
that field:

```python
filters={"source_doctype": "Operations Shift", "status": "Unassigned"}
...
frappe.delete_doc("Transportation Shipment", row.name, ignore_permissions=True, force=True)
```

All 101 cards the repair patch touches are shift-generated, so a stale tab followed by
someone pressing **Generate Shipments** could have deleted a placed card.

`status` answers "is this shipment on a plan". A direction mismatch does not change that
answer — it means the two sides disagree about which *leg*, which is a flag to look at,
not a card to send back to the pool. So a card the save still places is never reverted,
whatever flag it carries. The guard the check exists for is untouched: a mismatch still
never promotes a card to Assigned, it only no longer demotes one. Cards the plan
genuinely dropped revert exactly as before, with their own direction restored.

The log is also batched to one entry per save instead of one per card — a stale browser
disagrees about every card it carries.

**Replayed on the restore:** run the patch, then save from a browser still holding the
pre-patch directions. Every one of the 22 runs keeps its status, its `Mixed` direction
and its remembered leg; the save writes a single Error Log entry and changes nothing
else. Three of S-204's shipments are already sitting Unassigned on that restore with
their blocks on the lane — this bug having already fired during testing.

With this in, `bench migrate` no longer needs a quiet window or a reload drill.