### PR TITLE
WI-002161: a night shift's card shows the shift it actually covers

### DIFF
--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -919,7 +919,15 @@ def _build_transportation_shipment_cards(fmt, to_utc, get_coords_cached, timedel
 
             dep_utc = to_utc(str(dep))
             ret_utc = to_utc(str(ret))
-            if ret_utc <= dep_utc:
+            # A night shift finishes the morning after it starts, so its end time is
+            # legitimately earlier on the clock than its start. Reading that as a broken
+            # window and replacing it with "start + 1 hour" is why a 19:00-07:00 shift
+            # advertised a 20:00 finish on its card (WI-002161). The canvas is a rolling
+            # 24h view of one day's runs — the 07:00 pickup and the 19:00 drop both belong
+            # on it — so the end keeps its own time of day rather than rolling onto
+            # tomorrow's date and off the axis. Only a shift with no length recorded at
+            # all still needs a fallback.
+            if ret_utc == dep_utc:
                 ret_utc = dep_utc + timedelta(hours=1)
 
             stop_coords = get_coords_cached("Location", s.stop_location) if s.stop_location else None

--- a/one_fm/tests/test_shipment_card_window.py
+++ b/one_fm/tests/test_shipment_card_window.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002161: the shift window a Transportation Shipment card advertises.
+
+Security-Sawaber Credit Office-Night-1 runs 19:00 to 07:00, and its card said
+19:00-20:00. A night shift finishes the morning after it starts, so its end time is
+legitimately earlier on the clock than its start; reading that as a broken window and
+replacing it with "start plus an hour" is what invented the 20:00.
+"""
+
+from datetime import timedelta
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import get_datetime, today
+
+from one_fm.one_fm.page.transportation_schedule.transportation_schedule import (
+	_build_transportation_shipment_cards,
+)
+
+
+def _cards_for(shipment_name):
+	"""Run the real card builder and pick out one shipment's card.
+
+	``to_utc`` is handed in naive rather than timezone-aware: what is under test is
+	whether an end time earlier on the clock than its start is read as "the next
+	morning" or as "broken", and that comparison is the same in any timezone.
+	"""
+	cards = _build_transportation_shipment_cards(
+		fmt=lambda dt: dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+		to_utc=lambda value: get_datetime(f"{today()} {value}"),
+		get_coords_cached=lambda *args: None,
+		timedelta=timedelta,
+	)
+	return next(c for c in cards if c["shipment"] == shipment_name)
+
+
+def _shipment(start, end, direction="Outward"):
+	doc = frappe.new_doc("Transportation Shipment")
+	doc.status = "Unassigned"
+	doc.trip_direction = direction
+	doc.start_time = start
+	doc.end_time = end
+	doc.headcount = 1
+	doc.generation_key = frappe.generate_hash("TS-WINDOW", 10)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+class TestNightShiftCardWindow(FrappeTestCase):
+	def _times(self, card):
+		return card["shift_start"][11:16], card["shift_end"][11:16]
+
+	def test_a_night_shift_card_shows_the_shift_it_covers(self):
+		# The reported card: 19:00-07:00 was drawn as 19:00-20:00.
+		card = _cards_for(_shipment("19:00:00", "07:00:00"))
+
+		self.assertEqual(self._times(card), ("19:00", "07:00"))
+
+	def test_a_day_shift_is_unchanged(self):
+		card = _cards_for(_shipment("07:00:00", "19:00:00"))
+
+		self.assertEqual(self._times(card), ("07:00", "19:00"))
+
+	def test_a_shift_with_no_length_recorded_still_gets_an_hour(self):
+		# The one case the old guard was right about: identical start and end says
+		# nothing about how long the shift is, so the card keeps a nominal hour
+		# rather than collapsing to a zero-width window.
+		card = _cards_for(_shipment("08:00:00", "08:00:00"))
+
+		self.assertEqual(self._times(card), ("08:00", "09:00"))
+
+	def test_the_return_leg_is_collected_when_the_night_shift_ends(self):
+		# The pickup window is what the placement reads, so it has to move with the
+		# corrected end time and not stay pinned an hour after the drop.
+		card = _cards_for(_shipment("19:00:00", "07:00:00", direction="Return"))
+
+		self.assertEqual(card["return_window_start"][11:16], "07:00")


### PR DESCRIPTION
Fixes [WI-002161](https://one-fm.com/app/work-item/WI-002161) — *[Irfan] Shift Card Timing Issue*. HD tickets [1807461](https://one-fm.com/app/hd-ticket/1807461) and [1806397](https://one-fm.com/app/hd-ticket/1806397).

> Transportation Shipment Cards are showing wrong Shift Start Time and End Time.
> Operations Shift: Security-Sawaber Credit Office-Night-1 (In Transportation Shipment, it shows as Shift Start: 19:00, Shift End: 20:00)

## Root cause

The data was right all along. On the restore:

| | start | end |
|---|---|---|
| Operations Shift `Security-Sawaber Credit Office-Night-1` | 19:00 | 07:00 |
| Transportation Shipment `TS-0875` / `TS-0876` | 19:00 | 07:00 |
| Card on the canvas | 19:00 | **20:00** |

The card builder invented the 20:00:

```python
if ret_utc <= dep_utc:
    ret_utc = dep_utc + timedelta(hours=1)
```

A night shift finishes the morning after it starts, so its end time is legitimately earlier on the clock than its start. That guard read it as a broken window and replaced it with *start plus an hour* — which is where every overnight card's one-hour shift came from, not just Sawaber's.

## The fix

The canvas is a rolling 24h view of one day's runs — the 07:00 pickup and the 19:00 drop both belong on it — so the end keeps its own time of day rather than rolling onto tomorrow's date and off the visible axis.

The one case the old guard was right about survives: a shift recorded with an identical start and end says nothing about its length, so it still gets a nominal hour instead of collapsing to a zero-width window.

The return pickup window (`return_window_start`) moves with the corrected end time, so an overnight return leg is collected at 07:00 rather than an hour after the drop. `shift_start` / `shift_end` are display and filter values only — nothing computes a duration from them.

## Verification

Against the production restore, via the real `get_route_planner_data()`:

```
Security-Sawaber Credit Office-Night-1   19:00 -> 07:00   (was 19:00 -> 20:00)
Security-Sawaber Credit Office-Day-1     07:00 -> 19:00   (unchanged)
```

and a sweep of every card on the site: **none** still advertises a one-hour window its Operations Shift does not have.

4 new tests; `test_transportation_schedule` unchanged and green.

## Note

`create_shipment_pair` in the same module has the same overnight blind spot, but it belongs to `optimize_transportation_routes` (the Google route-optimizer path), not to the shipment cards this ticket is about. Left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)