### PR TITLE
WI-002160: one trip group on one vehicle is one bus run, not two [version-15]

### DIFF
--- a/one_fm/one_fm/page/transportation_schedule/test_transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/test_transportation_schedule.py
@@ -97,3 +97,53 @@ class TestSyncShipmentStatuses(FrappeTestCase):
 
 		self.assertEqual(self._status(self.outbound), "Unassigned")
 		self.assertEqual(self._status(self.return_leg), "Assigned")
+
+
+class TestAPlacedCardIsNeverReverted(FrappeTestCase):
+	"""A direction mismatch is a flag to fix, not a card to send back to the pool."""
+
+	def setUp(self):
+		self.pair = frappe.generate_hash("TRQ-KEEP", 8)
+		self.leg = _make_leg(self.pair, "Outward", status="Assigned")
+
+	def _read(self, name):
+		return frappe.db.get_value(
+			"Transportation Shipment", name,
+			["status", "trip_direction", "pre_merge_trip_direction"], as_dict=True
+		)
+
+	def test_a_card_still_on_the_plan_keeps_its_status(self):
+		# The stale-tab shape: the shipment reads Mixed, the browser still says OUTBOUND.
+		frappe.db.set_value("Transportation Shipment", self.leg, {
+			"trip_direction": "Mixed", "pre_merge_trip_direction": "Outward"
+		})
+
+		_sync_shipment_statuses(
+			[_swim_item(self.leg, "OUTBOUND")], previously_linked={self.leg}
+		)
+
+		kept = self._read(self.leg)
+		self.assertEqual(kept.status, "Assigned")
+		self.assertEqual(kept.trip_direction, "Mixed")
+		self.assertEqual(kept.pre_merge_trip_direction, "Outward")
+
+	def test_a_card_the_plan_dropped_still_reverts(self):
+		# What the revert branch is for: the block left the lane.
+		frappe.db.set_value("Transportation Shipment", self.leg, {
+			"trip_direction": "Mixed", "pre_merge_trip_direction": "Outward"
+		})
+
+		_sync_shipment_statuses([], previously_linked={self.leg})
+
+		reverted = self._read(self.leg)
+		self.assertEqual(reverted.status, "Unassigned")
+		self.assertEqual(reverted.trip_direction, "Outward")
+		self.assertIsNone(reverted.pre_merge_trip_direction)
+
+	def test_a_mismatched_card_is_still_not_newly_assigned(self):
+		# A mismatch never promotes a card to Assigned, it only stops it being demoted.
+		frappe.db.set_value("Transportation Shipment", self.leg, "status", "Unassigned")
+
+		_sync_shipment_statuses([_swim_item(self.leg, "RETURN")])
+
+		self.assertEqual(self._read(self.leg).status, "Unassigned")

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
@@ -343,7 +343,7 @@ function mountRoutePlannerApp(wrapper, data) {
                             type: 'merged',
                             tripId,
                             tripName: stops.find(s => s.tripName)?.tripName || null,
-                            direction: stops.some(s => s.direction === 'MIXED') ? 'MIXED' : firstItem.direction,
+                            direction: this.runDirection(stops),
                             start: firstItem.start,
                             end: lastItem.end,
                             headcount: totalHC,
@@ -771,7 +771,8 @@ function mountRoutePlannerApp(wrapper, data) {
                 }
 
                 // ── Seat capacity check (time-aware) ──
-                const peakLoad = this.peakLoadDuringCardWindows(card, vehicle.id);
+                const blockers = this.tripsDuringCardWindows(card, vehicle.id);
+                const peakLoad = blockers.reduce((sum, t) => sum + t.occupancy, 0);
 
                 if (peakLoad + card.headcount > this.passengerSeats(vehicle)) {
                     const shell = document.getElementById('rp-shell');
@@ -780,7 +781,7 @@ function mountRoutePlannerApp(wrapper, data) {
                         shell.style.backgroundColor = '#ffebee';
                         setTimeout(() => { shell.style.backgroundColor = ''; }, 400);
                     }
-                    frappe.throw(this.capacityMessage(card.headcount, vehicle));
+                    frappe.throw(this.capacityMessage(card.headcount, vehicle, blockers));
                     return;
                 }
 
@@ -853,6 +854,18 @@ function mountRoutePlannerApp(wrapper, data) {
                     } else {
                         // ── Multiple trips: let user pick which trip to join ──
                         const self = this;
+
+                        // Nearest run first: swimItems order is row order, so a distant
+                        // run could be the default. Runs overlapping the card sort first.
+                        const gapToCard = (items) => {
+                            const s = Math.min(...items.map(i => new Date(i.start).getTime()));
+                            const e = Math.max(...items.map(i => new Date(i.end).getTime()));
+                            if (e < cardWindowStart) return cardWindowStart - e;
+                            if (s > cardWindowEnd) return s - cardWindowEnd;
+                            return 0;
+                        };
+                        tripKeys.sort((a, b) => gapToCard(tripMap[a]) - gapToCard(tripMap[b]));
+
                         const tripOptions = tripKeys.map((key, idx) => {
                             const items = tripMap[key];
                             const sites = items.map(i => {
@@ -891,7 +904,9 @@ function mountRoutePlannerApp(wrapper, data) {
                                 {
                                     fieldtype: 'Int', fieldname: 'transit_min',
                                     label: 'Transit Time (minutes)', default: 30, reqd: 1,
-                                    description: 'Only used when adding to an existing trip'
+                                    description: 'Used when the stop joins a run going the same way. '
+                                        + 'Joining a run going the other way is a merge, and the Merge '
+                                        + 'Trip window collects the per-leg times itself.'
                                 }
                             ],
                             primary_action_label: 'Add Stop',
@@ -1307,7 +1322,10 @@ function mountRoutePlannerApp(wrapper, data) {
                 // stop after it and can put the bus over its seats. The modal is where the
                 // operator sees all three before committing, instead of the card being
                 // silently re-timed on a default 30-minute transit.
-                if (!presetTransitMin && self._isMergeDrop(newCard, existingItems)) {
+                // A merge is a merge however the operator got here: skipping this when a
+                // transit time arrived with the call meant the trip picker's own merges
+                // never reached merge_trip_shipments (WI-002160).
+                if (self._isMergeDrop(newCard, existingItems)) {
                     self._openMergeTripModal(newCard, existingItems, vehicleId);
                     return;
                 }
@@ -1315,7 +1333,8 @@ function mountRoutePlannerApp(wrapper, data) {
                 // ── Capacity check before chaining ──
                 const vehicle = this.planData.vehicles.find(v => v.id === vehicleId);
                 if (vehicle) {
-                    const currentLoad = this.peakLoadDuringCardWindows(newCard, vehicleId);
+                    const blockers = this.tripsDuringCardWindows(newCard, vehicleId);
+                    const currentLoad = blockers.reduce((sum, t) => sum + t.occupancy, 0);
                     if (currentLoad + newCard.headcount > this.passengerSeats(vehicle)) {
                         const shell = document.getElementById('rp-shell');
                         if (shell) {
@@ -1323,7 +1342,7 @@ function mountRoutePlannerApp(wrapper, data) {
                             shell.style.backgroundColor = '#ffebee';
                             setTimeout(() => { shell.style.backgroundColor = ''; }, 400);
                         }
-                        frappe.throw(this.capacityMessage(newCard.headcount, vehicle));
+                        frappe.throw(this.capacityMessage(newCard.headcount, vehicle, blockers));
                         return;
                     }
                 }
@@ -1427,32 +1446,32 @@ function mountRoutePlannerApp(wrapper, data) {
             },
 
             // ── Time-aware peak load helper ─────────────────────────────────
-            // The trips a vehicle actually runs today. Stops chained onto one trip
-            // merge — they ride together — but the outbound and return legs stay
-            // apart (WI-002000): they share a tripId, so keying on it alone fused a
-            // 05:00 drop and its 17:00 pickup into one twelve-hour block carrying
-            // double the passengers, which every later drop then "overlapped".
+            // The trips a vehicle actually runs today. One tripId is one bus run, however
+            // its stops are headed: keying the direction in as well split a chained run
+            // into two overlapping pseudo-trips, so the seat check added the same bus to
+            // itself (WI-002160). A run that both drops off and picks up is measured leg
+            // by leg instead.
             _getLogicalTrips(vehicleId) {
                 const vi = this.swimItems.filter(i => i.vehicleId === vehicleId && this._liveToday(i));
                 const tripsMap = {};
                 let soloIdx = 0;
 
                 vi.forEach(item => {
-                    const key = item.tripId
-                        ? `${item.tripId}::${item.direction}`
-                        : `_solo_${soloIdx++}`;
+                    const key = item.tripId || `_solo_${soloIdx++}`;
                     if (!tripsMap[key]) {
                         tripsMap[key] = {
                             start: new Date(item.start).getTime(),
                             end: new Date(item.end).getTime(),
                             headcount: item.headcount || 0,
                             direction: item.direction,
+                            tripName: item.tripName || null,
                             stops: [item]
                         };
                     } else {
                         tripsMap[key].start = Math.min(tripsMap[key].start, new Date(item.start).getTime());
                         tripsMap[key].end = Math.max(tripsMap[key].end, new Date(item.end).getTime());
                         tripsMap[key].headcount += (item.headcount || 0);
+                        tripsMap[key].tripName = tripsMap[key].tripName || item.tripName || null;
                         tripsMap[key].stops.push(item);
                     }
                 });
@@ -1461,8 +1480,20 @@ function mountRoutePlannerApp(wrapper, data) {
                 // total the bus is never asked to hold. Summing it painted a merged block
                 // purple for overcapacity on a run that fits (WI-002078).
                 const trips = Object.values(tripsMap);
-                trips.forEach(t => { t.occupancy = this.tripOccupancy(t); });
+                trips.forEach(t => {
+                    t.direction = this.runDirection(t.stops);
+                    t.occupancy = this.tripOccupancy(t);
+                });
                 return trips;
+            },
+
+            // Which way a whole run travels — every seat check reads it through here.
+            // Stops that do not all agree make it mixed whatever each one is labelled:
+            // only the Merge Trip modal ever writes MIXED onto a stop.
+            runDirection(stops) {
+                if (!stops || !stops.length) return 'OUTBOUND';
+                const first = stops[0].direction || 'OUTBOUND';
+                return stops.some(s => (s.direction || 'OUTBOUND') !== first) ? 'MIXED' : first;
             },
 
             // The most passengers one trip ever has aboard. Mirrors _trip_peak on the
@@ -1506,11 +1537,25 @@ function mountRoutePlannerApp(wrapper, data) {
 
             // One wording for every seat refusal, naming the limit the check
             // actually applied rather than the size of the bus.
-            capacityMessage(headcount, vehicle) {
-                return __(
+            capacityMessage(headcount, vehicle, blockers) {
+                const base = __(
                     'Capacity Exceeded: cannot assign {0} employees to {1} — it takes {2} passengers.',
                     [headcount, this.vehicleString(vehicle), this.passengerSeats(vehicle)]
                 );
+
+                // Name the runs holding the seats: a card is placed at its own shift
+                // window, so the blocking run is often not the block under the cursor.
+                const named = (blockers || [])
+                    .filter(t => t && t.occupancy)
+                    .map(t => __('{0} ({1} aboard, {2}–{3})', [
+                        t.tripName || __('an unnamed run'),
+                        t.occupancy,
+                        this.fmtTime(t.start),
+                        this.fmtTime(t.end)
+                    ]));
+                if (!named.length) return base;
+
+                return `${base} ${__('Those seats are held by {0}.', [named.join(', ')])}`;
             },
 
             // The headcount already aboard the vehicle during the window this card
@@ -1518,21 +1563,28 @@ function mountRoutePlannerApp(wrapper, data) {
             // the worse of the outbound and return windows meant an early drop was
             // judged against the evening traffic it never shares the road with.
             peakLoadDuringCardWindows(card, vehicleId, direction) {
-                const DEF = 3600000;
-                const leg = direction || card.direction;
-
-                let wStart, wEnd;
-                if (leg === 'RETURN') {
-                    wStart = new Date(card.return_window_start).getTime();
-                    wEnd = wStart + DEF;
-                } else {
-                    wEnd = new Date(card.outbound_window_end).getTime();
-                    wStart = wEnd - DEF;
-                }
-
-                return this._getLogicalTrips(vehicleId)
-                    .filter(t => t.start < wEnd && t.end > wStart)  // overlaps
+                return this.tripsDuringCardWindows(card, vehicleId, direction)
                     .reduce((sum, t) => sum + t.occupancy, 0);
+            },
+
+            // The runs already on the road during the window this card would occupy. The
+            // seat check and the refusal message read this one list so they cannot drift.
+            tripsDuringCardWindows(card, vehicleId, direction) {
+                const { start, end } = this.cardLegWindow(card, direction);
+                return this._getLogicalTrips(vehicleId)
+                    .filter(t => t.start < end && t.end > start);
+            },
+
+            // The hour a card's chosen leg occupies. Only the leg being placed counts
+            // (WI-002000), not the worse of the outbound and return windows.
+            cardLegWindow(card, direction) {
+                const DEF = 3600000;
+                if ((direction || card.direction) === 'RETURN') {
+                    const start = new Date(card.return_window_start).getTime();
+                    return { start, end: start + DEF };
+                }
+                const end = new Date(card.outbound_window_end).getTime();
+                return { start: end - DEF, end };
             },
 
             // ─ Place card + direction picker ─────────────────────────────
@@ -2098,7 +2150,7 @@ function mountRoutePlannerApp(wrapper, data) {
                         // merged run's stops are not all aboard at once, so its total is
                         // not what has to fit (WI-002078).
                         const movingHeadcount = self.tripOccupancy({
-                            direction: item.direction,
+                            direction: self.runDirection(journeyItems),
                             headcount: journeyItems.reduce((sum, i) => sum + (i.headcount || 0), 0),
                             stops: journeyItems
                         });
@@ -2108,10 +2160,9 @@ function mountRoutePlannerApp(wrapper, data) {
                         // so none of the moving stops are already on the target.
                         const blockStart = Math.min(...journeyItems.map(i => new Date(i.start).getTime()));
                         const blockEnd = Math.max(...journeyItems.map(i => new Date(i.end).getTime()));
-                        const logicalTrips = self._getLogicalTrips(targetVehicle.id);
-                        const existingLoad = logicalTrips
-                            .filter(t => t.start < blockEnd && t.end > blockStart)
-                            .reduce((sum, t) => sum + t.occupancy, 0);
+                        const blockers = self._getLogicalTrips(targetVehicle.id)
+                            .filter(t => t.start < blockEnd && t.end > blockStart);
+                        const existingLoad = blockers.reduce((sum, t) => sum + t.occupancy, 0);
 
                         if (existingLoad + movingHeadcount > self.passengerSeats(targetVehicle)) {
                             const shell = document.getElementById('rp-shell');
@@ -2120,7 +2171,7 @@ function mountRoutePlannerApp(wrapper, data) {
                                 shell.style.backgroundColor = '#ffebee';
                                 setTimeout(() => { shell.style.backgroundColor = ''; }, 400);
                             }
-                            frappe.throw(self.capacityMessage(movingHeadcount, targetVehicle));
+                            frappe.throw(self.capacityMessage(movingHeadcount, targetVehicle, blockers));
                             return;
                         }
 
@@ -2349,14 +2400,25 @@ function mountRoutePlannerApp(wrapper, data) {
                         const targetTripItems = tripsMap[targetTripId].items;
                         const targetVehicleId = selectedOpt.vehicle.id;
 
-                        // Check logical trip capacity directly instead of peakLoadDuringCardWindows 
-                        // because we want to know the target trip's total capacity + new card
-                        const tripLoad = targetTripItems.reduce((sum, i) => sum + (i.headcount || 0), 0);
+                        // The target run's own load, not the lane's. Read through
+                        // tripOccupancy: a run that both drops off and picks up never
+                        // carries all its stops at once, so summing them by hand refused
+                        // merges the bus could make (WI-002160).
+                        const tripLoad = self.tripOccupancy({
+                            direction: self.runDirection(targetTripItems),
+                            headcount: targetTripItems.reduce((sum, i) => sum + (i.headcount || 0), 0),
+                            stops: targetTripItems
+                        });
                         if (tripLoad + card.headcount > self.passengerSeats(selectedOpt.vehicle)) {
                             frappe.msgprint({
                                 title: __('Capacity Exceeded'),
                                 indicator: 'red',
-                                message: self.capacityMessage(card.headcount, selectedOpt.vehicle)
+                                message: self.capacityMessage(card.headcount, selectedOpt.vehicle, [{
+                                    tripName: targetTripItems.find(i => i.tripName)?.tripName || null,
+                                    occupancy: tripLoad,
+                                    start: Math.min(...targetTripItems.map(i => new Date(i.start).getTime())),
+                                    end: Math.max(...targetTripItems.map(i => new Date(i.end).getTime()))
+                                }])
                             });
                             return;
                         }
@@ -2452,25 +2514,20 @@ function mountRoutePlannerApp(wrapper, data) {
                     vehicleNumber = idx >= 0 ? idx + 1 : 1;
                 }
 
-                // Count existing unique trips on this vehicle
-                const existingTripIds = new Set();
-                this.swimItems.forEach(item => {
-                    if (item.vehicleId !== vehicleId) return;
-                    if (item.tripId) {
-                        existingTripIds.add(item.tripId);
-                    } else {
-                        existingTripIds.add(item.id);
-                    }
-                });
-                const nextSeq = existingTripIds.size + 1;
-
-                // Format: vehicleNumber + 2-digit sequence (e.g., 15 + 01 = "1501")
-                const seqStr = String(nextSeq).padStart(2, '0');
-                const tripName = `${vehicleNumber}${seqStr}`;
-
-                // Leased vehicles get "S-" prefix
+                // Format: vehicleNumber + 2-digit sequence (e.g., 15 + 01 = "1501").
+                // Leased vehicles get an "S-" prefix.
                 const prefix = vehicle.is_leased ? 'S-' : '';
-                return `${prefix}${tripName}`;
+                const name = (seq) => `${prefix}${vehicleNumber}${String(seq).padStart(2, '0')}`;
+
+                // The next FREE number, not the count: counting re-issued a name the
+                // moment any trip but the last was removed.
+                const taken = new Set();
+                this.swimItems.forEach(item => {
+                    if (item.vehicleId === vehicleId && item.tripName) taken.add(item.tripName);
+                });
+                let seq = 1;
+                while (taken.has(name(seq))) seq++;
+                return name(seq);
             },
 
             // ─ Persistence (save/load to Route Plan DocType) ──────────────

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -1040,6 +1040,7 @@ def _sync_shipment_statuses(items, previously_linked=None):
                 fields=["name", "trip_direction"],
             )
         }
+        mismatched = []
         for name, placed_dirs in placed_dirs_by_shipment.items():
             own_dir = shipment_dir.get(name)
             if own_dir is None:
@@ -1047,11 +1048,20 @@ def _sync_shipment_statuses(items, previously_linked=None):
             if own_dir in placed_dirs:
                 assigned.add(name)
             else:
-                frappe.log_error(
-                    f"Skipped assigning {name}: placed as {sorted(placed_dirs)} but "
-                    f"shipment direction is {own_dir}.",
-                    "Transportation Shipment Direction Mismatch",
+                mismatched.append(
+                    f"{name}: placed as {sorted(placed_dirs)}, shipment says {own_dir}"
                 )
+
+        if mismatched:
+            # One entry per save: a stale browser disagrees about every card it carries.
+            frappe.log_error(
+                title="Transportation Shipment Direction Mismatch",
+                message=(
+                    "Left as they are - the plan still places these cards, so what needs "
+                    "looking at is the direction flag, not the status:\n\n"
+                    + "\n".join(mismatched)
+                ),
+            )
 
     for name in assigned:
         if frappe.db.get_value("Transportation Shipment", name, "status") != "Assigned":
@@ -1063,8 +1073,16 @@ def _sync_shipment_statuses(items, previously_linked=None):
         unmerge_trip_shipment,
     )
 
+    # A card the plan still places is never reverted, whatever its direction flag says:
+    # `status` answers "is this shipment on a plan", and a mismatch is a flag to fix, not
+    # a card to send back to the pool. Reverting one left it Unassigned with its block
+    # still on the lane, and Generate Shipments deletes Unassigned shift-generated cards.
+    still_placed = set(placed_dirs_by_shipment)
+
     for name in (previously_linked or set()):
-        if name and name not in assigned and frappe.db.exists("Transportation Shipment", name):
+        if not name or name in assigned or name in still_placed:
+            continue
+        if frappe.db.exists("Transportation Shipment", name):
             frappe.db.set_value("Transportation Shipment", name, "status", "Unassigned")
             # A card returning to the pool takes its own direction back with it. Being
             # merged is a property of the block it was in, not of the journey the shipment

--- a/one_fm/operations/doctype/route_plan/route_plan.py
+++ b/one_fm/operations/doctype/route_plan/route_plan.py
@@ -236,8 +236,9 @@ class RoutePlan(Document):
 		(WI-002000). Two levels are enforced against the same limit:
 
 		* **Each trip on its own** — the accommodation cards merged onto one
-		  ``(vehicle, trip_group, direction)`` ride together even though their
-		  stops are sequential, so their headcounts still sum (MA4-13).
+		  ``(vehicle, trip_group)`` ride together even though their stops are
+		  sequential, so their headcounts still sum (MA4-13) — unless the run
+		  both drops off and picks up, which is walked leg by leg.
 		* **Trips that run at the same time** — when two trips' windows overlap,
 		  their passengers are on the bus together and the totals add up.
 
@@ -289,10 +290,11 @@ class RoutePlan(Document):
 	def _logical_trips(self) -> list:
 		"""Collapse the assignment rows into the trips a vehicle actually runs.
 
-		Rows sharing a ``(vehicle, trip_group, direction)`` are the stops of one
-		run: their headcounts sum and the trip spans from its first stop's start
-		to its last stop's end. A row with no ``trip_group`` is a standalone drop
-		and becomes a trip of its own, so it is weighed like any other.
+		Rows sharing a ``(vehicle, trip_group)`` are the stops of one run: their
+		headcounts sum and the trip spans from its first stop's start to its last
+		stop's end. A run whose stops do not all travel the same way is a mixed one
+		and is measured leg by leg instead. A row with no ``trip_group`` is a
+		standalone drop and becomes a trip of its own, so it is weighed like any other.
 
 		Each trip carries the daily time window its stops cover and the calendar
 		lifespan they are live for — the two halves of the timestamps a Route Plan
@@ -306,7 +308,11 @@ class RoutePlan(Document):
 			direction = _row_direction(row)
 			# Standalone rows are keyed by position so two of them never merge.
 			group = row.trip_group or f"\0row-{idx}"
-			key = (row.vehicle, group, direction)
+			# One trip group on one vehicle is one bus run, whichever way its stops
+			# travel. Keying the direction in as well split a chained run into two
+			# overlapping pseudo-trips, so the check added the same bus to itself
+			# (WI-002160).
+			key = (row.vehicle, group)
 			start, end = _row_time_window(row)
 			live_from, live_to = _row_date_range(row)
 
@@ -328,6 +334,11 @@ class RoutePlan(Document):
 				continue
 
 			trip.rows.append(row)
+			# Stops that do not all travel the same way make this a mixed run, walked leg
+			# by leg instead of summed - the row's own ``direction`` only ever said MIXED
+			# when the Merge Trip modal wrote it back.
+			if direction != trip.direction:
+				trip.direction = MIXED_DIRECTION
 			trip.headcount += cint(row.headcount)
 			trip.start = min(trip.start, start)
 			trip.end = max(trip.end, end)
@@ -602,12 +613,20 @@ def _trip_peak(trip):
 	if trip.direction != MIXED_DIRECTION:
 		return cint(trip.headcount), 1
 
-	by_index = sorted(trip.rows, key=lambda row: (cint(row.stop_index), row.name or ""))
+	# Stop order decides the answer - the same two loads read 3 or 6 depending on whether
+	# the return riders board before or after the outward ones get off. The child-row
+	# name is a random hash, so it can only be the last tie break.
+	by_index = sorted(
+		trip.rows,
+		key=lambda row: (cint(row.stop_index), str(row.start_time or ""), row.name or ""),
+	)
 	directions = _shipment_directions([row.transportation_shipment for row in by_index])
 	stops = [
 		{
 			"headcount": cint(row.headcount),
-			"boards": directions.get(row.transportation_shipment) == "RETURN",
+			# A row carrying no shipment still knows its own leg.
+			"boards": (directions.get(row.transportation_shipment) or _row_direction(row))
+			== "RETURN",
 		}
 		for row in by_index
 	]

--- a/one_fm/operations/doctype/route_plan/test_route_plan.py
+++ b/one_fm/operations/doctype/route_plan/test_route_plan.py
@@ -397,7 +397,7 @@ class TestRoutePlanCapacitySave(FrappeTestCase):
 		doc.flags.ignore_links = True
 		return doc
 
-	def _row(self, vehicle, *, trip, direction="OUTBOUND", headcount, card=None):
+	def _row(self, vehicle, *, trip, direction="OUTBOUND", headcount, card=None, stop=None):
 		return {
 			"card_id": card or frappe.generate_hash("CARD", 8),
 			"vehicle": vehicle,
@@ -405,6 +405,8 @@ class TestRoutePlanCapacitySave(FrappeTestCase):
 			"trip_group": trip,
 			"trip_name": trip,
 			"headcount": headcount,
+			# Stop order is what the leg walk reads, so a mixed run has to say its order.
+			"stop_index": stop,
 		}
 
 	def test_merged_camps_exceeding_seats_are_blocked(self):
@@ -428,12 +430,33 @@ class TestRoutePlanCapacitySave(FrappeTestCase):
 		plan.insert(ignore_permissions=True)
 		self.assertTrue(frappe.db.exists("Route Plan", plan.name))
 
-	def test_outbound_and_return_of_one_trip_are_counted_separately(self):
-		# Same trip_group but opposite directions are two physical runs, so each
-		# 3-seat leg is fine even though they'd overflow if summed together.
+	def test_outbound_and_return_of_one_trip_are_walked_leg_by_leg(self):
+		"""WI-002160: 3 out then 3 back fits three seats - the drop is off first."""
 		plan = self._make_plan([
-			self._row(self.VEHICLE, trip="TRIP-BOTH", direction="OUTBOUND", headcount=3),
-			self._row(self.VEHICLE, trip="TRIP-BOTH", direction="RETURN", headcount=3),
+			self._row(self.VEHICLE, trip="TRIP-BOTH", direction="OUTBOUND", headcount=3, stop=1),
+			self._row(self.VEHICLE, trip="TRIP-BOTH", direction="RETURN", headcount=3, stop=2),
+		])
+		plan.insert(ignore_permissions=True)
+		self.assertTrue(frappe.db.exists("Route Plan", plan.name))
+
+	def test_a_return_boarding_before_the_outward_drop_still_overloads(self):
+		"""Boarding the return riders first is six people on three seats, still refused."""
+		plan = self._make_plan([
+			self._row(self.VEHICLE, trip="TRIP-STACK", direction="RETURN", headcount=3, stop=1),
+			self._row(self.VEHICLE, trip="TRIP-STACK", direction="OUTBOUND", headcount=3, stop=2),
+		])
+		with self.assertRaises(frappe.ValidationError) as cm:
+			plan.insert(ignore_permissions=True)
+		self.assertIn("Capacity Exceeded on leg", str(cm.exception))
+
+	def test_a_chained_run_is_not_counted_against_itself(self):
+		"""WI-002160, the reported shape: S-204 on a 3-seat RAIZE peaks at two aboard."""
+		plan = self._make_plan([
+			self._row(self.VEHICLE, trip="S-204", direction="OUTBOUND", headcount=1, stop=1),
+			self._row(self.VEHICLE, trip="S-204", direction="RETURN", headcount=1, stop=2),
+			self._row(self.VEHICLE, trip="S-204", direction="RETURN", headcount=1, stop=3),
+			# No times recorded, so every trip spans the day and they all overlap.
+			self._row(self.VEHICLE, trip="EU-RESIDENCE", direction="RETURN", headcount=1, stop=1),
 		])
 		plan.insert(ignore_permissions=True)
 		self.assertTrue(frappe.db.exists("Route Plan", plan.name))

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -597,3 +597,4 @@ one_fm.patches.v15_0.approve_attendance_check_jul11_2026 #2026-08-16
 one_fm.patches.v15_0.fix_resignation_v2_stale_migration #2026-08-17
 one_fm.patches.v15_0.backfill_employee_resignation_auto_assign #2026-08-19
 one_fm.patches.v15_0.disable_roster_double_shift_ot_checker_assignment_rules #2026-08-21 WI-001689 reverted
+one_fm.patches.v15_0.mark_unflagged_mixed_trips #2026-08-25 WI-002160

--- a/one_fm/patches/v15_0/mark_unflagged_mixed_trips.py
+++ b/one_fm/patches/v15_0/mark_unflagged_mixed_trips.py
@@ -1,0 +1,76 @@
+import frappe
+from collections import defaultdict
+
+MIXED = "Mixed"
+
+# WI-002160: runs merged through the trip picker never reached merge_trip_shipments, so
+# they were left un-flagged. This writes what a real merge would have: every assignment
+# row MIXED, every shipment Mixed with its own leg kept in pre_merge_trip_direction so
+# unmerge_trip_shipment can still restore it. Only runs whose rows genuinely disagree are
+# touched.
+#
+# The shipment's own `trip_group` is deliberately left alone - a real merge fills it with
+# merge_key()'s hash, which is not the canvas trip id these rows carry, and nothing reads
+# it for logic. Rows are written with db.set_value rather than by saving the plan: saving
+# would re-run the whole plan's capacity validation, and a patch must not fail because
+# some unrelated lane on a months-old plan no longer passes.
+
+
+def execute():
+	if not frappe.db.exists("DocType", "Route Plan Assignment"):
+		return
+
+	rows = frappe.get_all(
+		"Route Plan Assignment",
+		filters={"trip_group": ["!=", ""]},
+		fields=["name", "parent", "vehicle", "trip_group", "direction", "transportation_shipment"],
+	)
+
+	runs = defaultdict(list)
+	for row in rows:
+		if row.vehicle and row.trip_group:
+			runs[(row.parent, row.vehicle, row.trip_group)].append(row)
+
+	repaired = 0
+	for run in runs.values():
+		directions = {(row.direction or "").upper() for row in run}
+		# One heading means one plain run; already all MIXED means nothing to do.
+		if len(directions) < 2:
+			continue
+
+		for row in run:
+			if (row.direction or "").upper() != "MIXED":
+				frappe.db.set_value(
+					"Route Plan Assignment", row.name, "direction", "MIXED", update_modified=False
+				)
+			_mark_shipment_mixed(row.transportation_shipment)
+		repaired += 1
+
+	if repaired:
+		# No commit here: the patch runner commits.
+		print(f"WI-002160: marked {repaired} un-flagged mixed run(s) as Mixed")
+
+
+def _mark_shipment_mixed(name):
+	"""Record the card's own leg, then flag it Mixed - the order a real merge uses.
+
+	The remembered direction is never overwritten: a card already carrying one was merged
+	before, and that original is the one to keep (WI-002071).
+	"""
+	if not name:
+		return
+
+	shipment = frappe.db.get_value(
+		"Transportation Shipment",
+		name,
+		["trip_direction", "pre_merge_trip_direction"],
+		as_dict=True,
+	)
+	if not shipment or shipment.trip_direction == MIXED:
+		return
+
+	values = {"trip_direction": MIXED}
+	if not shipment.pre_merge_trip_direction:
+		values["pre_merge_trip_direction"] = shipment.trip_direction
+
+	frappe.db.set_value("Transportation Shipment", name, values, update_modified=False)

--- a/one_fm/tests/test_merge_preview.py
+++ b/one_fm/tests/test_merge_preview.py
@@ -263,9 +263,14 @@ class TestTheMergedBlockPaintsMixed(FrappeTestCase):
 		self.assertIn("return this.bfill({", self.source)
 
 	def test_a_run_is_mixed_once_any_stop_is(self):
-		# Taking the first stop's direction left a merged run reading as whatever leg
-		# happened to be placed first.
-		self.assertIn("stops.some(s => s.direction === 'MIXED') ? 'MIXED'", self.source)
+		# The block asks runDirection, which answers MIXED whenever the stops do not all
+		# agree - one MIXED stop, or stops that merely disagree (WI-002160).
+		self.assertIn("direction: this.runDirection(stops),", self.source)
+		self.assertIn("runDirection(stops) {", self.source)
+		self.assertIn(
+			"return stops.some(s => (s.direction || 'OUTBOUND') !== first) ? 'MIXED' : first;",
+			self.source,
+		)
 
 	def test_both_block_shapes_still_show_conflict_and_overcapacity(self):
 		self.assertIn("conflict: entry.conflict", self.source)

--- a/one_fm/tests/test_one_trip_group_is_one_run.py
+++ b/one_fm/tests/test_one_trip_group_is_one_run.py
@@ -1,0 +1,248 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002160: one trip group on one vehicle is one bus run, not two.
+
+The lane refuses a drop before the save ever sees it, so the canvas and the Route Plan
+have to read a run the same way.
+"""
+
+import pathlib
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import today
+
+from one_fm.patches.v15_0.mark_unflagged_mixed_trips import execute as execute_mixed_patch
+
+CANVAS = pathlib.Path(frappe.get_app_path(
+	"one_fm", "one_fm", "page", "transportation_schedule", "transportation_schedule.js"
+))
+ROUTE_PLAN = pathlib.Path(frappe.get_app_path(
+	"one_fm", "operations", "doctype", "route_plan", "route_plan.py"
+))
+
+
+class TestOneTripGroupIsOneRun(FrappeTestCase):
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_the_lane_groups_a_run_by_its_trip_alone(self):
+		self.assertIn("const key = item.tripId || `_solo_${soloIdx++}`;", self.source)
+		self.assertNotIn("`${item.tripId}::${item.direction}`", self.source)
+
+	def test_stops_that_disagree_make_the_run_mixed(self):
+		self.assertIn("runDirection(stops) {", self.source)
+		self.assertIn(
+			"return stops.some(s => (s.direction || 'OUTBOUND') !== first) ? 'MIXED' : first;",
+			self.source,
+		)
+
+	def test_every_seat_check_reads_the_run_through_that_one_rule(self):
+		# The "merge into that trip" action re-summed the stops by hand.
+		self.assertNotIn(
+			"const tripLoad = targetTripItems.reduce((sum, i) => sum + (i.headcount || 0), 0);",
+			self.source,
+		)
+		# The three places a run is weighed: the lane, a reassign, and a merge.
+		self.assertIn("t.direction = this.runDirection(t.stops);", self.source)
+		self.assertIn("direction: self.runDirection(journeyItems),", self.source)
+		self.assertIn("direction: self.runDirection(targetTripItems),", self.source)
+
+	def test_the_save_reads_it_the_same_way(self):
+		source = ROUTE_PLAN.read_text()
+
+		self.assertIn("key = (row.vehicle, group)", source)
+		self.assertIn("trip.direction = MIXED_DIRECTION", source)
+
+	def test_the_leg_walk_reads_a_row_that_has_no_shipment(self):
+		# A row carrying no shipment still knows its own leg.
+		from one_fm.operations.doctype.route_plan.route_plan import _trip_peak
+
+		trip = frappe._dict(
+			direction="MIXED",
+			headcount=6,
+			rows=[
+				frappe._dict(direction="OUTBOUND", headcount=3, stop_index=1,
+							 start_time=None, name=None, transportation_shipment=None),
+				frappe._dict(direction="RETURN", headcount=3, stop_index=2,
+							 start_time=None, name=None, transportation_shipment=None),
+			],
+		)
+
+		self.assertEqual(_trip_peak(trip), (3, 1))
+
+	def test_the_leg_walk_is_not_left_to_chance(self):
+		# The child-row name is a random hash, so ordering on it alone was non-
+		# deterministic once a run held both directions.
+		self.assertIn('str(row.start_time or "")', ROUTE_PLAN.read_text())
+
+
+class TestARunIsDrawnAsWhatItIs(FrappeTestCase):
+	"""A run reading MIXED for the seat check must not still draw as an outbound one."""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_the_block_colour_comes_from_the_same_rule(self):
+		self.assertIn("direction: this.runDirection(stops),", self.source)
+		self.assertNotIn(
+			"stops.some(s => s.direction === 'MIXED') ? 'MIXED' : firstItem.direction",
+			self.source,
+		)
+
+
+class TestARefusalNamesTheRunThatTookTheSeats(FrappeTestCase):
+	"""A card is placed at its own shift window, never where it was dropped, so the run
+	that blocks it is often not the block the operator was aiming at.
+	"""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_the_message_can_name_the_blocking_runs(self):
+		self.assertIn("capacityMessage(headcount, vehicle, blockers) {", self.source)
+		self.assertIn("Those seats are held by {0}.", self.source)
+
+	def test_the_check_and_the_message_read_one_list(self):
+		# Computed separately they would drift, and name runs the check never counted.
+		self.assertIn("tripsDuringCardWindows(card, vehicleId, direction) {", self.source)
+		self.assertIn(
+			"return this.tripsDuringCardWindows(card, vehicleId, direction)", self.source
+		)
+
+	def test_a_logical_trip_carries_its_name(self):
+		self.assertIn("tripName: item.tripName || null,", self.source)
+
+
+class TestTripNamesAreNotReissued(FrappeTestCase):
+	"""Removing a trip that is not the last used to hand its successor a taken name."""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_the_next_free_number_is_used_not_the_count(self):
+		self.assertIn("while (taken.has(name(seq))) seq++;", self.source)
+		self.assertNotIn("const nextSeq = existingTripIds.size + 1;", self.source)
+
+
+class TestEveryMergeGoesThroughTheMergeWindow(FrappeTestCase):
+	"""The picker used to chain a cross-direction stop without ever showing the modal."""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_a_transit_time_no_longer_skips_the_merge_window(self):
+		self.assertIn("if (self._isMergeDrop(newCard, existingItems)) {", self.source)
+		self.assertNotIn(
+			"if (!presetTransitMin && self._isMergeDrop(newCard, existingItems)) {", self.source
+		)
+
+	def test_the_picker_offers_the_nearest_run_first(self):
+		# Options were built in row order, so any run could be the default.
+		self.assertIn("tripKeys.sort((a, b) => gapToCard(tripMap[a]) - gapToCard(tripMap[b]));", self.source)
+
+
+class TestMarkUnflaggedMixedTripsPatch(FrappeTestCase):
+	"""The runs merged through the trip picker before it reached merge_trip_shipments."""
+
+	VEHICLE = "VHL-L-0022"  # 4 seats -> 3 legal passenger seats
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		if not frappe.db.exists("Vehicle", cls.VEHICLE):
+			raise cls.skipTest(cls, f"Fixture vehicle {cls.VEHICLE} missing on this site")
+
+	def _shipment(self, direction):
+		doc = frappe.new_doc("Transportation Shipment")
+		doc.status = "Assigned"
+		doc.trip_direction = direction
+		doc.headcount = 1
+		doc.generation_key = frappe.generate_hash("TS-MIX", 10)
+		doc.insert(ignore_permissions=True)
+		return doc.name
+
+	def _plan(self, *legs):
+		"""One run on one vehicle; each leg is (direction, shipment)."""
+		group = frappe.generate_hash("RUN", 8)
+		doc = frappe.new_doc("Route Plan")
+		doc.title = frappe.generate_hash("RP-MIX", 8)
+		doc.status = "Draft"
+		doc.effective_from = today()
+		for index, (direction, shipment) in enumerate(legs, start=1):
+			doc.append("assignments", {
+				"card_id": f"TSHIP-{shipment}",
+				"transportation_shipment": shipment,
+				"vehicle": self.VEHICLE,
+				"direction": direction,
+				"trip_group": group,
+				"trip_name": group,
+				"stop_index": index,
+				"headcount": 1,
+			})
+		doc.flags.ignore_mandatory = True
+		doc.flags.ignore_links = True
+		doc.insert(ignore_permissions=True)
+		return doc
+
+	def _read(self, name):
+		return frappe.db.get_value(
+			"Transportation Shipment", name,
+			["trip_direction", "pre_merge_trip_direction"], as_dict=True
+		)
+
+	def test_a_run_whose_stops_disagree_is_marked_mixed(self):
+		out, ret = self._shipment("Outward"), self._shipment("Return")
+		plan = self._plan(("OUTBOUND", out), ("RETURN", ret))
+
+		execute_mixed_patch()
+
+		plan.reload()
+		self.assertEqual({row.direction for row in plan.assignments}, {"MIXED"})
+		self.assertEqual(self._read(out).trip_direction, "Mixed")
+		self.assertEqual(self._read(ret).trip_direction, "Mixed")
+
+	def test_each_card_keeps_a_record_of_the_leg_it_was_generated_for(self):
+		out, ret = self._shipment("Outward"), self._shipment("Return")
+		self._plan(("OUTBOUND", out), ("RETURN", ret))
+
+		execute_mixed_patch()
+
+		self.assertEqual(self._read(out).pre_merge_trip_direction, "Outward")
+		self.assertEqual(self._read(ret).pre_merge_trip_direction, "Return")
+
+	def test_the_repair_is_reversible(self):
+		# Without a remembered direction there is nothing to restore (WI-002071).
+		from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
+			unmerge_trip_shipment,
+		)
+
+		out, ret = self._shipment("Outward"), self._shipment("Return")
+		self._plan(("OUTBOUND", out), ("RETURN", ret))
+		execute_mixed_patch()
+
+		self.assertTrue(unmerge_trip_shipment(out))
+		self.assertEqual(self._read(out).trip_direction, "Outward")
+		self.assertIsNone(self._read(out).pre_merge_trip_direction)
+
+	def test_a_single_direction_run_is_left_alone(self):
+		# Several camps on one outbound run is not a merge.
+		a, b = self._shipment("Outward"), self._shipment("Outward")
+		plan = self._plan(("OUTBOUND", a), ("OUTBOUND", b))
+
+		execute_mixed_patch()
+
+		plan.reload()
+		self.assertEqual({row.direction for row in plan.assignments}, {"OUTBOUND"})
+		self.assertEqual(self._read(a).trip_direction, "Outward")
+		self.assertFalse(self._read(a).pre_merge_trip_direction)
+
+	def test_running_it_twice_does_not_overwrite_the_original_with_mixed(self):
+		out, ret = self._shipment("Outward"), self._shipment("Return")
+		self._plan(("OUTBOUND", out), ("RETURN", ret))
+
+		execute_mixed_patch()
+		execute_mixed_patch()
+
+		self.assertEqual(self._read(out).pre_merge_trip_direction, "Outward")
+		self.assertEqual(self._read(out).trip_direction, "Mixed")


### PR DESCRIPTION
Port of #6794 (merged to `staging`) onto `version-15`. Same code, with the explanatory comments cut back.

Fixes [WI-002160](https://one-fm.com/app/work-item/WI-002160) — *[Irfan] Overcapacity Issues in Transportation Scheduling*.

> When adding a new trip, the system shows a capacity-exceeded error because the count is being calculated based on the previous trip. Even if there is space left in the vehicle, it is showing over-capacity error.

## 1. The seat reading

Dropping a 1-passenger card onto **22/32135 RAIZE** (4 seats, 3 passengers) was refused. The run it collided with — **S-204**, an outward drop of 1 then two return pickups of 1 — never holds more than **2**.

Both the canvas and the Route Plan keyed a logical trip on `(vehicle, trip_group, direction)`. That splits a run which both drops off and picks up into two pseudo-trips **whose windows overlap each other**, and the concurrency check then adds the same bus to itself:

```
S-204 outbound  1 pax  15:50–16:50   ┐ counted as
S-204 return    2 pax  16:50–17:05   ┘ two buses
new card        1 pax  16:00–17:00
                ─────
                4 > 3  →  refused
```

Only the Merge Trip modal ever wrote `MIXED` onto a row, so a return stop chained onto an outbound run left every row on its original heading — **22 runs** on the live plan have that shape.

A trip group on one vehicle is now one run whichever way its stops are headed, and a run whose stops disagree is **mixed** — walked leg by leg rather than summed. The canvas reads it through a single `runDirection()` so the places that weigh a run cannot drift. Two supporting corrections: the leg walk falls back to a row's own direction when it carries no shipment, and it orders stops by `(stop_index, start_time)` rather than by the child-row name, which is a random hash — stop order changes the answer.

## 2. What testing it turned up

- **The block still drew blue** — a run reading MIXED for the seat check built its own colour from the first stop's direction.
- **The refusal named only the bus.** A card is placed at its own shift window, never where it was dropped, so the blocking run is routinely not the block being aimed at. It now names the runs holding the seats and when they hold them, off the same list the check reads.
- **Trip names were re-issued** — `generateTripName` used the *count* of trips plus one, so removing any trip but the last handed its successor a name already in use. Now the next free number.
- **The trip picker skipped the Merge Trip modal** whenever a transit time came with the call, which is always on the picker's path — so a cross-direction merge made there never reached `merge_trip_shipments`. **That is where the un-flagged mixed runs came from.**
- **The picker offered the wrong default** — options were in row order, so a distant run could be the default. Nearest run first now.
- **A direction mismatch no longer unassigns a placed card.** `_sync_shipment_statuses` demoted a card the plan still places, and Generate Shipments deletes Unassigned shift-generated cards — so a browser tab left open across a data change could get a placed card deleted. A mismatch still never promotes a card to Assigned; it only no longer demotes one. This is what makes `bench migrate` safe without a quiet window or a reload drill.

## 3. Repair patch

`mark_unflagged_mixed_trips` brings the runs already on the plan up to what a real merge would have written: every assignment row `MIXED`, every shipment `Mixed` with its own leg kept in `pre_merge_trip_direction` so `unmerge_trip_shipment` can still put it back. Only runs whose rows genuinely disagree are touched. Rows are written with `db.set_value` rather than by saving the plan, so a patch cannot fail on some unrelated lane of a months-old plan.

Measured against the restore: 22 runs to repair, 101 rows to flip, 101 shipments to mark Mixed, 0 failing the leg-by-leg seat check afterwards.

## Verification (from #6794)

Replayed over the live Route Plan (`RP-2026-06-1754678`, 25 lanes): the reported drop is accepted at `peakLoad 2 + 1 = 3` of 3 seats, and no lane gains a false refusal. `test_route_plan` 64 green, 18 new tests including that the patch is reversible, leaves single-direction runs alone, and never overwrites a remembered direction.

Diff against the merged version is comments only.

## Merge notes

Each of the four `version-15` ports is branched off `version-15` on its own, so they can land in any order.

- Conflicts with #6804 on the last line of `patches.txt` — both append a patch. Resolution is to keep both lines.
- Touches `transportation_schedule.js` alongside #6803 and `transportation_schedule.py` alongside #6801, in both cases a few hundred lines apart. Neither of their changes is included here.
