### PR TITLE
WI-002099: exempt the exempt sector, and state every figure as a whole number

### DIFF
--- a/one_fm/grd/doctype/pam_license_details/pam_license_details.py
+++ b/one_fm/grd/doctype/pam_license_details/pam_license_details.py
@@ -75,15 +75,19 @@ class PAMLicenseDetails(Document):
 				row.set(fieldname, value)
 
 
-def round_to_half(value):
-	"""PAM states its figures to the nearest half a person (WI-002094)."""
-	return round(flt(value) * 2) / 2
+def to_whole(value):
+	"""A figure as PAM states it: a whole number of people (WI-002094, WI-002099).
+
+	Half rounds up rather than to even, and by hand rather than through round() - every
+	figure here is a headcount and cannot be negative, and a licence that reads compliant on
+	one site and not on another because of a rounding setting is worse than either answer.
+	"""
+	return int(flt(value) + 0.5)
 
 
 def as_figure(value):
-	"""A figure as it goes into a Data field: "3" rather than "3.0", "2.5" as it is."""
-	value = round_to_half(value)
-	return str(int(value)) if value == int(value) else str(value)
+	"""A figure as it goes into a Data field: "3" rather than "3.0"."""
+	return str(to_whole(value))
 
 
 def expats_allowed(sector, ratio, nationals):
@@ -136,6 +140,12 @@ def derived_figures(sector, ratio, nationals, expatriates):
 	one that makes the figure and the Compliant / Non-Compliant status mean what they say.
 	Reversing it is one line if PAM's own wording turns out to be literal.
 
+	The exempt sector is the exception WI-002099 spells out: "there will be no expat
+	violation, as Kuwaitis are not allowed for this role... if the number of expats is 100,
+	the violation will be 0". PAM does not ration it, so it is allowed none and is over by
+	none - the allowance of zero is a statement that the ratio does not apply to it, not a
+	limit every expatriate on the books breaks.
+
 	The Status follows from the violation and nothing else (WI-002135): over the allowance by
 	any amount is Non-Compliant, otherwise Compliant. Derived here rather than left as a
 	Select the operator picks, so it cannot contradict the figure printed beside it.
@@ -148,19 +158,19 @@ def derived_figures(sector, ratio, nationals, expatriates):
 	required = 0.0
 	if 0 < ratio < 100:
 		required = flt(expatriates) * ratio / (100 - ratio)
-	required = round_to_half(required)
+	required = to_whole(required)
 
 	excess = max(required - flt(nationals), 0)
 
-	allowed = round_to_half(expats_allowed(sector, ratio, nationals))
-	violated = max(flt(expatriates) - allowed, 0)
+	allowed = to_whole(expats_allowed(sector, ratio, nationals))
+	violated = 0.0 if sector == EXEMPT_SECTOR else max(flt(expatriates) - allowed, 0)
 
 	return {
 		"required_number_of_national_workers": as_figure(required),
 		"exceeding_the_ratio_number_of_national_workers": as_figure(excess),
 		"exempt_number_of_workers": as_figure(allowed),
 		"violation_number_of_workers": as_figure(violated),
-		"status": NON_COMPLIANT if round_to_half(violated) > 0 else COMPLIANT,
+		"status": NON_COMPLIANT if violated > 0 else COMPLIANT,
 	}
 
 

--- a/one_fm/grd/doctype/pam_license_details/test_pam_compliance_status.py
+++ b/one_fm/grd/doctype/pam_license_details/test_pam_compliance_status.py
@@ -27,10 +27,11 @@ class TestComplianceStatus(FrappeTestCase):
 		self.assertEqual(figures["violation_number_of_workers"], "1")
 		self.assertEqual(figures["status"], NON_COMPLIANT)
 
-	def test_half_a_violation_still_counts(self):
-		# 30% ratio, 1 national -> 3.5 allowed; 4 on the books is 0.5 over.
+	def test_one_over_the_rounded_allowance_still_counts(self):
+		# 30% ratio, 1 national: 1 x 70 / 30 = 2.33 + 1 for managers = 3.33 -> 3 allowed;
+		# 4 on the books is 1 over.
 		figures = derived_figures("مديرون", ratio=30, nationals=1, expatriates=4)
-		self.assertEqual(figures["violation_number_of_workers"], "0.5")
+		self.assertEqual(figures["violation_number_of_workers"], "1")
 		self.assertEqual(figures["status"], NON_COMPLIANT)
 
 	def test_exactly_on_the_allowance_is_compliant(self):
