### PR TITLE
WI-002162: the transport team can refresh its own shipment cards [version-15]

### DIFF
--- a/one_fm/one_fm/doctype/transportation_shipment/shipment_generator.py
+++ b/one_fm/one_fm/doctype/transportation_shipment/shipment_generator.py
@@ -33,6 +33,8 @@ COMPANY_FLEET = "Company Fleet"
 MAHBOULA_LABELS = {"Mahboula 3", "Mahboula 12", "Mahboula 13", "Mahboula 15"}
 # Return riders may finish up to an hour after the outbound leg departs.
 RETURN_MATCH_FLOOR_SECONDS = -3600
+# Who may refresh the shipment cards from the canvas (WI-002162).
+GENERATE_ROLES = ("System Manager", "Transportation Manager", "Transportation Supervisor")
 
 
 def _minute_of_day(time_val) -> int | None:
@@ -328,7 +330,7 @@ def generate_transportation_shipments():
 	"""
 	# The scheduler runs as Administrator; guard interactive/API calls.
 	if frappe.session.user != "Administrator":
-		frappe.only_for("System Manager")
+		frappe.only_for(GENERATE_ROLES)
 
 	nested_map = get_grouped_employees_by_accommodation()
 	demands = build_demand_descriptors(nested_map)

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -597,3 +597,4 @@ one_fm.patches.v15_0.approve_attendance_check_jul11_2026 #2026-08-16
 one_fm.patches.v15_0.fix_resignation_v2_stale_migration #2026-08-17
 one_fm.patches.v15_0.backfill_employee_resignation_auto_assign #2026-08-19
 one_fm.patches.v15_0.disable_roster_double_shift_ot_checker_assignment_rules #2026-08-21 WI-001689 reverted
+one_fm.patches.v15_0.grant_transportation_manager_schedule_access #2026-08-24 WI-002162

--- a/one_fm/patches/v15_0/grant_transportation_manager_schedule_access.py
+++ b/one_fm/patches/v15_0/grant_transportation_manager_schedule_access.py
@@ -1,0 +1,67 @@
+import frappe
+
+PAGE = "transportation-schedule"
+ROLE = "Transportation Manager"
+# Mirrors what Transportation Supervisor already holds on Route Plan.
+ROUTE_PLAN_PERMS = {
+	"select": 1, "read": 1, "write": 1, "create": 1, "delete": 1,
+	"report": 1, "export": 1, "share": 1, "print": 1, "email": 1,
+}
+
+
+def execute():
+	"""Let Transportation Manager open and run the Transportation Schedule (WI-002162).
+
+	The page is role-restricted and the board behind it is a Route Plan, so relaxing
+	the whitelisted method's role gate is not enough on its own. Nothing is granted on
+	Transportation Shipment: the generator writes those with ignore_permissions and the
+	canvas reads them server-side, as it already does for the Supervisor.
+	"""
+	if not frappe.db.exists("Role", ROLE):
+		return
+
+	_grant_page_role()
+	_grant_route_plan_perms()
+	frappe.clear_cache()
+
+
+def _grant_page_role():
+	"""Add the role to the page's Custom Role, creating the record if there is none."""
+	name = frappe.db.get_value("Custom Role", {"page": PAGE}, "name")
+	if not name:
+		# No Custom Role means the Page's own roles still apply; carry them over so
+		# creating one here does not lock the current holders out.
+		page = frappe.get_doc("Page", PAGE)
+		doc = frappe.new_doc(doctype="Custom Role")
+		doc.page = PAGE
+		for row in page.roles:
+			doc.append("roles", {"role": row.role})
+		doc.append("roles", {"role": ROLE})
+		doc.insert(ignore_permissions=True)
+		return
+
+	doc = frappe.get_doc("Custom Role", name)
+	if any(row.role == ROLE for row in doc.roles):
+		return
+	doc.append("roles", {"role": ROLE})
+	doc.save(ignore_permissions=True)
+
+
+def _grant_route_plan_perms():
+	"""Give the role real access to Route Plan.
+
+	Route Plan already carries Custom DocPerm rows, and once any exist Frappe stops
+	honouring the DocType JSON for every other role - so this has to be one too.
+	"""
+	if frappe.db.exists("Custom DocPerm", {"parent": "Route Plan", "role": ROLE}):
+		return
+
+	frappe.get_doc({
+		"doctype": "Custom DocPerm",
+		"parent": "Route Plan",
+		"parenttype": "DocType",
+		"parentfield": "permissions",
+		"role": ROLE,
+		"permlevel": 0,
+		**ROUTE_PLAN_PERMS,
+	}).insert(ignore_permissions=True)

