### PR TITLE
Vehicle: show red "Insurance Expired" dashboard indicator when end_date has passed

### DIFF
--- a/one_fm/public/js/doctype_js/vehicle.js
+++ b/one_fm/public/js/doctype_js/vehicle.js
@@ -1,8 +1,9 @@
-frappe.ui.form.on('Vehicle', {
+frappe.ui.form.on("Vehicle", {
 	refresh(frm) {
 		set_qr_code(frm);
 		frappe.breadcrumbs.add("GSD");
-		frm.set_df_property('license_plate', 'hidden', false);
+		frm.set_df_property("license_plate", "hidden", false);
+		update_insurance_expired_indicator(frm);
 	},
 	onload(frm) {
 		if (frm.is_new() && !frm.doc.custom_naming_series) {
@@ -11,37 +12,37 @@ frappe.ui.form.on('Vehicle', {
 	},
 	one_fm_vehicle_category(frm) {
 		const series_map = {
-			"Owned": "VHL-.####",
-			"Leased": "VHL-L-.####",
-			"Subcontractor": "VHL-S-.####"
+			Owned: "VHL-.####",
+			Leased: "VHL-L-.####",
+			Subcontractor: "VHL-S-.####",
 		};
 		const category = frm.doc.one_fm_vehicle_category;
 		frm.set_value("custom_naming_series", series_map[category] || "VHL-.####");
 		frm.set_df_property("vehicle_leasing_contract", "reqd", category === "Leased");
 	},
-	vehicle_leasing_contract(frm){
-	  if(!frm.doc.vehicle_leasing_contract){
-	      frm.set_value('vehicle_leasing_details', '');
-	  }
+	vehicle_leasing_contract(frm) {
+		if (!frm.doc.vehicle_leasing_contract) {
+			frm.set_value("vehicle_leasing_details", "");
+		}
 	},
-	vehicle_leasing_details(frm){
-	    if(frm.doc.vehicle_leasing_details){
-	        frappe.call({
-	           method: "one_fm.fleet_management.doctype.vehicle_leasing_contract.vehicle_leasing_contract.get_vehicle_from_leasing_contract",
-				args: {'vehicle_detail': frm.doc.vehicle_leasing_details},
-				callback: function(r) {
-					if(!r.exc){
-					    var data = r.message;
-					    frm.set_value('make', data.make);
-					    frm.set_value('model', data.model);
-					    frm.set_value('one_fm_vehicle_type', data.vehicle_type);
-					    frm.set_value('one_fm_year_of_made', data.year_of_made);
+	vehicle_leasing_details(frm) {
+		if (frm.doc.vehicle_leasing_details) {
+			frappe.call({
+				method: "one_fm.fleet_management.doctype.vehicle_leasing_contract.vehicle_leasing_contract.get_vehicle_from_leasing_contract",
+				args: { vehicle_detail: frm.doc.vehicle_leasing_details },
+				callback: function (r) {
+					if (!r.exc) {
+						var data = r.message;
+						frm.set_value("make", data.make);
+						frm.set_value("model", data.model);
+						frm.set_value("one_fm_vehicle_type", data.vehicle_type);
+						frm.set_value("one_fm_year_of_made", data.year_of_made);
 					}
 				},
 				freeze: true,
-				freeze_message: "Fetching Vehicle Details..."
-	        });
-	    }
+				freeze_message: "Fetching Vehicle Details...",
+			});
+		}
 	},
 	employee(frm) {
 		// A handover to a new custodian is logged the moment a new Employee is
@@ -64,19 +65,24 @@ frappe.ui.form.on('Vehicle', {
 	one_fm_milage(frm) {
 		// The current mileage feeds the active custodian's covered distance.
 		calculate_custodian_mileage(frm);
-	}
-})
+	},
+	end_date(frm) {
+		// The insurance end_date can be edited while the form is open; keep the
+		// expiry indicator in sync without requiring a page reload.
+		update_insurance_expired_indicator(frm);
+	},
+});
 
-var log_custodian_handover = function(frm) {
+var log_custodian_handover = function (frm) {
 	let row = frm.add_child("custom_vehicle_custodian_history", {
 		employee_id: frm.doc.employee,
 		handover_date: frm.doc.custom_handover_date,
-		mileage_at_handover: cint(frm.doc.one_fm_milage)
+		mileage_at_handover: cint(frm.doc.one_fm_milage),
 	});
 
 	// Populate Employee Name immediately for display (also resolved on save via fetch_from).
 	if (frm.doc.employee) {
-		frappe.db.get_value("Employee", frm.doc.employee, "employee_name").then(r => {
+		frappe.db.get_value("Employee", frm.doc.employee, "employee_name").then((r) => {
 			if (r && r.message) {
 				row.employee_name = r.message.employee_name;
 				frm.refresh_field("custom_vehicle_custodian_history");
@@ -88,18 +94,18 @@ var log_custodian_handover = function(frm) {
 	calculate_custodian_mileage(frm);
 };
 
-var get_active_custodian_row = function(frm) {
+var get_active_custodian_row = function (frm) {
 	let rows = frm.doc.custom_vehicle_custodian_history || [];
 	return rows.length ? rows[rows.length - 1] : null;
 };
 
-var calculate_custodian_mileage = function(frm) {
+var calculate_custodian_mileage = function (frm) {
 	// Past rows:  next row's mileage_at_handover - this row's mileage_at_handover.
 	// Active row: parent's current mileage (one_fm_milage) - this row's mileage_at_handover.
 	let rows = frm.doc.custom_vehicle_custodian_history || [];
 	let current_mileage = flt(frm.doc.one_fm_milage);
 
-	rows.forEach(function(row, index) {
+	rows.forEach(function (row, index) {
 		let covered;
 		if (index < rows.length - 1) {
 			covered = flt(rows[index + 1].mileage_at_handover) - flt(row.mileage_at_handover);
@@ -112,11 +118,31 @@ var calculate_custodian_mileage = function(frm) {
 	frm.refresh_field("custom_vehicle_custodian_history");
 };
 
-var set_qr_code = function(frm) {
+var INSURANCE_EXPIRED_LABEL = "Insurance Expired";
+
+var update_insurance_expired_indicator = function (frm) {
+	// Remove any previously added copy of this indicator first, since
+	// frappe.ui.form.Dashboard has no built-in way to update one in place.
+	frm.dashboard.stats_area_row
+		.find(".indicator-column")
+		.filter(function () {
+			return $(this).text().trim() === INSURANCE_EXPIRED_LABEL;
+		})
+		.remove();
+
+	if (
+		frm.doc.end_date &&
+		frappe.datetime.get_diff(frm.doc.end_date, frappe.datetime.get_today()) < 0
+	) {
+		frm.dashboard.add_indicator(__(INSURANCE_EXPIRED_LABEL), "red");
+	}
+};
+
+var set_qr_code = function (frm) {
 	let qr_code_html = `{%if doc.name%}
 	<div style="display: inline-block;padding: 5%;">
 	<div class="qr_code_print" id="qr_code_print">
-		<img src="https://barcode.tec-it.com/barcode.ashx?code=MobileQRCode&multiplebarcodes=false&translate-esc=false&data={{doc.name}}&unit=Fit&dpi=150&imagetype=Gif&rotation=0&color=%23000000&bgcolor=%23ffffff&codepage=&qunit=Mm&quiet=2.5&eclevel=H" alt="">
+	<img src="https://barcode.tec-it.com/barcode.ashx?code=MobileQRCode&multiplebarcodes=false&translate-esc=false&data={{doc.name}}&unit=Fit&dpi=150&imagetype=Gif&rotation=0&color=%23000000&bgcolor=%23ffffff&codepage=&qunit=Mm&quiet=2.5&eclevel=H" alt="">
 	</div>
 	<br>
 	<input name="qr_b_print" type="button" class="qr_ipt" id="qr_ipt" value=" Print ">
@@ -130,8 +156,8 @@ var set_qr_code = function(frm) {
 	    newWin.print();
 	});
 	</script>
-	`
-	var qr_code = frappe.render_template(qr_code_html, {"doc":frm.doc});
+	`;
+	var qr_code = frappe.render_template(qr_code_html, { doc: frm.doc });
 	$(frm.fields_dict["one_fm_vehicle_qr_code"].wrapper).html(qr_code);
-	refresh_field("one_fm_vehicle_qr_code")
+	refresh_field("one_fm_vehicle_qr_code");
 };


### PR DESCRIPTION
Adds insurance-expiry logic to the existing one_fm customisation script for the ERPNext Vehicle DocType (one_fm/one_fm/public/js/doctype_js/vehicle.js). No erpnext/ files were touched.

What changed:
- New helper update_insurance_expired_indicator(frm): if frm.doc.end_date is set and is strictly before today (frappe.datetime.get_diff < 0), it adds a red dashboard indicator reading exactly "Insurance Expired" via frm.dashboard.add_indicator. If end_date is empty, today, or in the future, any previously-added copy of that indicator is removed and nothing is shown.
- Wired into refresh(frm) so opening an already-lapsed Vehicle shows the warning immediately.
- Wired into a new end_date(frm) event handler in the same frm.fields_dict form script object, so editing end_date live on an open form updates the indicator without a reload.
- Before adding a fresh indicator, the code removes any earlier "Insurance Expired" column it previously rendered (matched by exact text), since frappe.ui.form.Dashboard has no built-in "update in place" for indicators — this keeps repeated end_date edits from stacking duplicate indicators.

Confirmed unchanged / preserved:
- QR code generation (set_qr_code) — including the pre-existing document.write() call inside it, left exactly as-is per instructions (flagged by review as pre-existing, not touched).
- Breadcrumb logic (frappe.breadcrumbs.add("GSD")) and license_plate visibility handling in refresh.
- All existing custodian-handover and naming-series logic.

Hook registration: public/js/doctype_js/vehicle.js was already registered against Vehicle via the doctype_js hook in one_fm/hooks.py; register_hook confirmed this and made no changes to hooks.py.

Build/verification notes:
- This is a desk JavaScript change, not the Processa Vue app, so there is no Vite bundle to compile for it; review_change reported "No files from the Processa application are staged" and approved the change based on static/house-rule screening.
- Not independently verified in a running browser: that the indicator visually renders red and reads exactly "Insurance Expired" on a live Vehicle form, and that the duplicate-removal logic behaves correctly across multiple back-to-back end_date edits in the same session. A person should smoke-test this on a Vehicle record with a past end_date and then edit end_date live.
- Pre-existing issues in this file (unrelated to this change) were left untouched, as instructed: the file registers listeners without onBeforeUnmount cleanup (not applicable/relevant to desk form scripts), and the document.write() call inside the QR-code print helper.

---

Raised by the **Frontend Agent**. Source only - CI builds the Processa application on merge.

**Files**
- `one_fm/public/js/doctype_js/vehicle.js`

**Checks**
- build: no Processa application files in this change
- prettier: applied when each file was staged
- screening: passed
- house rules: no new findings

**Already in these files, left alone**
- one_fm/one_fm/public/js/doctype_js/vehicle.js: registers listeners but never cleans up in onBeforeUnmount.
- one_fm/one_fm/public/js/doctype_js/vehicle.js:155 - document.write() replaces the document.

This change has not been rendered in a browser. Review the diff.