@@ -41,10 +42,11 @@ class TestComplianceStatus(FrappeTestCase):
 		figures = derived_figures(PROFESSIONALS, ratio=20, nationals=0, expatriates=0)
 		self.assertEqual(figures["status"], COMPLIANT)
 
-	def test_an_expatriate_in_the_exempt_sector_is_not_compliant(self):
-		"""Nothing is allowed there, so anybody on the books is over the line."""
-		figures = derived_figures(EXEMPT_SECTOR, ratio=20, nationals=4, expatriates=1)
-		self.assertEqual(figures["status"], NON_COMPLIANT)
+	def test_the_exempt_sector_is_compliant_whoever_is_on_it(self):
+		"""WI-002099 exempts the sector from the ratio outright, so there is no limit for the
+		headcount to break and nothing for the status to report."""
+		figures = derived_figures(EXEMPT_SECTOR, ratio=20, nationals=4, expatriates=100)
+		self.assertEqual(figures["status"], COMPLIANT)
 
 	def test_the_status_is_not_the_operator_s_to_pick(self):
 		self.assertTrue(frappe.get_meta("PAM License Stats").get_field("status").read_only)

--- a/one_fm/grd/doctype/pam_license_details/test_pam_expats_allowed.py
+++ b/one_fm/grd/doctype/pam_license_details/test_pam_expats_allowed.py
@@ -75,17 +75,22 @@ class TestExpatsViolated(FrappeTestCase):
 		figures = derived_figures(PROFESSIONALS, ratio=20, nationals=4, expatriates=21)
 		self.assertEqual(figures["violation_number_of_workers"], "0")
 
-	def test_every_expatriate_in_the_exempt_sector_is_in_violation(self):
-		"""Nothing is allowed there, so anyone on the books is over the line."""
-		figures = derived_figures(EXEMPT_SECTOR, ratio=20, nationals=4, expatriates=3)
-		self.assertEqual(figures["exempt_number_of_workers"], "0")
-		self.assertEqual(figures["violation_number_of_workers"], "3")
+	def test_the_exempt_sector_is_never_in_violation(self):
+		"""WI-002099: "there will be no expat violation, as Kuwaitis are not allowed for this
+		role... if the number of expats is 100, the violation will be 0". PAM does not ration
+		the sector, so the allowance of zero says the ratio does not apply to it - not that
+		every expatriate on the books breaks a limit."""
+		for expatriates in (3, 100):
+			with self.subTest(expatriates=expatriates):
+				figures = derived_figures(EXEMPT_SECTOR, ratio=20, nationals=4, expatriates=expatriates)
+				self.assertEqual(figures["exempt_number_of_workers"], "0")
+				self.assertEqual(figures["violation_number_of_workers"], "0")
 
-	def test_the_figures_are_stated_to_the_nearest_half(self):
-		# 30% ratio, 1 national: 1 x 70 / 30 = 2.333 + 1 = 3.333 -> 3.5
+	def test_the_figures_are_stated_as_whole_numbers(self):
+		# 30% ratio, 1 national: 1 x 70 / 30 = 2.333 + 1 = 3.333 -> 3 allowed, 6 on the books.
 		figures = derived_figures(MANAGERS, ratio=30, nationals=1, expatriates=6)
-		self.assertEqual(figures["exempt_number_of_workers"], "3.5")
-		self.assertEqual(figures["violation_number_of_workers"], "2.5")
+		self.assertEqual(figures["exempt_number_of_workers"], "3")
+		self.assertEqual(figures["violation_number_of_workers"], "3")
 
 	def test_the_values_may_arrive_as_the_strings_the_row_stores(self):
 		figures = derived_figures(MANAGERS, "20", "4", "25")

--- a/one_fm/grd/doctype/pam_license_details/test_pam_sector_figures.py
+++ b/one_fm/grd/doctype/pam_license_details/test_pam_sector_figures.py
@@ -8,7 +8,7 @@ from frappe.tests.utils import FrappeTestCase
 from one_fm.grd.doctype.pam_license_details.pam_license_details import (
 	as_figure,
 	derived_figures,
-	round_to_half,
+	to_whole,
 )
 
 # The requirement and the shortfall do not depend on the sector - only the expatriate
@@ -26,15 +26,21 @@ def _a_sector(name):
 	return name
 
 
