### PR TITLE
WI-002069: add the GRD operator holder the BA site added after the migration

### DIFF
--- a/one_fm/patches/v15_0/migrate_visa_request_visibility.py
+++ b/one_fm/patches/v15_0/migrate_visa_request_visibility.py
@@ -36,6 +36,12 @@ GATED_FIELDS = (
 MOI_STATE = "Pending By MOI"
 
 
+# WI-002069 (third pass): a Link the BA site added after the migration. Hidden there, and
+# nothing on that site reads it yet - no assignment rule takes its assignee from it and no
+# script mentions it - so it comes across as the empty holder it currently is.
+NEW_FIELD = "assign_grd_operator"
+
+
 def execute():
 	frappe.reload_doc("visa_management", "doctype", "visa_request")
 
@@ -59,6 +65,9 @@ def verify():
 			frappe.throw(f"WI-002069: Visa Request has no {fieldname} field.")
 		if not field.depends_on:
 			frappe.throw(f"WI-002069: {fieldname} did not get its visibility rule.")
+
+	if not meta.get_field(NEW_FIELD):
+		frappe.throw(f"WI-002069: Visa Request has no {NEW_FIELD} field.")
 
 	for fieldname in READ_ONLY_FIELDS:
 		field = meta.get_field(fieldname)

--- a/one_fm/visa_management/doctype/visa_request/test_visa_request_visibility.py
+++ b/one_fm/visa_management/doctype/visa_request/test_visa_request_visibility.py
@@ -19,6 +19,33 @@ MOI_STATE = "Pending By MOI"
 # as a fieldname and quietly treats as false.
 DISABLED_RULES = ("custom_pam_file", "pam_reference_number", "custom_pam_designation_list")
 
+# Every field the BA site's Visa Request carries. A local addition (reapplied_from) is not
+# listed - this pins that nothing of theirs is missing, not that nothing of ours is extra.
+BA_FIELDS = (
+	"section_break_mbv7", "naming_series", "job_offer", "candidate_country_process",
+	"job_applicant", "column_break_vujs", "request_date", "job_applicant_full_name", "agency",
+	"assign_grd_operator", "applicant_details_section", "first_name", "second_name",
+	"third_name", "last_name", "first_name_in_arabic", "second_name_in_arabic",
+	"third_name_in_arabic", "last_name_in_arabic", "column_break_kupi", "nationality", "gender",
+	"religion", "place_of_birth", "date_of_birth", "marital_status", "designation",
+	"salary_details_section", "salary_type", "column_break_lzkz", "work_permit_salary",
+	"educational_qualification_details_section", "educational_qualification",
+	"education_specialization", "column_break_rlpq", "university", "place_of_study",
+	"passport_details_section", "passport_number", "passport_holder_of", "place_of_issue",
+	"column_break_wims", "passport_issued_on", "passport_expires_on", "attachments",
+	"passport_copy", "column_break_sqvj", "driver_license", "column_break_byjf",
+	"degree_certificate", "column_break_wjxj", "rejection_remarks_section", "column_break_cpvu",
+	"operator_rejection_remark", "grd_manager_remark", "column_break_jdrk",
+	"pam_rejection_remark", "moi_rejection_remark", "pam_details_section", "custom_pam_file",
+	"pam_reference_number", "custom_visa_application_date", "column_break_gvey",
+	"custom_pam_designation_list", "custom_work_permit_number", "pam_remarks",
+	"column_break_gcih", "pam_decision_date", "moi_details_section", "moi_reference_number",
+	"column_break_jvjp", "moi_remarks", "column_break_hyho", "moi_decision_date",
+	"visa_details_section", "visa_reference_number", "visa_issue_date", "visa_expiry_date",
+	"column_break_uxnb", "visa_document", "payment_receipt", "payment_date",
+	"section_break_jrbe", "amended_from",
+)
+
 # Every field the BA site locks once the request has moved past the step that fills it in.
 # A reference number still editable three states later is one an operator can quietly change
 # after the ministry has it.
@@ -122,6 +149,24 @@ class TestVisaRequestVisibility(FrappeTestCase):
 				self.assertIn("Completed", named)
 				# Still editable at the step that fills them in.
 				self.assertNotIn("Pending Visa Issuance", named)
+
+	def test_the_doctype_carries_every_field_the_ba_site_has(self):
+		"""Pinned as a list rather than a count, so a field added on the BA site and missed
+		here names itself instead of showing up as an off-by-one."""
+		meta_fields = {f.fieldname for f in self.meta.fields}
+		for fieldname in BA_FIELDS:
+			with self.subTest(fieldname=fieldname):
+				self.assertIn(fieldname, meta_fields)
+
+	def test_the_grd_operator_holder_is_present_and_hidden(self):
+		"""Added on the BA site after the first migration pass. Nothing reads it there yet -
+		no assignment rule takes its assignee from it, no script mentions it - so it is an
+		empty holder, and it is hidden the way the BA site hides it."""
+		field = self.meta.get_field("assign_grd_operator")
+		self.assertIsNotNone(field)
+		self.assertEqual(field.fieldtype, "Link")
+		self.assertEqual(field.options, "User")
+		self.assertTrue(field.hidden)
 
 	def test_the_remark_fields_match_the_ba_site(self):
 		self.assertTrue(self.meta.get_field("operator_rejection_remark").read_only)

--- a/one_fm/visa_management/doctype/visa_request/visa_request.json
+++ b/one_fm/visa_management/doctype/visa_request/visa_request.json
@@ -15,6 +15,7 @@
   "request_date",
   "job_applicant_full_name",
   "agency",
+  "assign_grd_operator",
   "applicant_details_section",
   "first_name",
   "second_name",
@@ -587,13 +588,20 @@
    "fieldtype": "Datetime",
    "label": "Payment Date",
    "read_only_depends_on": "eval:doc.workflow_state==\"Completed\" || doc.workflow_state==\"Rejected for Re Issue\" || doc.workflow_state==\"Awaiting Visa Cancellation\" || doc.workflow_state==\"Pending Cancel Work Permit\" || doc.workflow_state==\"Work Permit Cancelled\" || doc.workflow_state==\"Pending Recruiter Confirmation\""
+  },
+  {
+   "fieldname": "assign_grd_operator",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Assign GRD Operator",
+   "options": "User"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-24 12:00:00.000000",
+ "modified": "2026-08-24 14:00:00.000000",
  "modified_by": "Administrator",
  "module": "Visa Management",
  "name": "Visa Request",


### PR DESCRIPTION
[WI-002069] Migrate Visa Request Doctype from BA Site to Staging — third pass, following **#6766** and **#6793** (both merged).

## The new field

**`assign_grd_operator`** — Link → User, **hidden**, sitting after `agency`. It appeared on the BA site after the earlier passes had already compared the two doctypes.

It comes across as the empty holder it currently is. I checked what reads it on the BA site before adding it:

| | |
|---|---|
| Assignment rules on Visa Request | 7, **none** use it — all seven assign on `owner` |
| Client Scripts | 21, **0** mention it |
| Server Scripts | 192, **0** mention it |

So no rule or script needs to come with it. If it's meant to drive an assignment rule later, that rule isn't on the BA site yet — tell me when it is and I'll bring it over.

## Everything else is clean

I re-diffed across **every attribute** Frappe stores on a DocField, plus the doctype's own properties. After this change the only remaining differences are the two known, deliberate ones:

- the MOI state spelling (`Pending By MOI` here vs `Pending by MOI` there — this site's workflow uses the former, and a rule naming a state that doesn't exist never fires)
- BA lists `Rejected By MOI` twice in one `depends_on`; same set of states, no behavioural difference

`reapplied_from` remains a local-only addition from earlier work and is untouched.

## Closing the gap that let this through

The test now pins the BA site's field list **by name — all 84** — rather than leaving field presence uncompared. A field added there and missed here will now name itself in a failing test instead of going unnoticed. That's the same class of gap that produced the missing `read_only_depends_on` rules in #6793, so it's worth having a guard rather than another apology.

## Deploy

`bench migrate` — `migrate_visa_request_visibility` reloads the doctype and now also asserts the new field arrived.

## Tests

`test_visa_request_visibility` — **14 passing** (2 new: every BA field present, and the new field being a hidden Link to User). `one_fm.tests.test_visa_request_migration` (25) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)