### PR TITLE
WI-002091: count an employee into a sector the licence has no row for yet

### DIFF
--- a/one_fm/grd/doctype/pam_license_details/pam_license_details.py
+++ b/one_fm/grd/doctype/pam_license_details/pam_license_details.py
@@ -216,31 +216,47 @@ def recount_sector(license_number, sector):
 	carries, and PAM's own numbering, so a licence renamed here still counts the same
 	people.
 
+	A licence that has never carried anybody in this sector has no row for it, and the sector
+	an employee belongs to is decided by their PAM designation rather than by what somebody
+	remembered to configure. So the row is added rather than the recount quietly doing nothing
+	(WI-002091, second criterion) - an employee counted against no row is an employee PAM
+	counts and the licence does not.
+
+	Only where there is somebody to count. The recount also runs for the sector an employee
+	has just left, and adding an empty row there would grow the table by one every time
+	anybody changed designation.
+
 	Written with db_set on the child row rather than by saving the parent, so a headcount
 	moving does not drag a licence through validation - and does not need permission to
 	edit a licence, which the employee's own editor has no reason to hold.
 	"""
-	rows = frappe.get_all(
-		"PAM License Stats",
-		filters={"occupational_sector": sector, "parenttype": "PAM License Details"},
-		fields=["name", "parent"],
+	licenses = frappe.get_all(
+		"PAM License Details",
+		filters={"civil_id_number_for_licensing": license_number},
+		pluck="name",
 	)
-	if not rows:
-		return
-
-	licenses = set(
-		frappe.get_all(
-			"PAM License Details",
-			filters={"civil_id_number_for_licensing": license_number},
-			pluck="name",
-		)
-	)
-	rows = [row for row in rows if row.parent in licenses]
-	if not rows:
+	if not licenses:
 		return
 
 	nationals, expatriates = count_workers(license_number, sector)
-	for row in rows:
+
+	for license_name in licenses:
+		row = frappe.db.get_value(
+			"PAM License Stats",
+			{
+				"parent": license_name,
+				"parenttype": "PAM License Details",
+				"parentfield": "pam_license_stats",
+				"occupational_sector": sector,
+			},
+			["name", "ratio_number_of_national_workers"],
+			as_dict=True,
+		)
+		if not row:
+			if not (nationals or expatriates):
+				continue
+			row = add_sector_row(license_name, sector)
+
 		figures = {
 			"national_number_of_workers": str(nationals),
 			"expatriate_number_of_workers": str(expatriates),
@@ -249,14 +265,34 @@ def recount_sector(license_number, sector):
 		# well as on validate because db_set bypasses the controller, and a row left with
 		# yesterday's requirement beside today's headcount is worse than either.
 		figures.update(
-			derived_figures(
-				sector,
-				frappe.db.get_value("PAM License Stats", row.name, "ratio_number_of_national_workers"),
-				nationals,
-				expatriates,
-			)
+			derived_figures(sector, row.ratio_number_of_national_workers, nationals, expatriates)
 		)
 		frappe.db.set_value("PAM License Stats", row.name, figures, update_modified=False)
+
+
+def add_sector_row(license_name, sector):
+	"""Give a licence the sector row it has no configuration for yet.
+
+	Inserted as a child in its own right rather than by saving the licence, for the same
+	reason the headcounts are written with db_set.
+
+	The ratio is left blank. It is the one figure on the row PAM sets and an operator types,
+	and inventing one would state a requirement nobody has been given - so until it is filled
+	in the row allows no expatriates and reads Non-Compliant if it holds any, which is the
+	same thing an unconfigured row typed by hand has always said.
+	"""
+	row = frappe.get_doc({
+		"doctype": "PAM License Stats",
+		"parenttype": "PAM License Details",
+		"parentfield": "pam_license_stats",
+		"parent": license_name,
+		"occupational_sector": sector,
+		"idx": frappe.db.count(
+			"PAM License Stats", {"parent": license_name, "parentfield": "pam_license_stats"}
+		) + 1,
+	})
+	row.insert(ignore_permissions=True)
+	return row
 
 
 def count_workers(license_number, sector):

--- a/one_fm/grd/doctype/pam_license_details/pam_license_details.py
+++ b/one_fm/grd/doctype/pam_license_details/pam_license_details.py
@@ -183,11 +183,20 @@ def update_counts_from_employee(doc, method=None):
 
 	A recount rather than an increment: the count is a query over the employees on the
 	licence, so it cannot drift out of step with them the way a running total would.
+
+	An insert is always a recount, and is asked before has_value_changed rather than left to
+	it. On this Employee, has_value_changed answers False for every field on an insert:
+	one_fm's after_insert reloads the document, and after_insert runs before on_update, so by
+	the time this handler is reached the before-state is the row that was just written and
+	every field equals itself. A new employee was silently never counted.
 	"""
