### PR TITLE
WI-002069: the BA site renamed the GRD operator holder and put it on the form

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -585,7 +585,7 @@ one_fm.patches.v15_0.add_pcc_attestation_workflow_and_rules #2026-08-12 WI-00202
 one_fm.patches.v15_0.add_pcc_processing_fees_to_hr_settings #2026-08-12 WI-002026
 one_fm.patches.v15_0.add_shift_request_shift_preview #2026-08-12 WI-001834
 one_fm.patches.v15_0.restore_stranded_mixed_shipments #2026-08-17 WI-002071
-one_fm.patches.v15_0.migrate_visa_request_visibility #2026-08-20 WI-002069
+one_fm.patches.v15_0.migrate_visa_request_visibility #2026-08-29 WI-002069
 one_fm.patches.v15_0.hide_residency_apply_for #2026-08-20 WI-002105
 one_fm.patches.v15_0.add_preparation_category #2026-08-20 WI-002101
 one_fm.patches.v15_0.add_preparation_row_status #2026-08-20 WI-002093

--- a/one_fm/patches/v15_0/migrate_visa_request_visibility.py
+++ b/one_fm/patches/v15_0/migrate_visa_request_visibility.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.model.utils.rename_field import rename_field
 
 # WI-002069: the Visa Request visibility rules the BA site carries and this site did not, plus
 # three mandatory rules that had been switched off by writing "// " in front of them.
@@ -36,14 +37,20 @@ GATED_FIELDS = (
 MOI_STATE = "Pending By MOI"
 
 
-# WI-002069 (third pass): a Link the BA site added after the migration. Hidden there, and
-# nothing on that site reads it yet - no assignment rule takes its assignee from it and no
-# script mentions it - so it comes across as the empty holder it currently is.
-NEW_FIELD = "assign_grd_operator"
+# WI-002069 (third pass): a Link the BA site added after the migration, which that site has
+# since renamed and made visible - "assign_grd_operator", hidden, is now "grd_operator"
+# labelled GRD Operator. Still an empty holder there: no assignment rule takes its assignee
+# from it and no script mentions it.
+NEW_FIELD = "grd_operator"
+OLD_FIELD = "assign_grd_operator"
 
 
 def execute():
 	frappe.reload_doc("visa_management", "doctype", "visa_request")
+
+	# The holder shipped under its old name first, so anything already written to it moves
+	# with the rename rather than being left behind in an orphan column.
+	rename_field("Visa Request", OLD_FIELD, NEW_FIELD)
 
 	verify()
 

--- a/one_fm/visa_management/doctype/visa_request/test_visa_request_visibility.py
+++ b/one_fm/visa_management/doctype/visa_request/test_visa_request_visibility.py
@@ -24,7 +24,7 @@ DISABLED_RULES = ("custom_pam_file", "pam_reference_number", "custom_pam_designa
 BA_FIELDS = (
 	"section_break_mbv7", "naming_series", "job_offer", "candidate_country_process",
 	"job_applicant", "column_break_vujs", "request_date", "job_applicant_full_name", "agency",
-	"assign_grd_operator", "applicant_details_section", "first_name", "second_name",
+	"grd_operator", "applicant_details_section", "first_name", "second_name",
 	"third_name", "last_name", "first_name_in_arabic", "second_name_in_arabic",
 	"third_name_in_arabic", "last_name_in_arabic", "column_break_kupi", "nationality", "gender",
 	"religion", "place_of_birth", "date_of_birth", "marital_status", "designation",
@@ -158,15 +158,19 @@ class TestVisaRequestVisibility(FrappeTestCase):
 			with self.subTest(fieldname=fieldname):
 				self.assertIn(fieldname, meta_fields)
 
-	def test_the_grd_operator_holder_is_present_and_hidden(self):
-		"""Added on the BA site after the first migration pass. Nothing reads it there yet -
-		no assignment rule takes its assignee from it, no script mentions it - so it is an
-		empty holder, and it is hidden the way the BA site hides it."""
-		field = self.meta.get_field("assign_grd_operator")
+	def test_the_grd_operator_holder_matches_the_ba_site(self):
+		"""Added on the BA site after the first migration pass, and since renamed there from
+		"assign_grd_operator" to "grd_operator" and shown on the form. Nothing reads it yet -
+		no assignment rule takes its assignee from it, no script mentions it - so it is still
+		an empty holder, under the name and label the BA site now gives it."""
+		self.assertIsNone(self.meta.get_field("assign_grd_operator"))
+
+		field = self.meta.get_field("grd_operator")
 		self.assertIsNotNone(field)
 		self.assertEqual(field.fieldtype, "Link")
 		self.assertEqual(field.options, "User")
-		self.assertTrue(field.hidden)
+		self.assertEqual(field.label, "GRD Operator")
+		self.assertFalse(field.hidden)
 
 	def test_the_remark_fields_match_the_ba_site(self):
 		self.assertTrue(self.meta.get_field("operator_rejection_remark").read_only)

--- a/one_fm/visa_management/doctype/visa_request/visa_request.json
+++ b/one_fm/visa_management/doctype/visa_request/visa_request.json
@@ -15,7 +15,7 @@
   "request_date",
   "job_applicant_full_name",
   "agency",
-  "assign_grd_operator",
+  "grd_operator",
   "applicant_details_section",
   "first_name",
   "second_name",
@@ -590,10 +590,9 @@
    "read_only_depends_on": "eval:doc.workflow_state==\"Completed\" || doc.workflow_state==\"Rejected for Re Issue\" || doc.workflow_state==\"Awaiting Visa Cancellation\" || doc.workflow_state==\"Pending Cancel Work Permit\" || doc.workflow_state==\"Work Permit Cancelled\" || doc.workflow_state==\"Pending Recruiter Confirmation\""
   },
   {
-   "fieldname": "assign_grd_operator",
+   "fieldname": "grd_operator",
    "fieldtype": "Link",
-   "hidden": 1,
-   "label": "Assign GRD Operator",
+   "label": "GRD Operator",
    "options": "User"
   }
  ],
@@ -601,7 +600,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-08-24 14:00:00.000000",
+ "modified": "2026-08-29 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Visa Management",
  "name": "Visa Request",


### PR DESCRIPTION
[WI-002069](https://one-fm.com/app/work-item/WI-002069) — *migrate the Visa Request DocType and its configurations from the BA site to Staging.*

## What moved

The third pass added `assign_grd_operator` — a Link to User, hidden — because that is what the BA site's Visa Request carried on 24 August. On **27 August that site renamed it to `grd_operator` and stopped hiding it**, so the field now reads **GRD Operator** on the form.

Brought across as it now stands. It is still an empty holder there: no assignment rule takes its assignee from it, and none of that site's client or server scripts mentions it.

## The patch

`migrate_visa_request_visibility` now calls `rename_field`, so anything already written to the holder moves with the rename instead of being left behind in an orphan column. It is a no-op on a site that never received the earlier pass. The `patches.txt` line is re-dated so the patch runs again where it has already run once.

## Verification

Re-diffed the whole doctype against the BA site afterwards — every field, every attribute Frappe stores on a DocField, the doctype's own properties, and the permissions. Nothing else differs.

`test_visa_request_visibility` pins the BA site's field list by name and now asserts the new name, the label, and that the old fieldname is gone.

## After merge

    bench migrate
    bench restart