--- a/one_fm/tests/test_generate_shipments_access.py
+++ b/one_fm/tests/test_generate_shipments_access.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002162: who may press "Generate Shipments" on the Transportation Schedule."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.one_fm.doctype.transportation_shipment.shipment_generator import GENERATE_ROLES
+from one_fm.patches.v15_0.grant_transportation_manager_schedule_access import execute
+
+ROLE = "Transportation Manager"
+
+
+class TestGenerateShipmentsIsTheTransportTeams(FrappeTestCase):
+	def test_both_transport_roles_may_refresh_the_cards(self):
+		self.assertIn("Transportation Manager", GENERATE_ROLES)
+		self.assertIn("Transportation Supervisor", GENERATE_ROLES)
+
+	def test_system_manager_keeps_the_access_it_had(self):
+		self.assertIn("System Manager", GENERATE_ROLES)
+
+	def _page_roles(self):
+		name = frappe.db.get_value("Custom Role", {"page": "transportation-schedule"}, "name")
+		return [row.role for row in frappe.get_doc("Custom Role", name).roles]
+
+	def test_the_patch_opens_the_page_and_the_plan_to_the_manager(self):
+		# The page is role-restricted and the board is a Route Plan: both are needed
+		# before the manager even reaches the button.
+		if not frappe.db.exists("Role", ROLE):
+			self.skipTest(f"{ROLE} role missing on this site")
+
+		execute()
+
+		roles = self._page_roles()
+		self.assertIn(ROLE, roles)
+		self.assertIn("Transportation Supervisor", roles)  # not disturbed
+		self.assertTrue(frappe.db.exists(
+			"Custom DocPerm", {"parent": "Route Plan", "role": ROLE}
+		))
+
+	def test_running_the_patch_twice_grants_nothing_twice(self):
+		if not frappe.db.exists("Role", ROLE):
+			self.skipTest(f"{ROLE} role missing on this site")
+
+		execute()
+		execute()
+
+		self.assertEqual(self._page_roles().count(ROLE), 1)
+		self.assertEqual(frappe.db.count(
+			"Custom DocPerm", {"parent": "Route Plan", "role": ROLE}
+		), 1)


### PR DESCRIPTION
Port of #6796 (merged to `staging`) onto `version-15`. Same code, with the explanatory comments cut back.

Fixes [WI-002162](https://one-fm.com/app/work-item/WI-002162) — *[Irfan] Generate Shipment Cards*.

> Transportation Manager and Transportation Supervisors should have access to click the "Generate Shipments" button and update the Shipment Cards.

## The report

`i.anware@one-fm.com`, who holds both transport roles, presses **Generate Shipments** and gets *"You do not have enough permissions to access this resource"*. `generate_transportation_shipments` was gated on `frappe.only_for("System Manager")`, so the person running the board had to ask someone else to press the button on it.

## The fix

Both transport roles may now run it, alongside System Manager. The scheduler still runs as Administrator and is unaffected.

The role gate is only half of it — the page is role-restricted and the board it saves to is a Route Plan, and neither listed Transportation Manager, so the manager never reached the button to be refused by it. A patch adds the role to the page's **Custom Role** and to Route Plan as a **Custom DocPerm** (not the DocType JSON: Route Plan already carries Custom DocPerm rows, and Frappe stops honouring the JSON for every other role once any exist). Transportation Supervisor already holds both and is untouched. Nothing is granted on Transportation Shipment — the generator writes those with `ignore_permissions` and the canvas reads them server-side.

## Verification (from #6796)

4 tests, including running the patch twice and asserting nothing is granted twice.

## To deploy

`bench migrate` — the grants land through the patch.

Diff against the merged version is comments only.

## Merge note

Conflicts with #6802 on the last line of `patches.txt` — both append a patch. Resolution is to keep both lines.
