### PR TITLE
fix(transportation-schedule): redraw a saved run on one day, not two

### DIFF
--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
@@ -2558,22 +2558,46 @@ function mountRoutePlannerApp(wrapper, data) {
                     return endDate >= todayStr;   // drop lapsed (release the lane)
                 });
 
-                // Rebase EACH block onto today's timeline independently, then
-                // re-derive its end from the daily trip length. Every block now
-                // carries its own lifespan start date (the DATE part of start_time),
-                // so a single shared offset is wrong: one block whose start sits in
-                // the past — an ongoing multi-day lock, or a row edited to a past
-                // date — would otherwise drag every block off-screen and blank the
-                // whole grid. Shifting per block by whole days (which preserves the
-                // UTC time-of-day, and so the render position) keeps each one in the
-                // current window on its own.
+                // Rebase onto today's timeline by whole days, which preserves the UTC
+                // time-of-day and so the render position. A single shared offset is wrong
+                // — every block carries its own lifespan start date (the DATE part of
+                // start_time), and one block sitting in the past would drag every other
+                // one off-screen — so each block is moved on its own first.
+                //
+                // Blocks land on TODAY, not merely somewhere inside the window: planStart
+                // carries a 3h margin before today's local midnight, and a shift that only
+                // had to reach planStart let a stop whose time of day falls in that margin
+                // — 21:00 to midnight local — settle a day early, off the visible axis.
+                const todayStart = this.planStart.getTime() + (3 * 3600000);
+                const dayShift = (startMs) => -Math.floor((startMs - todayStart) / dayMs) * dayMs;
                 parsedItems = parsedItems.map(i => {
-                    let startMs = i.start.getTime();
-                    if (startMs < this.planStart.getTime()) {
-                        startMs += Math.ceil((this.planStart.getTime() - startMs) / dayMs) * dayMs;
-                    } else if (startMs > this.planEnd.getTime()) {
-                        startMs -= Math.ceil((startMs - this.planEnd.getTime()) / dayMs) * dayMs;
+                    const startMs = i.start.getTime();
+                    return { ...i, start: new Date(startMs + dayShift(startMs)) };
+                });
+
+                // Then pull each trip back onto one day. The plan window is ~30h wide, so
+                // a run straddling its edge came back with its first stop shifted three
+                // days and the rest two — a 45-minute trip torn into a band nearly a day
+                // wide, which then "overlapped" every other run on the lane and painted
+                // them overcapacity. The stops of one run are hours apart at most, so each
+                // takes the day that puts it NEAREST its trip's first stop: the time of
+                // day is untouched and a stop that legitimately sits a little before stop
+                // one (a leg re-timed after it was dropped) stays where it is instead of
+                // being flung a day forward.
+                const tripAnchor = {};
+                parsedItems.forEach(i => {
+                    if (!i.tripId) return;
+                    const idx = i.stopIndex || 0;
+                    const ms = i.start.getTime();
+                    const held = tripAnchor[i.tripId];
+                    if (!held || idx < held.idx || (idx === held.idx && ms < held.ms)) {
+                        tripAnchor[i.tripId] = { idx, ms };
                     }
+                });
+                parsedItems = parsedItems.map(i => {
+                    const anchor = i.tripId ? tripAnchor[i.tripId] : null;
+                    let startMs = i.start.getTime();
+                    if (anchor) startMs += Math.round((anchor.ms - startMs) / dayMs) * dayMs;
                     const start = new Date(startMs);
                     const end = new Date(startMs + i._dailyDurMs);
                     return { ...i, start, end };

--- a/one_fm/tests/test_lane_day_rebase.py
+++ b/one_fm/tests/test_lane_day_rebase.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""A saved run is redrawn on today's lane, and its stops must land on the same day.
+
+Route Plan Assignment timestamps carry two things: the TIME is the daily trip window,
+the DATE is the multi-day lock lifespan. The canvas therefore shifts every block onto
+today by whole days. Two faults came out of doing that per block:
+
+* The plan window is about thirty hours wide, so a run sitting across its edge had its
+  first stop shifted three days and the rest two — a 45-minute trip redrawn as a band
+  nearly a day wide, which then overlapped every other run on the lane and painted them
+  Overcapacity (reported on 23/79322, trips S-1701 and S-1703).
+* Reaching the window was not the same as reaching today: planStart carries a 3h margin
+  before today's local midnight, so a stop whose time of day fell in that margin settled
+  a day early and rendered off the visible axis.
+"""
+
+import pathlib
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+CANVAS = pathlib.Path(frappe.get_app_path(
+	"one_fm", "one_fm", "page", "transportation_schedule", "transportation_schedule.js"
+))
+
+
+class TestATripComesBackInOnePiece(FrappeTestCase):
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_every_block_lands_on_today_at_its_own_time_of_day(self):
+		self.assertIn(
+			"const todayStart = this.planStart.getTime() + (3 * 3600000);", self.source
+		)
+		self.assertIn(
+			"const dayShift = (startMs) => -Math.floor((startMs - todayStart) / dayMs) * dayMs;",
+			self.source,
+		)
+		self.assertIn("return { ...i, start: new Date(startMs + dayShift(startMs)) };", self.source)
+
+	def test_a_trip_is_then_pulled_onto_one_day(self):
+		self.assertIn("const tripAnchor = {};", self.source)
+		self.assertIn(
+			"if (anchor) startMs += Math.round((anchor.ms - startMs) / dayMs) * dayMs;",
+			self.source,
+		)
+
+	def test_the_day_is_the_nearest_one_not_the_next_one(self):
+		# Rounding, not flooring. The stops of one trip carry unrelated save-dates —
+		# S-102's stop 3 was saved 20 days after its stop 1 — so a stop that ends up
+		# slightly before stop one must stay where it is. Pushing it forward a day put
+		# the run back across the whole lane, which is the fault this is fixing.
+		self.assertNotIn("Math.ceil((anchor.ms - startMs)", self.source)
+		self.assertIn("Math.round((anchor.ms - startMs)", self.source)
+
+	def test_the_shift_is_not_decided_by_the_trips_earliest_stamp(self):
+		# Anchoring on the earliest raw timestamp reads the lock lifespan as if it were
+		# the run's date, so a trip whose stops were saved on different days is dragged
+		# apart by the difference between them.
+		self.assertNotIn("tripShift[i.tripId] = { earliest", self.source)


### PR DESCRIPTION
No work item — reported by @yusuffGoodie alongside WI-002160 while reproducing it on a production restore. Separate root cause, so it ships on its own.

## The report

On lane **23/79322** (Coaster, 22 seats), trips **S-1701** and **S-1703** were painted **Overcapacity** purple — 18 and 17 passengers against 22 seats, with nothing else on the lane at those hours. A long purple dashed band ran across the whole lane behind them.

No trip was over its seats. The lane was reading a *fourth* run as though it lasted all day.

## Root cause

A Route Plan Assignment timestamp carries two things: the **TIME** is the daily trip window, the **DATE** is the multi-day lock lifespan. So the canvas shifts every block onto today by whole days. Doing that per block tore a run apart.

S-1704's stops sit across the plan window's edge (`planStart` = local midnight − 3h):

| stop | stored | days needed | landed |
|---|---|---|---|
| 1 | `08-21T17:15Z` | +3 | `08-24 17:15` |
| 2 | `08-21T18:05Z` | +2 | `08-23 18:05` |
| 3 | `08-21T18:10Z` | +2 | `08-23 18:10` |
| 4 | `08-21T18:30Z` | +2 | `08-23 18:30` |

A 45-minute run came back as a band spanning **23 hours** — which then overlapped every other run on the lane and lent them its 9 passengers: `18 + 9 = 27 > 22`, `17 + 9 = 26 > 22`. Exactly the two trips in the screenshot.

## The fix

Blocks are still moved one at a time — each carries its own lifespan date, and one block sitting in the past would drag the rest off-screen — but each **trip** is then pulled back onto a single day: every stop takes the day that puts it **nearest its trip's first stop**.

Nearest, not next. The stops of one trip carry unrelated save-dates — S-102's third stop was saved twenty days after its first, S-501's stops span two dates — so a stop that lands slightly *before* stop one has to stay where it is. An earlier attempt at this (on the stale `overcapacity-bug` branch, never opened as a PR) anchored the whole trip on its earliest raw timestamp, which reads the lock lifespan as if it were the run's date; replayed against the live plan that cleared 23/79322 but painted **five other lanes** overcapacity instead — 60/59220, 22/17293, 23/79106, 23/79494, 15/58303. There is a regression test for that specific mistake.

That branch did have one idea worth keeping, and it is carried over here: the shift anchors on today's **local midnight** rather than on `planStart`, which carries a 3h margin before it. Reaching the window was not the same as reaching today — a stop whose time of day fell in that margin (21:00 to midnight local) settled a day early and rendered off the visible axis.

## Verification

Replayed the canvas pipeline over the live Route Plan (`RP-2026-06-1754678`, 25 lanes), before and after, on the same clock:

| | before | after |
|---|---|---|
| lanes painted Overcapacity | `23/79322 [S-1701, S-1703]` | **none** |
| blocks landing off today's axis | — | **none** |
| longest trip span | ~24h | 2.5h |

4 new tests; `test_merge_preview` unchanged and green.

## Interaction with #6794

Both touch `transportation_schedule.js`, about 1,100 lines apart. Test-merged locally: clean, and the result is byte-identical to the combined version the numbers above were measured on. Either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)