### PR TITLE
fix(transportation-schedule): redraw a saved run on one day, not two [version-15]

### DIFF
--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
@@ -2558,22 +2558,39 @@ function mountRoutePlannerApp(wrapper, data) {
                     return endDate >= todayStr;   // drop lapsed (release the lane)
                 });
 
-                // Rebase EACH block onto today's timeline independently, then
-                // re-derive its end from the daily trip length. Every block now
-                // carries its own lifespan start date (the DATE part of start_time),
-                // so a single shared offset is wrong: one block whose start sits in
-                // the past — an ongoing multi-day lock, or a row edited to a past
-                // date — would otherwise drag every block off-screen and blank the
-                // whole grid. Shifting per block by whole days (which preserves the
-                // UTC time-of-day, and so the render position) keeps each one in the
-                // current window on its own.
+                // Rebase onto today's timeline by whole days, which preserves the UTC
+                // time-of-day and so the render position. Each block carries its own
+                // lifespan start date, so it is shifted on its own: a shared offset would
+                // let one block sitting in the past drag every other one off-screen.
+                // The anchor is today's local midnight, not planStart, which sits 3h before
+                // it — reaching the window is not the same as reaching today.
+                const todayStart = this.planStart.getTime() + (3 * 3600000);
+                const dayShift = (startMs) => -Math.floor((startMs - todayStart) / dayMs) * dayMs;
                 parsedItems = parsedItems.map(i => {
-                    let startMs = i.start.getTime();
-                    if (startMs < this.planStart.getTime()) {
-                        startMs += Math.ceil((this.planStart.getTime() - startMs) / dayMs) * dayMs;
-                    } else if (startMs > this.planEnd.getTime()) {
-                        startMs -= Math.ceil((startMs - this.planEnd.getTime()) / dayMs) * dayMs;
+                    const startMs = i.start.getTime();
+                    return { ...i, start: new Date(startMs + dayShift(startMs)) };
+                });
+
+                // Then pull each trip back onto one day: shifted per block, a run
+                // straddling the ~30h window's edge came back spanning nearly a day and
+                // "overlapped" every other run on the lane. Each stop takes the day
+                // NEAREST its trip's first stop — nearest, not next, because the stops of
+                // one trip carry unrelated save-dates and one landing slightly before stop
+                // one must stay where it is.
+                const tripAnchor = {};
+                parsedItems.forEach(i => {
+                    if (!i.tripId) return;
+                    const idx = i.stopIndex || 0;
+                    const ms = i.start.getTime();
+                    const held = tripAnchor[i.tripId];
+                    if (!held || idx < held.idx || (idx === held.idx && ms < held.ms)) {
+                        tripAnchor[i.tripId] = { idx, ms };
                     }
+                });
+                parsedItems = parsedItems.map(i => {
+                    const anchor = i.tripId ? tripAnchor[i.tripId] : null;
+                    let startMs = i.start.getTime();
+                    if (anchor) startMs += Math.round((anchor.ms - startMs) / dayMs) * dayMs;
                     const start = new Date(startMs);
                     const end = new Date(startMs + i._dailyDurMs);
                     return { ...i, start, end };

--- a/one_fm/tests/test_lane_day_rebase.py
+++ b/one_fm/tests/test_lane_day_rebase.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""A saved run is redrawn on today's lane, and its stops must land on the same day."""
+
+import pathlib
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+CANVAS = pathlib.Path(frappe.get_app_path(
+	"one_fm", "one_fm", "page", "transportation_schedule", "transportation_schedule.js"
+))
+
+
+class TestATripComesBackInOnePiece(FrappeTestCase):
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_every_block_lands_on_today_at_its_own_time_of_day(self):
+		self.assertIn(
+			"const todayStart = this.planStart.getTime() + (3 * 3600000);", self.source
+		)
+		self.assertIn(
+			"const dayShift = (startMs) => -Math.floor((startMs - todayStart) / dayMs) * dayMs;",
+			self.source,
+		)
+		self.assertIn("return { ...i, start: new Date(startMs + dayShift(startMs)) };", self.source)
+
+	def test_a_trip_is_then_pulled_onto_one_day(self):
+		self.assertIn("const tripAnchor = {};", self.source)
+		self.assertIn(
+			"if (anchor) startMs += Math.round((anchor.ms - startMs) / dayMs) * dayMs;",
+			self.source,
+		)
+
+	def test_the_day_is_the_nearest_one_not_the_next_one(self):
+		# Rounding, not flooring: a stop landing slightly before stop one stays put.
+		self.assertNotIn("Math.ceil((anchor.ms - startMs)", self.source)
+		self.assertIn("Math.round((anchor.ms - startMs)", self.source)
+
+	def test_the_shift_is_not_decided_by_the_trips_earliest_stamp(self):
+		# The earliest raw timestamp is a lock lifespan, not the run's date.
+		self.assertNotIn("tripShift[i.tripId] = { earliest", self.source)


### PR DESCRIPTION
Port of #6797 (merged to `staging`) onto `version-15`. Same code, with the explanatory comments cut back.

## The report

On lane **23/79322** (Coaster, 22 seats), trips **S-1701** and **S-1703** were painted **Overcapacity** — 18 and 17 passengers against 22 seats, with nothing else on the lane at those hours. No trip was over its seats: the lane was reading a *fourth* run as though it lasted all day.

## Root cause

A Route Plan Assignment timestamp carries two things — the **TIME** is the daily trip window, the **DATE** is the multi-day lock lifespan — so the canvas shifts every block onto today by whole days. Doing that per block tore a run apart: S-1704's stops sit across the plan window's edge, so its first stop shifted 3 days and the rest 2. A 45-minute run came back as a 23-hour band, which then overlapped every other run on the lane and lent them its 9 passengers (`18 + 9 > 22`, `17 + 9 > 22`).

## The fix

Blocks are still moved one at a time — each carries its own lifespan date, and one block sitting in the past would drag the rest off-screen — but each **trip** is then pulled back onto a single day: every stop takes the day that puts it **nearest** its trip's first stop. Nearest, not next: the stops of one trip carry unrelated save-dates, so a stop landing slightly *before* stop one has to stay where it is.

The shift also anchors on today's **local midnight** rather than on `planStart`, which sits 3h before it — a stop whose time of day fell in that margin settled a day early and rendered off the visible axis.

## Verification (from #6797)

Replayed over the live Route Plan (`RP-2026-06-1754678`, 25 lanes): lanes painted Overcapacity went from `23/79322 [S-1701, S-1703]` to none, no blocks land off today's axis, longest trip span 24h → 2.5h. 4 tests.

Diff against the merged version is comments only.
