### PR TITLE
Add live "Insurance Expired" dashboard indicator to Vehicle desk form

### DIFF
--- a/one_fm/public/js/doctype_js/vehicle.js
+++ b/one_fm/public/js/doctype_js/vehicle.js
@@ -1,8 +1,9 @@
-frappe.ui.form.on('Vehicle', {
+frappe.ui.form.on("Vehicle", {
 	refresh(frm) {
 		set_qr_code(frm);
 		frappe.breadcrumbs.add("GSD");
-		frm.set_df_property('license_plate', 'hidden', false);
+		frm.set_df_property("license_plate", "hidden", false);
+		show_insurance_expired_indicator(frm);
 	},
 	onload(frm) {
 		if (frm.is_new() && !frm.doc.custom_naming_series) {
@@ -11,37 +12,37 @@ frappe.ui.form.on('Vehicle', {
 	},
 	one_fm_vehicle_category(frm) {
 		const series_map = {
-			"Owned": "VHL-.####",
-			"Leased": "VHL-L-.####",
-			"Subcontractor": "VHL-S-.####"
+			Owned: "VHL-.####",
+			Leased: "VHL-L-.####",
+			Subcontractor: "VHL-S-.####",
 		};
 		const category = frm.doc.one_fm_vehicle_category;
 		frm.set_value("custom_naming_series", series_map[category] || "VHL-.####");
 		frm.set_df_property("vehicle_leasing_contract", "reqd", category === "Leased");
 	},
-	vehicle_leasing_contract(frm){
-	  if(!frm.doc.vehicle_leasing_contract){
-	      frm.set_value('vehicle_leasing_details', '');
-	  }
+	vehicle_leasing_contract(frm) {
+		if (!frm.doc.vehicle_leasing_contract) {
+			frm.set_value("vehicle_leasing_details", "");
+		}
 	},
-	vehicle_leasing_details(frm){
-	    if(frm.doc.vehicle_leasing_details){
-	        frappe.call({
-	           method: "one_fm.fleet_management.doctype.vehicle_leasing_contract.vehicle_leasing_contract.get_vehicle_from_leasing_contract",
-				args: {'vehicle_detail': frm.doc.vehicle_leasing_details},
-				callback: function(r) {
-					if(!r.exc){
-					    var data = r.message;
-					    frm.set_value('make', data.make);
-					    frm.set_value('model', data.model);
-					    frm.set_value('one_fm_vehicle_type', data.vehicle_type);
-					    frm.set_value('one_fm_year_of_made', data.year_of_made);
+	vehicle_leasing_details(frm) {
+		if (frm.doc.vehicle_leasing_details) {
+			frappe.call({
+				method: "one_fm.fleet_management.doctype.vehicle_leasing_contract.vehicle_leasing_contract.get_vehicle_from_leasing_contract",
+				args: { vehicle_detail: frm.doc.vehicle_leasing_details },
+				callback: function (r) {
+					if (!r.exc) {
+						var data = r.message;
+						frm.set_value("make", data.make);
+						frm.set_value("model", data.model);
+						frm.set_value("one_fm_vehicle_type", data.vehicle_type);
+						frm.set_value("one_fm_year_of_made", data.year_of_made);
 					}
 				},
 				freeze: true,
-				freeze_message: "Fetching Vehicle Details..."
-	        });
-	    }
+				freeze_message: "Fetching Vehicle Details...",
+			});
+		}
 	},
 	employee(frm) {
 		// A handover to a new custodian is logged the moment a new Employee is
@@ -64,19 +65,24 @@ frappe.ui.form.on('Vehicle', {
 	one_fm_milage(frm) {
 		// The current mileage feeds the active custodian's covered distance.
 		calculate_custodian_mileage(frm);
-	}
-})
+	},
+	end_date(frm) {
+		// Insurance end date changed on an open form: re-evaluate the
+		// expired-insurance indicator immediately, without needing a reload.
+		show_insurance_expired_indicator(frm);
+	},
+});
 
-var log_custodian_handover = function(frm) {
+var log_custodian_handover = function (frm) {
 	let row = frm.add_child("custom_vehicle_custodian_history", {
 		employee_id: frm.doc.employee,
 		handover_date: frm.doc.custom_handover_date,
-		mileage_at_handover: cint(frm.doc.one_fm_milage)
+		mileage_at_handover: cint(frm.doc.one_fm_milage),
 	});
 
 	// Populate Employee Name immediately for display (also resolved on save via fetch_from).
 	if (frm.doc.employee) {
-		frappe.db.get_value("Employee", frm.doc.employee, "employee_name").then(r => {
+		frappe.db.get_value("Employee", frm.doc.employee, "employee_name").then((r) => {
 			if (r && r.message) {
 				row.employee_name = r.message.employee_name;
 				frm.refresh_field("custom_vehicle_custodian_history");
@@ -88,18 +94,18 @@ var log_custodian_handover = function(frm) {
 	calculate_custodian_mileage(frm);
 };
 
-var get_active_custodian_row = function(frm) {
+var get_active_custodian_row = function (frm) {
 	let rows = frm.doc.custom_vehicle_custodian_history || [];
 	return rows.length ? rows[rows.length - 1] : null;
 };
 
-var calculate_custodian_mileage = function(frm) {
+var calculate_custodian_mileage = function (frm) {
 	// Past rows:  next row's mileage_at_handover - this row's mileage_at_handover.
 	// Active row: parent's current mileage (one_fm_milage) - this row's mileage_at_handover.
 	let rows = frm.doc.custom_vehicle_custodian_history || [];
 	let current_mileage = flt(frm.doc.one_fm_milage);
 
-	rows.forEach(function(row, index) {
+	rows.forEach(function (row, index) {
 		let covered;
 		if (index < rows.length - 1) {
 			covered = flt(rows[index + 1].mileage_at_handover) - flt(row.mileage_at_handover);
@@ -112,7 +118,27 @@ var calculate_custodian_mileage = function(frm) {
 	frm.refresh_field("custom_vehicle_custodian_history");
 };
 
-var set_qr_code = function(frm) {
+var is_insurance_expired = function (frm) {
+	// Insurance fields: insurance_company, policy_no, start_date, end_date.
+	// Only end_date drives the expiry check, and only a real, strictly-past
+	// date counts as expired \u2014 empty/unset and today/future do not.
+	if (!frm.doc.end_date) {
+		return false;
+	}
+	return frappe.datetime.get_day_diff(frappe.datetime.get_today(), frm.doc.end_date) > 0;
+};
+
+var show_insurance_expired_indicator = function (frm) {
+	if (is_insurance_expired(frm)) {
+		frm.dashboard.set_headline_alert(
+			`<div class="text-danger font-weight-bold">${__("Insurance Expired")}</div>`,
+		);
+	} else {
+		frm.dashboard.clear_headline();
+	}
+};
+
+var set_qr_code = function (frm) {
 	let qr_code_html = `{%if doc.name%}
 	<div style="display: inline-block;padding: 5%;">
 	<div class="qr_code_print" id="qr_code_print">
@@ -130,8 +156,8 @@ var set_qr_code = function(frm) {
 	    newWin.print();
 	});
 	</script>
-	`
-	var qr_code = frappe.render_template(qr_code_html, {"doc":frm.doc});
+	`;
+	var qr_code = frappe.render_template(qr_code_html, { doc: frm.doc });
 	$(frm.fields_dict["one_fm_vehicle_qr_code"].wrapper).html(qr_code);
-	refresh_field("one_fm_vehicle_qr_code")
+	refresh_field("one_fm_vehicle_qr_code");
 };


### PR DESCRIPTION
Vehicle DocType is owned by erpnext, so this customisation lives entirely in one_fm's existing client script (one_fm/one_fm/public/js/doctype_js/vehicle.js), already registered via the doctype_js hook against Vehicle — no erpnext files were touched.

Change:
- Added a helper `is_insurance_expired(frm)` that checks the insurance `end_date` field: returns true only when end_date is set and strictly before today (frappe.datetime.get_day_diff > 0). Empty/unset, today, and future dates all evaluate to false.
- Added `show_insurance_expired_indicator(frm)`, which calls `frm.dashboard.set_headline_alert(...)` with a red ("text-danger") "Insurance Expired" banner when expired, and `frm.dashboard.clear_headline()` otherwise — so a previously-shown indicator is cleared rather than stacked once the condition no longer holds.
- Wired this into the existing `refresh` handler and added a new `end_date` field-change handler that calls the same helper, so editing end_date on an open, unsaved form updates the indicator immediately without a reload.
- Left all other existing behaviour untouched and in place: QR code generation (including its pre-existing `document.write()` print helper — not touched or "fixed" per the work order), breadcrumb ("GSD") logic, licence-plate field handling, custodian handover logic, and naming-series logic.

Verification:
- Staged and reviewed via the house tooling; passed clean. Two pre-existing findings were reported (no onBeforeUnmount listener cleanup, and the document.write() print helper) — both predate this change and the work order explicitly asked to leave the QR code helper alone, so they were left untouched and are only noted here for the reviewer's awareness.
- This is desk JavaScript, not the Vite-built Processa app, so there is no bundle build step; the review tool confirmed the hook wiring is already correctly registered in hooks.py (no change needed there — it pre-existed).
- Not verified: actual on-screen behaviour in a running site (indicator colour rendering, banner placement) — no live site was touched, per policy. A reviewer should open a Vehicle record with a past end_date to confirm the red banner appears and clears correctly when the date is changed.

---

Raised by the **Frontend Agent**. Source only - CI builds the Processa application on merge.

**Files**
- `one_fm/public/js/doctype_js/vehicle.js`

**Checks**
- build: no Processa application files in this change
- prettier: applied when each file was staged
- screening: passed
- house rules: no new findings

**Already in these files, left alone**
- one_fm/one_fm/public/js/doctype_js/vehicle.js: registers listeners but never cleans up in onBeforeUnmount.
- one_fm/one_fm/public/js/doctype_js/vehicle.js:155 - document.write() replaces the document.

This change has not been rendered in a browser. Review the diff.