### PR TITLE
fix: repair interview feedback customisation for hrms v15/v16

### DIFF
--- a/one_fm/public/js/doctype_js/interview.js
+++ b/one_fm/public/js/doctype_js/interview.js
@@ -1,55 +1,67 @@
 frappe.ui.form.on('Interview', {
-	refresh: function (frm) {
-		frappe.model.get_value("Job Applicant", {"name": frm.doc.job_applicant}, "one_fm_hiring_method", 
-		function(res) {
-			if(res.one_fm_hiring_method == "Bulk Recruitment"){
-				// Bulk Recruitment: feedback is auto-created from Interview Console
-				frm.remove_custom_button('Submit Feedback');
-				remove_custom_button_from_mobile_view(frm, "Submit Feedback");
-				
-				// Show editable text box for Interview Summary
-				frm.toggle_display('interview_summary', true);
-				frm.toggle_display('interview_summary_render', false);
-				frm.set_df_property('interview_summary', 'label', 'Interview Summary');
-			} else {
-				// Non-Bulk: remove standard Submit Feedback and conditionally add custom Submit Interview Feedback
-				frm.remove_custom_button('Submit Feedback');
-				remove_custom_button_from_mobile_view(frm, "Submit Feedback");
+	/*
+		Registered after the HRMS handler, and script_manager runs handlers of the
+		same event serially (awaiting returned promises), so by the time this runs
+		HRMS has already finished adding its own "Submit Feedback" action.
+		Doing this in `refresh` instead races with the async HRMS handler and the
+		standard button survives.
+	*/
+	add_custom_buttons: async function (frm) {
+		if (frm.doc.docstatus === 2 || frm.doc.__islocal) {
+			return;
+		}
 
-				let allowed_interviewers = [];
-				frm.doc.interview_details.forEach(values => {
-					allowed_interviewers.push(values.interviewer);
-				});
-		
-				if (frm.doc.docstatus != 2 && !frm.doc.__islocal){
-					if ((allowed_interviewers.includes(frappe.session.user))) {
-						frappe.db.get_value('Interview Feedback', {'interviewer': frappe.session.user, 'interview': frm.doc.name, 'docstatus': 1}, 'name', (r) => {
-							if (Object.keys(r).length === 0) {
-								frm.add_custom_button(__('Submit Interview Feedback'), function () {
-									frappe.call({
-										method: 'one_fm.hiring.utils.get_interview_skill_and_question_set',
-										args: {
-											interview_round: frm.doc.interview_round,
-											interviewer: frappe.session.user,
-											interview_name: frm.doc.name,
-										},
-										callback: function (r) {
-											if(r.message){
-												frm.events.show_custom_feedback_dialog(frm, r.message[1], r.message[0], r.message[2]);
-											}
-											frm.refresh();
-										},
-										freeze: true,
-										freeze_message: __("Fetch interview details..!")
-									});
-								}).addClass('btn-primary');
-							}
-						});
-					}							
-				}				
-			}	
-		})
+		remove_standard_submit_feedback(frm);
+
+		const hiring_method = await get_hiring_method(frm.doc.job_applicant);
+
+		if (hiring_method == "Bulk Recruitment") {
+			// Bulk Recruitment: feedback is auto-created from Interview Console
+			// Show editable text box for Interview Summary
+			frm.toggle_display('interview_summary', true);
+			frm.toggle_display('interview_summary_render', false);
+			frm.set_df_property('interview_summary', 'label', __('Interview Summary'));
+			return;
+		}
+
+		// Non-Bulk: conditionally add custom Submit Interview Feedback
+		const allowed_interviewers = (frm.doc.interview_details || []).map(
+			(values) => values.interviewer
+		);
+		if (!allowed_interviewers.includes(frappe.session.user)) {
+			return;
+		}
+
+		const submitted_feedback = await frappe.db.get_value('Interview Feedback', {
+			'interviewer': frappe.session.user,
+			'interview': frm.doc.name,
+			'docstatus': 1
+		}, 'name');
+
+		if (submitted_feedback && submitted_feedback.message && submitted_feedback.message.name) {
+			return;
+		}
+
+		frm.add_custom_button(__('Submit Interview Feedback'), function () {
+			frappe.call({
+				method: 'one_fm.hiring.utils.get_interview_skill_and_question_set',
+				args: {
+					interview_round: frm.doc.interview_round,
+					interviewer: frappe.session.user,
+					interview_name: frm.doc.name,
+				},
+				callback: function (r) {
+					if (r.message) {
+						frm.events.show_custom_feedback_dialog(frm, r.message[1], r.message[0], r.message[2]);
+					}
+					frm.refresh();
+				},
+				freeze: true,
+				freeze_message: __("Fetch interview details..!")
+			});
+		}).addClass('btn-primary');
 	},
+
 
 	// Override: show actual score % for Bulk Recruitment only
 	calculate_reviews_per_rating(frm) {
@@ -85,8 +97,10 @@ frappe.ui.form.on('Interview', {
 			frm.events.render_feedback(frm);
 		});
 	},
-	show_custom_feedback_dialog: function (frm, data, question_data, feedback_exists) {
-		let fields = frm.events.get_fields_for_feedback();
+	show_custom_feedback_dialog: async function (frm, data, question_data, feedback_exists) {
+		// HRMS's get_fields_for_feedback() is async (returns a Promise) - it must be
+		// awaited, otherwise fields.push() throws "fields.push is not a function"
+		let fields = await frm.events.get_fields_for_feedback();
 		fields.push({
 			fieldtype: 'Data',
 			fieldname: 'parent',
@@ -198,6 +212,30 @@ frappe.ui.form.on('Interview', {
 	}
 
 });
+
+var get_hiring_method = function (job_applicant) {
+	if (!job_applicant) {
+		return Promise.resolve(null);
+	}
+	return frappe.db
+		.get_value("Job Applicant", job_applicant, "one_fm_hiring_method")
+		.then((r) => (r && r.message ? r.message.one_fm_hiring_method : null));
+}
+
+var remove_standard_submit_feedback = function (frm) {
+	// Non-interviewers get a disabled custom button
+	frm.remove_custom_button('Submit Feedback');
+	remove_custom_button_from_mobile_view(frm, "Submit Feedback");
+
+	// Interviewers get it as the page primary action instead (HRMS v15/v16),
+	// which remove_custom_button() cannot touch - clear it and let the form
+	// toolbar put back the framework's own Save/Submit action
+	if (frm.page.btn_primary && frm.page.btn_primary.text().trim() === __('Submit Feedback')) {
+		frm.page.clear_primary_action();
+		// pass dirty=true so the doctype's user actions in the menu are kept
+		frm.toolbar.set_primary_action(true);
+	}
+}
 
 var remove_custom_button_from_mobile_view = function(frm, label) {
 	// Find the span element with the specified data-label attribute


### PR DESCRIPTION
The Interview client customisation was written against the older HRMS Interview JS and broke after the upgrade: the custom "Submit Interview Feedback" button threw "fields.push is not a function", and the standard "Submit Feedback" button reappeared despite being removed.

- await frm.events.get_fields_for_feedback(), which HRMS made async, so the skill assessment fields are an array instead of a Promise
- clear the page primary action when HRMS sets "Submit Feedback" through frm.page.set_primary_action(), which remove_custom_button() cannot reach, and restore the framework Save/Submit action afterwards
- move the button logic from refresh to the add_custom_buttons event so it runs after the async HRMS handler instead of racing it
- look up the hiring method with frappe.db.get_value for a single linear async flow
