### PR TITLE
WI-002162: the transport team can refresh its own shipment cards

### DIFF
--- a/one_fm/one_fm/doctype/transportation_shipment/shipment_generator.py
+++ b/one_fm/one_fm/doctype/transportation_shipment/shipment_generator.py
@@ -33,6 +33,8 @@ COMPANY_FLEET = "Company Fleet"
 MAHBOULA_LABELS = {"Mahboula 3", "Mahboula 12", "Mahboula 13", "Mahboula 15"}
 # Return riders may finish up to an hour after the outbound leg departs.
 RETURN_MATCH_FLOOR_SECONDS = -3600
+# Who may refresh the shipment cards from the canvas (WI-002162).
+GENERATE_ROLES = ("System Manager", "Transportation Manager", "Transportation Supervisor")
 
 
 def _minute_of_day(time_val) -> int | None:
@@ -326,9 +328,12 @@ def generate_transportation_shipments():
 	Entry point for both the daily scheduler and the canvas "Generate" button.
 	Returns a summary dict of what changed.
 	"""
-	# The scheduler runs as Administrator; guard interactive/API calls.
+	# The scheduler runs as Administrator; guard interactive/API calls. The button
+	# lives on the Transportation Schedule canvas, which is the transport team's own
+	# board, so the roles that run it may refresh their own cards (WI-002162) instead
+	# of having to ask a System Manager.
 	if frappe.session.user != "Administrator":
-		frappe.only_for("System Manager")
+		frappe.only_for(GENERATE_ROLES)
 
 	nested_map = get_grouped_employees_by_accommodation()
 	demands = build_demand_descriptors(nested_map)

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -600,3 +600,4 @@ one_fm.patches.v15_0.rename_work_permit_supervisor_state #2026-08-20 WI-002097
 one_fm.patches.v15_0.add_medical_insurance_draft_state #2026-08-19 WI-002098
 one_fm.patches.v15_0.update_paci_no_payment_workflow #2026-08-19 WI-002136
 one_fm.patches.v15_0.add_paci_damj_fields #2026-08-20 WI-002109
+one_fm.patches.v15_0.grant_transportation_manager_schedule_access #2026-08-24 WI-002162

--- a/one_fm/patches/v15_0/grant_transportation_manager_schedule_access.py
+++ b/one_fm/patches/v15_0/grant_transportation_manager_schedule_access.py
@@ -1,0 +1,74 @@
+import frappe
+
+PAGE = "transportation-schedule"
+ROLE = "Transportation Manager"
+# What Transportation Supervisor already holds on Route Plan, mirrored rather than
+# invented so the two transport roles work the same board the same way.
+ROUTE_PLAN_PERMS = {
+	"select": 1, "read": 1, "write": 1, "create": 1, "delete": 1,
+	"report": 1, "export": 1, "share": 1, "print": 1, "email": 1,
+}
+
+
+def execute():
+	"""Let Transportation Manager open and run the Transportation Schedule (WI-002162).
+
+	The AC is that Transportation Manager and Transportation Supervisor may click
+	"Generate Shipments" and update the shipment cards. Relaxing the whitelisted
+	method's role gate is only half of it: the page itself is role-restricted and the
+	plan behind it is a Route Plan, so without these two grants a Transportation
+	Manager never reaches the button to be refused by it.
+
+	Transportation Supervisor already holds both and is left alone. Nothing is granted
+	on Transportation Shipment: the generator writes those with ignore_permissions and
+	the canvas reads them server-side, which is how the Supervisor already works.
+	"""
+	if not frappe.db.exists("Role", ROLE):
+		return
+
+	_grant_page_role()
+	_grant_route_plan_perms()
+	frappe.clear_cache()
+
+
+def _grant_page_role():
+	"""Add the role to the page's Custom Role, creating the record if there is none."""
+	name = frappe.db.get_value("Custom Role", {"page": PAGE}, "name")
+	if not name:
+		# No Custom Role means the Page's own roles still apply; carry them over so
+		# creating one here does not quietly lock the current holders out.
+		page = frappe.get_doc("Page", PAGE)
+		doc = frappe.new_doc(doctype="Custom Role")
+		doc.page = PAGE
+		for row in page.roles:
+			doc.append("roles", {"role": row.role})
+		doc.append("roles", {"role": ROLE})
+		doc.insert(ignore_permissions=True)
+		return
+
+	doc = frappe.get_doc("Custom Role", name)
+	if any(row.role == ROLE for row in doc.roles):
+		return
+	doc.append("roles", {"role": ROLE})
+	doc.save(ignore_permissions=True)
+
+
+def _grant_route_plan_perms():
+	"""Give the role real access to Route Plan.
+
+	Route Plan already carries Custom DocPerm rows, and once any exist Frappe stops
+	honouring the DocType JSON's permissions for every other role — so the grant has
+	to be a Custom DocPerm too, not an entry in the JSON.
+	"""
+	if frappe.db.exists("Custom DocPerm", {"parent": "Route Plan", "role": ROLE}):
+		return
+
+	frappe.get_doc({
+		"doctype": "Custom DocPerm",
+		"parent": "Route Plan",
+		"parenttype": "DocType",
+		"parentfield": "permissions",
+		"role": ROLE,
+		"permlevel": 0,
+		**ROUTE_PLAN_PERMS,
+	}).insert(ignore_permissions=True)

