### PR TITLE
WI-002161: a night shift's card shows the shift it actually covers [version-15]

### DIFF
--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -919,7 +919,9 @@ def _build_transportation_shipment_cards(fmt, to_utc, get_coords_cached, timedel
 
             dep_utc = to_utc(str(dep))
             ret_utc = to_utc(str(ret))
-            if ret_utc <= dep_utc:
+            # A night shift ends earlier on the clock than it starts; only a shift with
+            # no length recorded at all needs a fallback.
+            if ret_utc == dep_utc:
                 ret_utc = dep_utc + timedelta(hours=1)
 
             stop_coords = get_coords_cached("Location", s.stop_location) if s.stop_location else None

--- a/one_fm/tests/test_shipment_card_window.py
+++ b/one_fm/tests/test_shipment_card_window.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002161: the shift window a Transportation Shipment card advertises."""
+
+from datetime import timedelta
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import get_datetime, today
+
+from one_fm.one_fm.page.transportation_schedule.transportation_schedule import (
+	_build_transportation_shipment_cards,
+)
+
+
+def _cards_for(shipment_name):
+	"""Run the real card builder and pick out one shipment's card."""
+	cards = _build_transportation_shipment_cards(
+		fmt=lambda dt: dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+		to_utc=lambda value: get_datetime(f"{today()} {value}"),
+		get_coords_cached=lambda *args: None,
+		timedelta=timedelta,
+	)
+	return next(c for c in cards if c["shipment"] == shipment_name)
+
+
+def _shipment(start, end, direction="Outward"):
+	doc = frappe.new_doc("Transportation Shipment")
+	doc.status = "Unassigned"
+	doc.trip_direction = direction
+	doc.start_time = start
+	doc.end_time = end
+	doc.headcount = 1
+	doc.generation_key = frappe.generate_hash("TS-WINDOW", 10)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+class TestNightShiftCardWindow(FrappeTestCase):
+	def _times(self, card):
+		return card["shift_start"][11:16], card["shift_end"][11:16]
+
+	def test_a_night_shift_card_shows_the_shift_it_covers(self):
+		card = _cards_for(_shipment("19:00:00", "07:00:00"))
+
+		self.assertEqual(self._times(card), ("19:00", "07:00"))
+
+	def test_a_day_shift_is_unchanged(self):
+		card = _cards_for(_shipment("07:00:00", "19:00:00"))
+
+		self.assertEqual(self._times(card), ("07:00", "19:00"))
+
+	def test_a_shift_with_no_length_recorded_still_gets_an_hour(self):
+		# Identical start and end says nothing about length, so keep a nominal hour.
+		card = _cards_for(_shipment("08:00:00", "08:00:00"))
+
+		self.assertEqual(self._times(card), ("08:00", "09:00"))
+
+	def test_the_return_leg_is_collected_when_the_night_shift_ends(self):
+		card = _cards_for(_shipment("19:00:00", "07:00:00", direction="Return"))
+
+		self.assertEqual(card["return_window_start"][11:16], "07:00")


### PR DESCRIPTION
Port of #6795 (merged to `staging`) onto `version-15`. Same code, with the explanatory comments cut back.

Fixes [WI-002161](https://one-fm.com/app/work-item/WI-002161) — *[Irfan] Shift Card Timing Issue*. HD tickets [1807461](https://one-fm.com/app/hd-ticket/1807461) and [1806397](https://one-fm.com/app/hd-ticket/1806397).

> Transportation Shipment Cards are showing wrong Shift Start Time and End Time.

## Root cause

The data was right all along — Operations Shift `Security-Sawaber Credit Office-Night-1` and its shipments both read 19:00 → 07:00. The card builder invented the 20:00:

```python
if ret_utc <= dep_utc:
    ret_utc = dep_utc + timedelta(hours=1)
```

A night shift finishes the morning after it starts, so its end is legitimately earlier on the clock than its start. That guard read it as a broken window and replaced it with *start plus an hour* — which is where every overnight card's one-hour shift came from, not just Sawaber's.

## The fix

The canvas is a rolling 24h view of one day's runs, so the end keeps its own time of day rather than rolling onto tomorrow's date and off the visible axis. The one case the old guard was right about survives: an identical start and end says nothing about length, so it still gets a nominal hour instead of collapsing to zero width. `return_window_start` moves with the corrected end, so an overnight return leg is collected at 07:00.

## Verification (from #6795)

Against the production restore, via the real `get_route_planner_data()`: Sawaber Night-1 reads 19:00 → 07:00 (was 19:00 → 20:00), Day-1 unchanged, and no card on the site still advertises a one-hour window its Operations Shift does not have. 4 tests.

Diff against the merged version is comments only.