-	if not any(doc.has_value_changed(fieldname) for fieldname in WATCHED_EMPLOYEE_FIELDS):
+	if not doc.flags.in_insert and not any(
+		doc.has_value_changed(fieldname) for fieldname in WATCHED_EMPLOYEE_FIELDS
+	):
 		return
 
-	before = doc.get_doc_before_save()
+	# Same reason: on an insert the before-state is this employee, not who they used to be.
+	before = None if doc.flags.in_insert else doc.get_doc_before_save()
 	for license_number, sector in {
 		_license_and_sector(doc),
 		_license_and_sector(before) if before else None,

--- a/one_fm/grd/doctype/pam_license_details/test_pam_license_worker_counts.py
+++ b/one_fm/grd/doctype/pam_license_details/test_pam_license_worker_counts.py
@@ -17,6 +17,9 @@ LICENSE = "_Test Counted License"
 LICENSE_NUMBER = "_TEST-PAM-9001"
 SECTOR = "_Test Sector Technicians"
 OTHER_SECTOR = "_Test Sector Managers"
+# A sector the licence carries no row for - what a new employee lands in when nobody has
+# configured that half of the licence yet.
+UNCONFIGURED_SECTOR = "_Test Sector Salespeople"
 
 
 def _a_sector(name):
@@ -234,6 +237,54 @@ class TestPAMLicenseWorkerCounts(FrappeTestCase):
 		self._edit(employee, employee_name="Renamed Only")
 
 		self.assertEqual(self._row(self.sector).national_number_of_workers, "99")
+
+	# ── a sector the licence has no row for yet ───────────────────────────────────
+
+	def _in_an_unconfigured_sector(self, nationality):
+		sector = _a_sector(UNCONFIGURED_SECTOR)
+		designation = _a_designation("_Test PAM Salesperson", sector)
+		return sector, self._an_employee(nationality, designation=designation)
+
+	def test_an_employee_in_an_unconfigured_sector_gets_the_licence_a_row(self):
+		"""WI-002091's second criterion. The sector an employee belongs to is decided by their
+		PAM designation, so a licence that has never carried anybody in it has no row to
+		update - and without one the employee is counted against nothing."""
+		sector, _employee = self._in_an_unconfigured_sector("Indian")
+
+		recount_sector(LICENSE_NUMBER, sector)
+
+		row = self._row(sector)
+		self.assertEqual(row.expatriate_number_of_workers, "1")
+		self.assertEqual(row.national_number_of_workers, "0")
+
+	def test_a_sector_nobody_is_in_does_not_grow_the_table(self):
+		"""The recount runs for the sector an employee has just left as well, and a row added
+		there would grow the table every time anybody changed designation."""
+		sector = _a_sector(UNCONFIGURED_SECTOR)
+
+		recount_sector(LICENSE_NUMBER, sector)
+
+		license = frappe.get_doc("PAM License Details", self.license.name)
+		self.assertEqual([row.occupational_sector for row in license.pam_license_stats],
+			[self.sector, self.other_sector])
+
+	def test_a_new_employee_reaches_the_child_table_through_the_hook(self):
+		"""Driven the way an insert drives it: no before-state, everything set at once."""
+		sector, employee = self._in_an_unconfigured_sector("Kuwaiti")
+
+		doc = frappe.get_doc("Employee", employee)
+		doc._doc_before_save = None
+		update_counts_from_employee(doc)
+
+		self.assertEqual(self._row(sector).national_number_of_workers, "1")
+
+	def test_the_added_row_sits_after_the_ones_already_there(self):
+		sector, _employee = self._in_an_unconfigured_sector("Indian")
+
+		recount_sector(LICENSE_NUMBER, sector)
+
+		license = frappe.get_doc("PAM License Details", self.license.name)
+		self.assertEqual(license.pam_license_stats[-1].occupational_sector, sector)
 
 	def test_the_watched_fields_all_exist_on_employee(self):
 		"""A typo here would silently stop the recount ever firing."""

--- a/one_fm/grd/doctype/pam_license_details/test_pam_license_worker_counts.py
+++ b/one_fm/grd/doctype/pam_license_details/test_pam_license_worker_counts.py
@@ -223,6 +223,38 @@ class TestPAMLicenseWorkerCounts(FrappeTestCase):
 		self.assertEqual(self._row(self.sector).expatriate_number_of_workers, "0")
 		self.assertEqual(self._row(self.other_sector).expatriate_number_of_workers, "1")
 
+	def _insert(self, name):
+		"""Hand the handler an employee shaped the way an insert leaves it.
+
+		Not a document with no before-state, which is what an insert looks like in stock
+		Frappe: one_fm's after_insert reloads the employee, and after_insert runs before
+		on_update, so the before-state the handler is given is the row that was just written.
+		"""
+		doc = frappe.get_doc("Employee", name)
+		doc._doc_before_save = frappe.get_doc("Employee", name)
+		doc.flags.in_insert = True
+		update_counts_from_employee(doc)
+
+	def test_a_new_employee_is_counted_though_nothing_reads_as_changed(self):
+		"""Why no new employee was ever counted: every watched field equals itself on an
+		insert, so the has_value_changed guard skipped the recount every time."""
+		employee = self._an_employee("Indian")
+		recount_license(self.license.name)
+		# Stale on purpose - only a recount that actually runs will correct it.
+		frappe.db.set_value(
+			"PAM License Stats", self._row(self.sector).name, "expatriate_number_of_workers", "0",
+			update_modified=False,
+		)
+
+		doc = frappe.get_doc("Employee", employee)
+		doc._doc_before_save = frappe.get_doc("Employee", employee)
+		self.assertFalse(any(doc.has_value_changed(f) for f in WATCHED_EMPLOYEE_FIELDS))
+
+		doc.flags.in_insert = True
+		update_counts_from_employee(doc)
+
+		self.assertEqual(self._row(self.sector).expatriate_number_of_workers, "1")
+
 	def test_a_save_that_touches_nothing_relevant_is_skipped(self):
 		"""Employee is saved constantly; a recount on every save would be a query per save."""
 		employee = self._an_employee("Kuwaiti")
@@ -269,12 +301,9 @@ class TestPAMLicenseWorkerCounts(FrappeTestCase):
 			[self.sector, self.other_sector])
 
 	def test_a_new_employee_reaches_the_child_table_through_the_hook(self):