--- a/one_fm/tests/test_generate_shipments_access.py
+++ b/one_fm/tests/test_generate_shipments_access.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002162: who may press "Generate Shipments" on the Transportation Schedule.
+
+The button lives on the transport team's own board, but the whitelisted method behind
+it was gated on System Manager, so the supervisor running the board was told "You do
+not have enough permissions to access this resource".
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.one_fm.doctype.transportation_shipment.shipment_generator import GENERATE_ROLES
+from one_fm.patches.v15_0.grant_transportation_manager_schedule_access import execute
+
+ROLE = "Transportation Manager"
+
+
+class TestGenerateShipmentsIsTheTransportTeams(FrappeTestCase):
+	def test_both_transport_roles_may_refresh_the_cards(self):
+		self.assertIn("Transportation Manager", GENERATE_ROLES)
+		self.assertIn("Transportation Supervisor", GENERATE_ROLES)
+
+	def test_system_manager_keeps_the_access_it_had(self):
+		self.assertIn("System Manager", GENERATE_ROLES)
+
+	def _page_roles(self):
+		name = frappe.db.get_value("Custom Role", {"page": "transportation-schedule"}, "name")
+		return [row.role for row in frappe.get_doc("Custom Role", name).roles]
+
+	def test_the_patch_opens_the_page_and_the_plan_to_the_manager(self):
+		# Relaxing the method's role gate alone is not enough: the page is
+		# role-restricted and the board is a Route Plan, so without both grants a
+		# Transportation Manager never reaches the button to be refused by it.
+		if not frappe.db.exists("Role", ROLE):
+			self.skipTest(f"{ROLE} role missing on this site")
+
+		execute()
+
+		roles = self._page_roles()
+		self.assertIn(ROLE, roles)
+		self.assertIn("Transportation Supervisor", roles)  # not disturbed
+		self.assertTrue(frappe.db.exists(
+			"Custom DocPerm", {"parent": "Route Plan", "role": ROLE}
+		))
+
+	def test_running_the_patch_twice_grants_nothing_twice(self):
+		if not frappe.db.exists("Role", ROLE):
+			self.skipTest(f"{ROLE} role missing on this site")
+
+		execute()
+		execute()
+
+		self.assertEqual(self._page_roles().count(ROLE), 1)
+		self.assertEqual(frappe.db.count(
+			"Custom DocPerm", {"parent": "Route Plan", "role": ROLE}
+		), 1)


### PR DESCRIPTION
Fixes [WI-002162](https://one-fm.com/app/work-item/WI-002162) — *[Irfan] Generate Shipment Cards*.

> Transportation Manager and Transportation Supervisors should have access to click the "Generate Shipments" button and update the Shipment Cards.

## The report

`i.anware@one-fm.com` — who holds both Transportation Manager and Transportation Supervisor — presses **Generate Shipments** on the Transportation Schedule and gets:

> **Not permitted** — You do not have enough permissions to access this resource. Please contact your manager to get access.

`generate_transportation_shipments` was gated on `frappe.only_for("System Manager")`, so the person running the board had to ask someone else to press the button on it.

## The fix

Both transport roles may now run it, alongside System Manager. The scheduler still runs as Administrator and is unaffected.

Relaxing the role gate is only half of it. The page is role-restricted and the board it saves to is a Route Plan, and on the restore neither listed Transportation Manager:

| | before |
|---|---|
| Custom Role for page `transportation-schedule` | System Manager, Fleet Manager, Transportation **Supervisor** |
| Custom DocPerm on Route Plan | System Manager, Operations Manager, Transportation **Supervisor** |

So without those grants a Transportation Manager never reaches the button to be refused by it, and the AC would still read as failing. A patch adds the role to both — **Custom DocPerm** rather than the DocType JSON, because Route Plan already carries Custom DocPerm rows and Frappe stops honouring the JSON for every other role once any exist. Transportation Supervisor already holds both and is left untouched.

Nothing is granted on Transportation Shipment: the generator writes those with `ignore_permissions` and the canvas reads them server-side, which is how the Supervisor already works today. The patch is idempotent, and if the page ever has no Custom Role it carries the Page's own roles across rather than quietly locking the current holders out.

## Verification

4 new tests, including running the patch twice and asserting nothing is granted twice. `test_transportation_shipment` unchanged and green.

`frappe.only_for` is a no-op under `flags.in_test`, so the role gate itself is asserted through the `GENERATE_ROLES` constant it reads; the patch is exercised for real.

## To deploy

`bench migrate` — the grants land through the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)