### PR TITLE
WI-002159: request the Google Task sync through the workflow engine

### DIFF
--- a/one_fm/overrides/todo.py
+++ b/one_fm/overrides/todo.py
@@ -326,24 +326,6 @@ def sync_google_tasks_with_todos():
 
 
 @frappe.whitelist()
-def sync_my_google_tasks_with_todos():
-    try:
-        logged_in_user = frappe.session.user
-
-        # Skip if general trigger is not enabled
-        if not is_google_task_synchronization_enabled() or logged_in_user == "Administrator":
-            return { "error": True, "message" : "You are not allowed to sync google tasks" }
-
-        frappe.enqueue(sync_google_tasks_for_users, user_emails=[logged_in_user], is_async=True, timeout=600)
-
-        return { "error": False, "message" : "Your Google Tasks will be synced in the background." }
-
-    except Exception as e:
-        frappe.log_error(message =str(e),title = "Failed to sync google tasks to ERP ToDo")
-        return { "error": True, "message" : str(e) }
-
-
-@frappe.whitelist()
 def sync_google_tasks_for_users(user_emails=[], timedelta_kwargs=None):
     all_google_tasks = []
 

--- a/one_fm/public/js/doctype_list_js/todo_list.js
+++ b/one_fm/public/js/doctype_list_js/todo_list.js
@@ -1,21 +1,47 @@
 frappe.listview_settings['ToDo'] = {
 	onload: function(listview) {
 		sync_my_google_tasks(listview)
+		listen_for_sync_result(listview)
 	}
 };
 
+// The button no longer performs the sync. It names the event that happened —
+// the user asked for a sync — and the workflow engine decides which process
+// answers to that name. What the sync then does lives in the process map, so
+// it can change without this file changing.
+const GOOGLE_TASK_SYNC_MESSAGE = 'ToDo_SyncGoogleTasks_Action';
+
 const sync_my_google_tasks = function(listview) {
 	listview.page.add_button(__('Sync My Google Tasks'), function() {
-        frappe.call({
-			method: 'one_fm.overrides.todo.sync_my_google_tasks_with_todos',
+		frappe.call({
+			method: 'one_bpmn.api.instance_api.trigger_process_by_message',
+			args: { message_name: GOOGLE_TASK_SYNC_MESSAGE },
 			callback: function (r) {
 				if (!r.exc) {
-					frappe.msgprint(__(r.message || "Tasks Synched!"));
-					listview.refresh();
+					frappe.show_alert({
+						message: __(r.message && r.message.message || 'Sync requested'),
+						indicator: 'blue'
+					});
 				}
 			},
 			freeze: true,
-			freeze_message: __('Syncing My Google Tasks')
+			freeze_message: __('Requesting Google Task sync')
 		});
-    }, 'primary');
+	}, 'primary');
+};
+
+// The process runs on a worker, so its outcome cannot come back on the call
+// above — it arrives later over the realtime channel the map's script tasks
+// publish to. Refresh only on success: there is nothing new to show when the
+// sync was refused.
+const listen_for_sync_result = function(listview) {
+	frappe.realtime.on('gsync_sync_result', function(data) {
+		frappe.show_alert({
+			message: __(data && data.message || 'Google Task sync finished'),
+			indicator: (data && data.indicator) || 'green'
+		});
+		if (data && data.indicator === 'green') {
+			listview.refresh();
+		}
+	});
 };


### PR DESCRIPTION
### What this does

The ToDo list button called `one_fm.overrides.todo.sync_my_google_tasks_with_todos` directly, so the behaviour lived in Python and the process map that describes it could never run.

The button now names the event that happened — the user asked for a sync — and the workflow engine decides which process answers to it. What the sync does moves into the map, so it can change without this file changing.

### Notes for review

- The outcome cannot come back on the `frappe.call`: the process runs on a worker. The list subscribes to the `gsync_sync_result` realtime channel that the map's script tasks publish to.
- It refreshes **only** on success — a refusal leaves nothing new to show.
- `sync_my_google_tasks_with_todos` is left in place. Its `is_google_task_synchronization_enabled` helper is still used by the map's check script. Whether the rest of it retires is a follow-up.

### Depends on

ONE-F-M/one_bpmn#603 — `trigger_process_by_message`, the endpoint this calls. Merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Also in this PR

`sync_my_google_tasks_with_todos` is retired. Nothing called it once the button changed — its only reference was its own definition — and leaving a whitelisted endpoint that duplicates the process is a second way to do the same thing, reachable by anyone who knows the method path.

`is_google_task_synchronization_enabled` **stays**: three other flows in the module still call it. The map no longer does — reading the setting is one line, so the check script reads it directly and the process does not depend on one_fm being importable to answer a question about its own gate.

`get_google_task_service` and `get_mapped_status_from_google_task` also stay and are still called by the map's sync script. Those carry real weight — credential construction and status mapping — and belong in Python as a library the script calls.