### PR TITLE
Vehicle: warn when insurance has expired

### DIFF
--- a/one_fm/public/js/doctype_js/vehicle.js
+++ b/one_fm/public/js/doctype_js/vehicle.js
@@ -1,8 +1,9 @@
-frappe.ui.form.on('Vehicle', {
+frappe.ui.form.on("Vehicle", {
 	refresh(frm) {
 		set_qr_code(frm);
 		frappe.breadcrumbs.add("GSD");
-		frm.set_df_property('license_plate', 'hidden', false);
+		frm.set_df_property("license_plate", "hidden", false);
+		check_insurance_expiry(frm);
 	},
 	onload(frm) {
 		if (frm.is_new() && !frm.doc.custom_naming_series) {
@@ -11,37 +12,37 @@ frappe.ui.form.on('Vehicle', {
 	},
 	one_fm_vehicle_category(frm) {
 		const series_map = {
-			"Owned": "VHL-.####",
-			"Leased": "VHL-L-.####",
-			"Subcontractor": "VHL-S-.####"
+			Owned: "VHL-.####",
+			Leased: "VHL-L-.####",
+			Subcontractor: "VHL-S-.####",
 		};
 		const category = frm.doc.one_fm_vehicle_category;
 		frm.set_value("custom_naming_series", series_map[category] || "VHL-.####");
 		frm.set_df_property("vehicle_leasing_contract", "reqd", category === "Leased");
 	},
-	vehicle_leasing_contract(frm){
-	  if(!frm.doc.vehicle_leasing_contract){
-	      frm.set_value('vehicle_leasing_details', '');
-	  }
+	vehicle_leasing_contract(frm) {
+		if (!frm.doc.vehicle_leasing_contract) {
+			frm.set_value("vehicle_leasing_details", "");
+		}
 	},
-	vehicle_leasing_details(frm){
-	    if(frm.doc.vehicle_leasing_details){
-	        frappe.call({
-	           method: "one_fm.fleet_management.doctype.vehicle_leasing_contract.vehicle_leasing_contract.get_vehicle_from_leasing_contract",
-				args: {'vehicle_detail': frm.doc.vehicle_leasing_details},
-				callback: function(r) {
-					if(!r.exc){
-					    var data = r.message;
-					    frm.set_value('make', data.make);
-					    frm.set_value('model', data.model);
-					    frm.set_value('one_fm_vehicle_type', data.vehicle_type);
-					    frm.set_value('one_fm_year_of_made', data.year_of_made);
+	vehicle_leasing_details(frm) {
+		if (frm.doc.vehicle_leasing_details) {
+			frappe.call({
+				method: "one_fm.fleet_management.doctype.vehicle_leasing_contract.vehicle_leasing_contract.get_vehicle_from_leasing_contract",
+				args: { vehicle_detail: frm.doc.vehicle_leasing_details },
+				callback: function (r) {
+					if (!r.exc) {
+						var data = r.message;
+						frm.set_value("make", data.make);
+						frm.set_value("model", data.model);
+						frm.set_value("one_fm_vehicle_type", data.vehicle_type);
+						frm.set_value("one_fm_year_of_made", data.year_of_made);
 					}
 				},
 				freeze: true,
-				freeze_message: "Fetching Vehicle Details..."
-	        });
-	    }
+				freeze_message: "Fetching Vehicle Details...",
+			});
+		}
 	},
 	employee(frm) {
 		// A handover to a new custodian is logged the moment a new Employee is
@@ -64,19 +65,24 @@ frappe.ui.form.on('Vehicle', {
 	one_fm_milage(frm) {
 		// The current mileage feeds the active custodian's covered distance.
 		calculate_custodian_mileage(frm);
-	}
-})
+	},
+	end_date(frm) {
+		// Insurance end date changed while the form is open: re-evaluate the
+		// expiry indicator immediately, without waiting for a reload.
+		check_insurance_expiry(frm);
+	},
+});
 
-var log_custodian_handover = function(frm) {
+var log_custodian_handover = function (frm) {
 	let row = frm.add_child("custom_vehicle_custodian_history", {
 		employee_id: frm.doc.employee,
 		handover_date: frm.doc.custom_handover_date,
-		mileage_at_handover: cint(frm.doc.one_fm_milage)
+		mileage_at_handover: cint(frm.doc.one_fm_milage),
 	});
 
 	// Populate Employee Name immediately for display (also resolved on save via fetch_from).
 	if (frm.doc.employee) {
-		frappe.db.get_value("Employee", frm.doc.employee, "employee_name").then(r => {
+		frappe.db.get_value("Employee", frm.doc.employee, "employee_name").then((r) => {
 			if (r && r.message) {
 				row.employee_name = r.message.employee_name;
 				frm.refresh_field("custom_vehicle_custodian_history");
@@ -88,18 +94,18 @@ var log_custodian_handover = function(frm) {
 	calculate_custodian_mileage(frm);
 };
 
-var get_active_custodian_row = function(frm) {
+var get_active_custodian_row = function (frm) {
 	let rows = frm.doc.custom_vehicle_custodian_history || [];
 	return rows.length ? rows[rows.length - 1] : null;
 };
 
-var calculate_custodian_mileage = function(frm) {
+var calculate_custodian_mileage = function (frm) {
 	// Past rows:  next row's mileage_at_handover - this row's mileage_at_handover.
 	// Active row: parent's current mileage (one_fm_milage) - this row's mileage_at_handover.
 	let rows = frm.doc.custom_vehicle_custodian_history || [];
 	let current_mileage = flt(frm.doc.one_fm_milage);
 
-	rows.forEach(function(row, index) {
+	rows.forEach(function (row, index) {
 		let covered;
 		if (index < rows.length - 1) {
 			covered = flt(rows[index + 1].mileage_at_handover) - flt(row.mileage_at_handover);
@@ -112,7 +118,32 @@ var calculate_custodian_mileage = function(frm) {
 	frm.refresh_field("custom_vehicle_custodian_history");
 };
 
-var set_qr_code = function(frm) {
+var check_insurance_expiry = function (frm) {
+	// The dashboard has no API to remove a single indicator once added, so we
+	// keep a reference to the element we appended and drop it ourselves before
+	// deciding, from scratch, whether it belongs on the form right now. This
+	// keeps the check safe to re-run on every refresh and on every end_date edit.
+	if (frm.__insurance_expired_indicator) {
+		frm.__insurance_expired_indicator.remove();
+		frm.__insurance_expired_indicator = null;
+	}
+
+	if (!frm.doc.end_date) {
+		return;
+	}
+
+	let end_date = frappe.datetime.str_to_obj(frm.doc.end_date);
+	let today = frappe.datetime.str_to_obj(frappe.datetime.get_today());
+
+	if (end_date < today) {
+		frm.__insurance_expired_indicator = frm.dashboard.add_indicator(
+			__("Insurance Expired"),
+			"red",
+		);
+	}
+};
+
+var set_qr_code = function (frm) {
 	let qr_code_html = `{%if doc.name%}
 	<div style="display: inline-block;padding: 5%;">
 	<div class="qr_code_print" id="qr_code_print">
@@ -130,8 +161,8 @@ var set_qr_code = function(frm) {
 	    newWin.print();
 	});
 	</script>
-	`
-	var qr_code = frappe.render_template(qr_code_html, {"doc":frm.doc});
+	`;
+	var qr_code = frappe.render_template(qr_code_html, { doc: frm.doc });
 	$(frm.fields_dict["one_fm_vehicle_qr_code"].wrapper).html(qr_code);
-	refresh_field("one_fm_vehicle_qr_code")
+	refresh_field("one_fm_vehicle_qr_code");
 };


### PR DESCRIPTION
Added an insurance-expiry check to the one_fm customisation script for the ERPNext Vehicle DocType (one_fm/one_fm/public/js/doctype_js/vehicle.js), already registered against Vehicle via the doctype_js hook (confirmed already present in hooks.py — no hooks.py change was needed).

What changed:
- New helper check_insurance_expiry(frm): if end_date is set and is before today, adds a red dashboard indicator reading "Insurance Expired" via frm.dashboard.add_indicator. If end_date is empty, today, or in the future, no indicator is shown.
- Since Frappe's form dashboard has no API to remove a single indicator, the helper keeps a reference to the jQuery element it appended on frm.__insurance_expired_indicator and removes that element itself at the start of every call before re-deciding from scratch — so it is safe to call repeatedly and the indicator correctly appears/disappears as end_date changes.
- Wired into refresh(frm) so the check is correct on form load.
- Wired into a new end_date(frm) field handler so editing the date on an open form re-evaluates the indicator live, with no reload needed.
- All existing behaviour is preserved untouched: QR code generation (set_qr_code, including its document.write() call, left exactly as-is per instructions), breadcrumb handling, license_plate field handling, custodian handover/mileage logic, and the vehicle-leasing logic.

Not touched: no file under erpnext/ was edited. This is purely a one_fm customisation script.

Verification:
- draft_change staged the file cleanly with no new house-rule findings.
- review_change approved the change. It reported two pre-existing findings (missing onBeforeUnmount cleanup, and the existing document.write() call) that were already in the file before this change and were explicitly called out in the work order as not to be fixed — left as-is.
- Desk JavaScript is bundled by bench at deploy time, not by the Vite build, so review_change correctly reports there was nothing for it to compile in that step; this is expected for desk-script-only changes.
- Not verified: actual on-screen appearance/behaviour in a running Frappe desk session (no live site access from this tool). A person should open a Vehicle record with an expired end_date, and one with a future/empty end_date, to confirm the indicator shows/hides as expected, and should edit end_date live on an open form to confirm the indicator updates without a reload.

---

Raised by the **Frontend Agent**. Source only - CI builds the Processa application on merge.

**Files**
- `one_fm/public/js/doctype_js/vehicle.js`

**Checks**
- build: no Processa application files in this change
- prettier: applied when each file was staged
- screening: passed
- house rules: no new findings

**Already in these files, left alone**
- one_fm/one_fm/public/js/doctype_js/vehicle.js: registers listeners but never cleans up in onBeforeUnmount.
- one_fm/one_fm/public/js/doctype_js/vehicle.js:160 - document.write() replaces the document.

This change has not been rendered in a browser. Review the diff.