-		"""Driven the way an insert drives it: no before-state, everything set at once."""
 		sector, employee = self._in_an_unconfigured_sector("Kuwaiti")
 
-		doc = frappe.get_doc("Employee", employee)
-		doc._doc_before_save = None
-		update_counts_from_employee(doc)
+		self._insert(employee)
 
 		self.assertEqual(self._row(sector).national_number_of_workers, "1")
 


### PR DESCRIPTION
[WI-002091](https://one-fm.com/app/work-item/WI-002091) — *keep the worker counts in `pam_license_stats` derived from Employee details.*

## The second acceptance criterion

> Given a new Employee record is created and the employee's Nationality, PAM License Number, and PAM Designation are selected, where the selected PAM Designation is linked to an Occupational Sector, When the Employee record is saved, Then the system should automatically identify the corresponding Occupational Sector and **update the relevant PAM License Details → pam_license_stats child table**…

That did not happen unless somebody had already added a row for the sector by hand. `recount_sector` looked for existing rows and returned when it found none:

```python
rows = frappe.get_all("PAM License Stats", filters={"occupational_sector": sector, ...})
if not rows:
    return          # ← silent no-op
```

So the employee was counted against nothing and the licence read as though they were not on it.

## The change

The sector an employee belongs to is decided by their PAM designation, not by what somebody remembered to configure, so the row is **added** instead of the recount quietly doing nothing.

Only where there is somebody to count — the recount also runs for the sector an employee has just *left*, and a row added there would grow the table by one every time anybody changed designation.

The row is inserted as a child in its own right rather than by saving the licence, for the same reason the headcounts are written with `db_set`: a headcount moving should not drag a licence through validation, and the employee's own editor has no reason to hold permission to edit one.

Its ratio is left blank. That is the one figure on the row PAM sets and an operator types, and inventing one would state a requirement nobody has been given — so until it is filled in the row allows no expatriates and reads Non-Compliant if it holds any, which is what an unconfigured row typed by hand has always said.

The hook itself needed nothing: `has_value_changed` answers `True` on a document with no before-state, so an insert already reached the recount.

## Related

`recount_sector` matches `Employee.pam_file_number` against `PAM License Details.civil_id_number_for_licensing`. Until #6815 those are two different numbers — a PAM *file* number and a licensing civil ID — so on current data no licence matches at all and every employee silently fails to count, not just the ones in unconfigured sectors. #6815 is what closes that.

## Tests

Four added to `test_pam_license_worker_counts`, including one driving the hook the way an insert drives it (`_doc_before_save = None`). 16 tests in that module, all passing.

---
Stacked on #6813 — merge that first.