-class TestRoundToHalf(FrappeTestCase):
-	def test_it_rounds_to_the_nearest_half(self):
-		for value, expected in ((0, 0), (0.2, 0), (0.3, 0.5), (0.7, 0.5), (0.8, 1.0), (2.24, 2.0), (2.26, 2.5)):
+class TestToWhole(FrappeTestCase):
+	def test_it_rounds_to_the_nearest_whole_number(self):
+		for value, expected in ((0, 0), (0.2, 0), (0.49, 0), (0.7, 1), (2.24, 2), (2.75, 3)):
 			with self.subTest(value=value):
-				self.assertEqual(round_to_half(value), expected)
+				self.assertEqual(to_whole(value), expected)
 
-	def test_a_whole_figure_loses_its_decimal(self):
+	def test_half_rounds_up(self):
+		"""Not to even, which is what round() would do - 2.5 and 3.5 must not land on the
+		same side of the line as each other."""
+		self.assertEqual(to_whole(2.5), 3)
+		self.assertEqual(to_whole(3.5), 4)
+
+	def test_a_figure_carries_no_decimal(self):
 		self.assertEqual(as_figure(3.0), "3")
-		self.assertEqual(as_figure(3.5), "3.5")
+		self.assertEqual(as_figure(3.5), "4")
 		self.assertEqual(as_figure(0), "0")
 
 	def test_a_blank_reads_as_nothing(self):
@@ -49,13 +55,13 @@ class TestDerivedFigures(FrappeTestCase):
 		figures = derived_figures(SECTOR_UNDER_TEST, ratio=20, nationals=0, expatriates=8)
 		self.assertEqual(figures["required_number_of_national_workers"], "2")
 
-	def test_the_requirement_is_stated_to_the_nearest_half(self):
+	def test_the_requirement_is_stated_as_a_whole_number(self):
 		# 9 x 20 / 80 = 2.25 -> 2
 		self.assertEqual(derived_figures(SECTOR_UNDER_TEST, 20, 0, 9)["required_number_of_national_workers"], "2")
-		# 11 x 20 / 80 = 2.75 -> 2.5... rounds to 3 at .75
+		# 11 x 20 / 80 = 2.75 -> 3
 		self.assertEqual(derived_figures(SECTOR_UNDER_TEST, 20, 0, 11)["required_number_of_national_workers"], "3")
-		# 10 x 20 / 80 = 2.5, already a half
-		self.assertEqual(derived_figures(SECTOR_UNDER_TEST, 20, 0, 10)["required_number_of_national_workers"], "2.5")
+		# 10 x 20 / 80 = 2.5 -> 3
+		self.assertEqual(derived_figures(SECTOR_UNDER_TEST, 20, 0, 10)["required_number_of_national_workers"], "3")
 
 	def test_a_shortfall_is_what_the_sector_is_missing(self):
 		figures = derived_figures(SECTOR_UNDER_TEST, ratio=20, nationals=1, expatriates=8)


### PR DESCRIPTION
[WI-002099](https://one-fm.com/app/work-item/WI-002099) — *calculate Number of Expats Allowed and Number of Expats Violated per occupational sector.*

Two things the acceptance criteria ask for that the merged pass (#6756) does not do.

## 1. The exempt sector was reporting every expatriate as a violation

WI-002099 is explicit:

> make sure that for the occupational sector ie: مهن غير مشمولة / معفي There will be no expat violation, as Kuwaitis are not allowed for this role. For example, if the number of expats is 100, the violation will be 0

The merged code allowed that sector `0` and then subtracted, so 100 expatriates read as 100 in violation and the row read Non-Compliant. The AC is right: PAM does not ration that sector by the ratio at all, so an allowance of zero says *the ratio does not apply*, not that every expatriate breaks a limit. A sector with no limit to break is Compliant whoever is on it.

## 2. Figures were stated to the nearest half

Both WI-002094 and WI-002099 say *"all calculated figures should be rounded to the nearest **Whole Number**"*. The half came from a claim about how PAM states its figures that neither work item makes.

Now whole, with **half rounding up** rather than to even, and computed by hand rather than through `round()` or a precision setting — a licence that reads Compliant on one site and Non-Compliant on another because of a rounding configuration is worse than either answer.

This changes the WI-002094 figures too (Required Nationals, Excess Nationals), which is what that work item's AC asks for as well.

## Unchanged

The direction of Number of Expats Violated stays **actual − allowed**, as decided when WI-002099 was first raised, not the AC's literal `allowed − actual`.

## Tests

`test_pam_expats_allowed`, `test_pam_compliance_status` and `test_pam_sector_figures` updated to the AC's arithmetic — including the AC's own worked example, 100 expatriates in the exempt sector reading `0`. 34 tests, all passing.

---
Stacked on #6812 — merge that first.