### PR TITLE
WI-002151: a run is timed forward from a stated departure [version-15]

### DIFF
--- a/one_fm/one_fm/doctype/transportation_shipment/transportation_shipment.py
+++ b/one_fm/one_fm/doctype/transportation_shipment/transportation_shipment.py
@@ -323,12 +323,70 @@ def _seconds_into_day(value) -> int | None:
 		return None
 
 
+def _departure_seconds(value):
+	"""The departure the dispatcher stated, as seconds past midnight.
+
+	The modal sends a clock string ("05:30" or "05:30:00"), which `_seconds_into_day`
+	cannot read - it handles the timedelta a Time column returns, and int("05:30") raises.
+	A blank means "nothing stated", which is what makes the run fall back to the time it
+	would have backed into.
+	"""
+	if value is None or value == "":
+		return None
+	if hasattr(value, "total_seconds"):
+		return int(value.total_seconds())
+	if isinstance(value, str) and ":" in value:
+		parts = value.split(":")
+		try:
+			hours, minutes = int(parts[0]), int(parts[1])
+			seconds = int(parts[2]) if len(parts) > 2 else 0
+		except (TypeError, ValueError):
+			return None
+		return hours * 3600 + minutes * 60 + seconds
+	try:
+		return int(value)
+	except (TypeError, ValueError):
+		return None
+
+
+def _clock_seconds(seconds) -> str:
+	"""Seconds past midnight as HH:MM:SS, which is what a Time control accepts.
+
+	`_clock` prints HH:MM for people to read; a Frappe Time field rejects it outright
+	("Time 09:00 must be in format: HH:mm:ss"), so the value the modal seeds its
+	departure field with has to carry the seconds.
+	"""
+	if seconds is None:
+		return ""
+	seconds = int(seconds) % 86400
+	return f"{seconds // 3600:02d}:{(seconds % 3600) // 60:02d}:{seconds % 60:02d}"
+
+
 def _clock(seconds) -> str:
 	"""Seconds past midnight as HH:MM, for the modal to print."""
 	if seconds is None:
 		return ""
 	seconds = int(seconds) % 86400
 	return f"{seconds // 3600:02d}:{(seconds % 3600) // 60:02d}"
+
+
+# Where the driver's report-time buffer lives. Named away from the manifest's own QOA
+# pass/fail fields so the two are never mistaken for one another.
+QOA_BUFFER_FIELD = "custom_transportation_qoa_buffer_minutes"
+
+
+def qoa_buffer_minutes() -> int:
+	"""The driver's report-time buffer, in minutes, from HR Settings (WI-002151 AC 1.2).
+
+	One reader for the whole feature - the modal, the block drawer and the manifest all
+	print the same QOA time, and a second lookup would be a second answer. Absent or
+	unset it is 0, which makes QOA Time equal the departure time and changes nothing.
+	"""
+	# Guarded on the field existing: the modal must still open on a site that has not
+	# run the patch yet, and get_single_value throws rather than returning None.
+	if not frappe.get_meta("HR Settings").get_field(QOA_BUFFER_FIELD):
+		return 0
+	return _minutes(frappe.db.get_single_value("HR Settings", QOA_BUFFER_FIELD))
 
 
 def _minutes(value) -> int:
@@ -345,31 +403,57 @@ def _minutes(value) -> int:
 DEFAULT_TRANSIT_MINUTES = 30
 
 
-def walk_legs(legs, anchor: int) -> list:
+def walk_legs(legs, anchor: int, departure=None) -> list:
 	"""When the vehicle leaves for each stop and when it reaches it, seconds past midnight.
 
 	One rule, applied here to the itinerary the modal prints and by the canvas to the
 	blocks on the lane: a stop's buffer is the dwell before departing towards it and its
-	transit is the drive, so a leg runs [departs, arrives].
+	transit is the drive, so a leg runs [departs, arrives]. Every stop after the first is
+	driven forward from the stop before it, so an edit high up the run moves everything
+	after it.
 
-	The first stop is the one the run is scheduled on - it backs into its anchor instead
-	of being driven forward from anything - which is why editing its minutes moves when
-	the run leaves, not when it arrives. Every later stop is driven forward from the stop
-	before it, so an edit high up the run moves everything after it.
+	The first stop is the one that has nothing to drive from, and there are two ways to
+	place it. Given a `departure` the run leaves at that moment and its arrival is
+	calculated forward from it - which is what the dispatcher states in the trip modal
+	(WI-002151 AC 1.1). Without one it backs into `anchor`, the shift time the card is
+	scheduled on, which is how a run reads before anyone has stated a departure and how
+	every caller that has no departure to give still gets a sensible itinerary.
 
-	`legs` is [(transit_minutes, buffer_minutes), ...] in stop order.
+	`legs` is [(transit_minutes, buffer_minutes), ...] in stop order. Seconds may run past
+	86400: a run that crosses midnight keeps counting, so the day it rolls into is
+	recoverable rather than silently wrapped.
 	"""
 	walked, clock = [], None
 	for transit, buffer_minutes in legs:
 		if clock is None:
-			arrives = anchor
-			departs = arrives - (buffer_minutes + transit) * 60
+			if departure is None:
+				arrives = anchor
+				departs = arrives - (buffer_minutes + transit) * 60
+			else:
+				departs = departure
+				arrives = departs + (buffer_minutes + transit) * 60
 		else:
-			departs = clock + buffer_minutes * 60
-			arrives = departs + transit * 60
+			# The leg begins when the bus is released from the stop before it, and its
+			# buffer is dwell WITHIN the leg - which is what makes AC 1.1's formula read
+			# literally: Arrival = Departure + Buffer + Transit. The process owner's own
+			# sample itinerary is walked exactly this way, departure by departure.
+			departs = clock
+			arrives = departs + (buffer_minutes + transit) * 60
 		walked.append((departs, arrives))
 		clock = arrives
 	return walked
+
+
+def day_offset(seconds) -> int:
+	"""How many whole days past the run's own day a stamp falls (WI-002151 AC 1.6).
+
+	A late run keeps counting past 86400 rather than wrapping, so this is what tells the
+	modal and the manifest to print a `(+1 Day)` badge instead of a time that reads as
+	though the bus arrived before it left.
+	"""
+	if seconds is None:
+		return 0
+	return max(0, int(seconds) // 86400)
 
 
 def _timings_by_shipment(timings) -> dict:
@@ -385,7 +469,7 @@ def _timings_by_shipment(timings) -> dict:
 
 
 @frappe.whitelist()
-def get_merge_preview(shipments, vehicle: str = None, timings=None) -> dict:
+def get_merge_preview(shipments, vehicle: str = None, timings=None, departure=None) -> dict:
 	"""What the Merge Trip modal shows before anyone confirms (WI-002078).
 
 	Builds the itinerary the merged run would have, walks it leg by leg, and reports
@@ -437,19 +521,62 @@ def get_merge_preview(shipments, vehicle: str = None, timings=None) -> dict:
 			_minutes(adjustment.get("buffer_minutes")),
 		))
 
-	walked = walk_legs(legs, arrival_time(docs[0]) or 0)
+	anchor = arrival_time(docs[0]) or 0
+	departure = _departure_seconds(departure)
+	# What the run leaves on before anyone states otherwise: the moment it would have
+	# backed into its first stop's shift time. Pre-filling this rather than a blank keeps
+	# an untouched trip timed exactly as it is today, so switching the modal to forward
+	# calculation does not silently re-time every run on the board.
+	first_transit, first_buffer = legs[0]
+	default_departure = max(0, anchor - (first_buffer + first_transit) * 60)
+	if departure is None:
+		departure = default_departure
+
+	walked = walk_legs(legs, anchor, departure=departure)
+
+	# The camp the run belongs to, and the Location that stands for it. Stop 1 leaves
+	# from there; every later stop leaves from the stop before it, which is what makes
+	# QOA an accommodation-departure fact rather than a per-leg one (AC 1.2).
+	base_accommodation = next((doc.accommodation for doc in docs if doc.accommodation), None)
+	camp_stop = _camp_stop(docs[0]) if docs else None
+	# The readable camp name lives on the shipment, not on Accommodation.
+	camp_label = next((doc.accommodation_name for doc in docs if doc.accommodation_name), None) \
+		or base_accommodation
+	qoa_buffer = qoa_buffer_minutes()
 
 	stops = []
 	for index, doc in enumerate(docs, start=1):
 		boards = own_direction(doc) == "RETURN"
 		transit, buffer_minutes = legs[index - 1]
 		departs, arrives = walked[index - 1]
+		# Where the bus collects these riders: an outward card loads at its own camp, a
+		# return card loads at the site it is collecting from.
+		origin = doc.stop_location if boards else (
+			_camp_stop(doc) or doc.accommodation_name or doc.accommodation
+		)
+
+		# QOA is the driver's report time at a camp, so it belongs to a leg that actually
+		# departs one. Riders from two cards at the SAME camp board together once, so only
+		# the first of them reports; a run calling at three different camps departs each,
+		# which is why the sample itinerary carries three separate report times. The same
+		# rule the saved assignment row is stamped with, so the modal and the plan agree.
+		previous_camp = docs[index - 2].accommodation if index > 1 else None
+		departs_camp = bool(not boards and doc.accommodation and doc.accommodation != previous_camp)
+		qoa = _clock(departs - qoa_buffer * 60) if departs_camp else None
 
 		stops.append({
 			"stop_index": index,
 			"shipment": doc.name,
 			"card_id": card_ids.get(doc.name, ""),
 			"stop_location": doc.stop_location,
+			"origin_location": origin,
+			"is_accommodation_origin": departs_camp,
+			# Where these riders work, which is not where the bus goes next once a run
+			# collects from several camps before dropping anyone.
+			"shift_location": doc.stop_location,
+			# Filled in below, once every leg's own origin is known.
+			"next_stop_location": None,
+			"direction": own_direction(doc),
 			"headcount": doc.headcount or 0,
 			"boards": boards,
 			"action": "Boarding" if boards else "Dropping Off",
@@ -458,6 +585,8 @@ def get_merge_preview(shipments, vehicle: str = None, timings=None) -> dict:
 			"buffer_minutes": buffer_minutes,
 			"departs": _clock(departs),
 			"arrives": _clock(arrives),
+			"arrives_day_offset": day_offset(arrives),
+			"qoa_time": qoa,
 		})
 
 	from one_fm.operations.doctype.route_plan.route_plan import leg_occupancy
@@ -469,6 +598,24 @@ def get_merge_preview(shipments, vehicle: str = None, timings=None) -> dict:
 
 	exceeded = bool(limit) and peak > limit
 
+	# The next stop is the following leg's origin; the last leg drives home to the camp
+	# the run started from.
+	for position, stop in enumerate(stops):
+		stop["next_stop_location"] = (
+			stops[position + 1]["origin_location"] if position + 1 < len(stops)
+			else (camp_stop or camp_label)
+		)
+
+	# AC 1.5: a mixed run ends by taking its return riders home, so its last leg has to be
+	# the one that ends at the base camp. Enforced for mixed runs only - a plain outbound
+	# run legitimately finishes at a site, and holding those to it would refuse every
+	# multi-stop drop-off on the board.
+	ends_home = _ends_at_base_camp(docs)
+	route_message = "" if ends_home else _(
+		"The last leg of a mixed run must be the ride home: end the run on a return card "
+		"collecting for {0}, so the bus finishes at the camp rather than at a site."
+	).format(camp_label or base_accommodation or _("the base accommodation"))
+
 	return {
 		"trip_direction": MIXED,
 		"vehicle": vehicle,
@@ -477,14 +624,55 @@ def get_merge_preview(shipments, vehicle: str = None, timings=None) -> dict:
 		"peak_occupancy": peak,
 		"worst_leg": worst_leg,
 		"exceeded": exceeded,
+		"departure": _clock(departure),
+		"default_departure": _clock(default_departure),
+		# What the Time control is seeded with; it refuses anything without seconds.
+		"departure_input": _clock_seconds(departure),
+		# Raw seconds as well as the clock strings: the canvas moves the blocks by the
+		# DIFFERENCE between the two, which is a duration and so needs no timezone
+		# conversion. Rebuilding an instant from "05:30" in the browser would.
+		"departure_seconds": int(departure),
+		"default_departure_seconds": int(default_departure),
+		"qoa_buffer_minutes": qoa_buffer,
+		"base_accommodation": camp_label or base_accommodation,
+		"ends_at_base_camp": ends_home,
+		"route_message": route_message,
 		# The modal disables Confirm on this alone, so it is decided here rather than
 		# left to the browser to work out from the numbers.
-		"can_merge": not exceeded,
+		"can_merge": not exceeded and ends_home,
 		"message": (
 			_("Leg {0}: {1}/{2} Seats EXCEEDED").format(worst_leg, peak, limit)
 			if exceeded else ""
 		),
 	}
+
+
+def _camp_stop(shipment):
+	"""The Location that stands for a card's accommodation camp, or None."""
+	if not shipment.accommodation:
+		return None
+	return frappe.db.get_value(
+		"Accommodation", shipment.accommodation, "transport_stop_location"
+	)
+
+
+def _ends_at_base_camp(docs) -> bool:
+	"""True when the run's final leg is one that finishes at the base accommodation.
+
+	A return card's `stop_location` is where it *collects*; the camp it is heading for is
+	its `accommodation`. So "the final stop location must be the base accommodation camp"
+	is a statement about the last leg being a ride home, not about a camp appearing in the
+	stop column - no card on the board carries the camp as its stop location, and adding a
+	terminal camp stop would be a change to the route model rather than a validation.
+
+	A run that is not mixed is left alone: it has no return riders to take home.
+	"""
+	directions = {own_direction(doc) for doc in docs}
+	if len(directions) < 2:
+		return True
+
+	last = docs[-1]
+	return own_direction(last) == "RETURN"
 
 
 def unmerge_trip_shipment(name) -> bool:

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
@@ -831,11 +831,27 @@ function mountRoutePlannerApp(wrapper, data) {
                         if (!tripMap[key]) tripMap[key] = [];
                         tripMap[key].push(item);
                     });
+
+                    // A trip is joined WHOLE. Proximity decides which run is near enough
+                    // to join; it must not decide how much of that run takes part. A trip
+                    // whose stops are spread over more than the proximity window arrived
+                    // here half-present, so the modal drew half an itinerary, the seat
+                    // walk counted half the riders, and the merge marked half the stops
+                    // Mixed — leaving the rest of the run behind on its old heading.
+                    Object.keys(tripMap).forEach(key => {
+                        if (key.startsWith('_solo_')) return;
+                        tripMap[key] = this.swimItems.filter(
+                            i => i.vehicleId === vehicle.id && i.tripId === key
+                        );
+                    });
                     const tripKeys = Object.keys(tripMap);
 
                     if (tripKeys.length === 1) {
                         // ── Single trip: simple confirm ──
-                        const existingStops = nearbyBlocks.map(i => {
+                        // The WHOLE trip, not just the stops proximity picked out: the
+                        // merge takes all of them, so the operator has to be shown all of
+                        // them before saying yes.
+                        const existingStops = tripMap[tripKeys[0]].map(i => {
                             const c = this.planData.shipment_cards.find(sc => sc.id === i.cardId);
                             const siteName = c ? c.site_location : i.cardId;
                             const campName = (c && c.accommodation) ? c.accommodation : '';
@@ -1072,22 +1088,44 @@ function mountRoutePlannerApp(wrapper, data) {
                 // comes back, and the server accepts either key.
                 const timings = {};
                 existingItems.forEach((item) => {
-                    // A reload hands back 0 for a leg that was never timed - the Int
-                    // column cannot say "unset" - so only a leg carrying real minutes
-                    // overrides the preview's defaults.
-                    if (!item.transitMinutes && !item.bufferMinutes) return;
-                    timings[item.cardId] = {
-                        transit_minutes: item.transitMinutes || 0,
-                        buffer_minutes: item.bufferMinutes || 0,
-                    };
+                    if (item.transitMinutes || item.bufferMinutes) {
+                        timings[item.cardId] = {
+                            transit_minutes: item.transitMinutes || 0,
+                            buffer_minutes: item.bufferMinutes || 0,
+                        };
+                        return;
+                    }
+                    // A leg that was never given minutes still has a length on the lane —
+                    // an Int column cannot say "unset", so 0/0 and "an hour long" look the
+                    // same in the row. Sending the drawn length keeps the modal showing
+                    // the run where it actually sits: without it a block spanning 07:00 to
+                    // 08:00 collapsed to nothing and the whole itinerary jumped an hour
+                    // later. The same rule _retimeTrip already applies when it redraws.
+                    const span = Math.round(
+                        (new Date(item.end).getTime() - new Date(item.start).getTime()) / 60000
+                    );
+                    if (span > 0) {
+                        timings[item.cardId] = { transit_minutes: span, buffer_minutes: 0 };
+                    }
                 });
                 let previewStops = [];
+                // The run's own departure and the one it would have backed into. The blocks
+                // are moved by the difference between them, so a departure the dispatcher
+                // never touched moves nothing (WI-002151 AC 1.1).
+                let departureShiftMs = 0;
 
                 const d = new frappe.ui.Dialog({
-                    title: __('Merge Trip'),
+                    title: __('Trip Builder'),
                     size: 'large',
-                    fields: [{ fieldtype: 'HTML', fieldname: 'preview' }],
-                    primary_action_label: __('Confirm & Merge Trip'),
+                    fields: [
+                        {
+                            fieldtype: 'Time', fieldname: 'departure',
+                            label: __('Initial Departure Time'),
+                            description: __('When the vehicle leaves for its first stop. Every arrival below is calculated forward from here.')
+                        },
+                        { fieldtype: 'HTML', fieldname: 'preview' }
+                    ],
+                    primary_action_label: __('Confirm & Apply'),
                     primary_action() {
                         frappe.call({
                             method: 'one_fm.one_fm.doctype.transportation_shipment.transportation_shipment.merge_trip_shipments',
@@ -1096,7 +1134,8 @@ function mountRoutePlannerApp(wrapper, data) {
                             callback(r) {
                                 if (!r.message) return;
                                 d.hide();
-                                self._applyMerge(newCard, existingItems, vehicleId, r.message, previewStops);
+                                self._applyMerge(newCard, existingItems, vehicleId, r.message,
+                                    previewStops, departureShiftMs);
                             }
                         });
                     }
@@ -1105,11 +1144,23 @@ function mountRoutePlannerApp(wrapper, data) {
                 const render = () => {
                     frappe.call({
                         method: 'one_fm.one_fm.doctype.transportation_shipment.transportation_shipment.get_merge_preview',
-                        args: { shipments: shipments, vehicle: vehicleId, timings: timings },
+                        args: {
+                            shipments: shipments, vehicle: vehicleId, timings: timings,
+                            departure: d.get_value('departure') || null
+                        },
                         callback(r) {
                             const p = r.message;
                             if (!p) return;
                             previewStops = p.stops || [];
+                            departureShiftMs =
+                                (p.departure_seconds - p.default_departure_seconds) * 1000;
+                            // Seed the field on the first render with the moment the run would
+                            // have left anyway, so an untouched trip is timed exactly as before.
+                            if (!d.get_value('departure')) {
+                                // departure_input, not departure: a Time control refuses
+                                // anything without seconds ("must be in format HH:mm:ss").
+                                d.set_value('departure', p.departure_input);
+                            }
                             d.fields_dict.preview.$wrapper.html(self._mergeModalHtml(p, vehicle));
                             // Confirm is disabled by the server's verdict, so the button and
                             // the banner can never disagree about whether the trip fits.
@@ -1128,9 +1179,12 @@ function mountRoutePlannerApp(wrapper, data) {
 
                 render();
                 d.show();
+                // Re-walk the whole itinerary whenever the departure moves.
+                d.fields_dict.departure.$input.on('change', () => render());
             },
 
             _mergeModalHtml(p, vehicle) {
+                const self = this;
                 const esc = (v) => frappe.utils.escape_html(String(v == null ? '' : v));
 
                 const banner = p.exceeded
@@ -1157,17 +1211,40 @@ function mountRoutePlannerApp(wrapper, data) {
                     </div>`;
                 }).join('');
 
-                const legs = p.stops.map((s) => `
-                    <tr>
-                        <td style="padding:4px 8px">Seq ${s.stop_index}</td>
-                        <td style="padding:4px 8px">${esc(s.stop_location || '—')}</td>
-                        <td style="padding:4px 8px"><input class="rp-leg-min" type="number" min="0"
-                            data-shipment="${esc(s.card_id || s.shipment)}" data-key="transit_minutes"
-                            value="${esc(s.transit_minutes)}" style="width:70px"></td>
-                        <td style="padding:4px 8px"><input class="rp-leg-min" type="number" min="0"
+                const legs = p.stops.map((s) => {
+                    // A leg that crosses midnight arrives on the next day, and saying so is
+                    // the difference between a readable itinerary and one where the bus
+                    // appears to arrive before it left (AC 1.6).
+                    const rollover = s.arrives_day_offset
+                        ? ` <span class="indicator-pill orange">${__('+{0} Day', [s.arrives_day_offset])}</span>`
+                        : '';
+                    // QOA belongs only to the leg that leaves the camp carrying outward
+                    // riders; it is hidden for intermediate pickups and return legs (AC 1.2).
+                    return `
+                    <tr class="${s.exceeded ? 'text-danger font-weight-bold' : ''}">
+                        <td class="small">${esc(s.card_id || s.shipment)}</td>
+                        <td class="small">${esc(self.dirName(s.direction))}</td>
+                        <td class="small">${esc(s.origin_location || '—')}</td>
+                        <td class="small rp-leg-time-col">${s.qoa_time ? esc(s.qoa_time) : '—'}</td>
+                        <td class="small rp-leg-time-col">${esc(s.departs)}</td>
+                        <td class="rp-leg-mins-col"><input class="rp-leg-min form-control input-sm"
+                            type="number" min="0"
                             data-shipment="${esc(s.card_id || s.shipment)}" data-key="buffer_minutes"
-                            value="${esc(s.buffer_minutes)}" style="width:70px"></td>
-                    </tr>`).join('');
+                            value="${esc(s.buffer_minutes)}"></td>
+                        <td class="rp-leg-mins-col"><input class="rp-leg-min form-control input-sm"
+                            type="number" min="0"
+                            data-shipment="${esc(s.card_id || s.shipment)}" data-key="transit_minutes"
+                            value="${esc(s.transit_minutes)}"></td>
+                        <td class="small">${esc(s.shift_location || '—')}</td>
+                        <td class="small">${esc(s.next_stop_location || '—')}</td>
+                        <td class="small font-weight-bold rp-leg-time-col">${esc(s.arrives)}${rollover}</td>
+                    </tr>`;
+                }).join('');
+
+                // AC 1.5: a mixed run has to finish by taking its return riders home.
+                const routeBanner = p.route_message
+                    ? `<div class="alert alert-warning p-3 mb-3 small">${esc(p.route_message)}</div>`
+                    : '';
 
                 return `
                     <div style="display:flex;gap:8px;align-items:center;margin-bottom:10px">
@@ -1178,19 +1255,30 @@ function mountRoutePlannerApp(wrapper, data) {
                     ${banner}
                     <div style="font-size:11px;font-weight:700;color:#9ca3af;text-transform:uppercase;margin-bottom:6px">Itinerary</div>
                     ${stops}
-                    <div style="font-size:11px;font-weight:700;color:#9ca3af;text-transform:uppercase;margin:12px 0 6px">Per-Leg Transit &amp; Buffer Times</div>
-                    <table style="width:100%;font-size:12px;border-collapse:collapse">
-                        <thead><tr style="background:#f3f4f6">
-                            <th style="text-align:left;padding:4px 8px">Leg</th>
-                            <th style="text-align:left;padding:4px 8px">Stop</th>
-                            <th style="text-align:left;padding:4px 8px">Transit (min)</th>
-                            <th style="text-align:left;padding:4px 8px">Buffer (min)</th>
+                    ${routeBanner}
+                    <div class="text-muted small font-weight-bold text-uppercase mb-2 mt-3">
+                        ${__('Legs — arrival is calculated forward from the departure above')}
+                    </div>
+                    <div class="table-responsive">
+                    <table class="table table-sm table-bordered small mb-0">
+                        <thead><tr>
+                            <th>${__('Card')}</th>
+                            <th>${__('Direction')}</th>
+                            <th>${__('Accommodation / Stop')}</th>
+                            <th>${__('QOA')}</th>
+                            <th>${__('Departure')}</th>
+                            <th class="rp-leg-mins-col">${__('Buffer (min)')}</th>
+                            <th class="rp-leg-mins-col">${__('Transit (min)')}</th>
+                            <th>${__('Shift Location')}</th>
+                            <th>${__('Next Stop')}</th>
+                            <th>${__('Target Arrival')}</th>
                         </tr></thead>
                         <tbody>${legs}</tbody>
-                    </table>`;
+                    </table>
+                    </div>`;
             },
 
-            _applyMerge(newCard, existingItems, vehicleId, merged, previewStops) {
+            _applyMerge(newCard, existingItems, vehicleId, merged, previewStops, departureShiftMs) {
                 const self = this;
                 const tripId = merged.trip_group;
 
@@ -1234,6 +1322,19 @@ function mountRoutePlannerApp(wrapper, data) {
                 // and then left the block sitting on the 60/15 it was dropped with
                 // (feedback on WI-002074).
                 self._retimeTrip(tripId);
+
+                // _retimeTrip lays the run out from the shift time it backs into. Moving
+                // every stop by the difference between that and the departure the
+                // dispatcher stated puts the whole run where they asked for it, without
+                // rebuilding an instant from a clock string in the browser (AC 1.1).
+                if (departureShiftMs) {
+                    self.swimItems.forEach((item) => {
+                        if (item.tripId !== tripId) return;
+                        item.start = new Date(new Date(item.start).getTime() + departureShiftMs);
+                        item.end = new Date(new Date(item.end).getTime() + departureShiftMs);
+                    });
+                    self.swimItems = [...self.swimItems];
+                }
 
                 self.assignedCards.add(newCard.id);
                 self.selectedPoolCard = null;
@@ -1303,8 +1404,11 @@ function mountRoutePlannerApp(wrapper, data) {
                 let cursor = new Date(stops[0].end).getTime();
                 stops.slice(1).forEach((item) => {
                     const { buffer, transit } = leg(item);
-                    const start = cursor + buffer;
-                    const end = start + Math.max(transit, MIN_BLOCK_MS);
+                    // A leg starts when the bus is released from the stop before it, and
+                    // its buffer is dwell inside the leg — the same walk the server prints
+                    // the itinerary with, so the block and the table cannot disagree.
+                    const start = cursor;
+                    const end = start + Math.max(buffer + transit, MIN_BLOCK_MS);
                     item.start = new Date(start);
                     item.end = new Date(end);
                     cursor = end;
@@ -1513,6 +1617,27 @@ function mountRoutePlannerApp(wrapper, data) {
                     peak = Math.max(peak, onBoard);
                 });
                 return peak;
+            },
+
+            // The driver's report time for a leg, or '' where QOA does not apply. Only the
+            // leg that leaves the accommodation carrying outward riders has one: an
+            // intermediate pickup and a return leg heading home are neither (AC 1.2).
+            stopQoaTime(stop) {
+                if (!stop || stop.stopNum !== 1) return '';
+                if (this.cardOwnDirection(stop.item) === 'RETURN') return '';
+                const buffer = (this.planData.qoa_buffer_minutes || 0) * 60000;
+                return this.fmtTime(new Date(stop.item.start).getTime() - buffer);
+            },
+
+            // Whole days between a run's first departure and this stop's arrival, so a leg
+            // that crosses midnight says so instead of reading as though it landed earlier
+            // the same morning (AC 1.6).
+            stopDayOffset(stop) {
+                const stops = this.selectedTripStops || [];
+                if (!stops.length || !stop) return 0;
+                const first = new Date(stops[0].item.start).getTime();
+                const arrival = new Date(stop.item.end).getTime();
+                return Math.max(0, Math.floor((arrival - first) / 86400000));
             },
 
             // Which way one stop's own riders travel. A merged card reads MIXED, so the
@@ -3891,8 +4016,29 @@ function injectRPVueTemplate() {
                     </div>
                   </div>
                 </div>
-                <div class="rp-detail-row" style="padding:4px 0 3px 30px"
-                     v-if="stop.item.transitMinutes || stop.item.bufferMinutes">
+                <!-- The forward cascade, per leg (WI-002151): when the vehicle leaves
+                     for this stop and when it is due there. -->
+                <div class="rp-detail-row" style="padding:4px 0 3px 30px">
+                  <div class="rp-detail-row-icon"><span class="rp-icon">departure_board</span></div>
+                  <div class="rp-detail-row-content">
+                    <div class="rp-detail-row-label">Departure &rarr; Target Arrival</div>
+                    <div class="rp-detail-row-value">
+                      {{ fmtTime(stop.item.start) }} &rarr; {{ fmtTime(stop.item.end) }}
+                      <span v-if="stopDayOffset(stop)" class="rp-detail-row-label" style="display:inline">
+                        (+{{ stopDayOffset(stop) }} Day)
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <!-- QOA: only where the leg leaves the camp carrying outward riders. -->
+                <div class="rp-detail-row" style="padding:4px 0 3px 30px" v-if="stopQoaTime(stop)">
+                  <div class="rp-detail-row-icon"><span class="rp-icon">alarm</span></div>
+                  <div class="rp-detail-row-content">
+                    <div class="rp-detail-row-label">Driver QOA Report Time</div>
+                    <div class="rp-detail-row-value">{{ stopQoaTime(stop) }}</div>
+                  </div>
+                </div>
+                <div class="rp-detail-row" style="padding:4px 0 3px 30px">
                   <div class="rp-detail-row-icon"><span class="rp-icon">timer</span></div>
                   <div class="rp-detail-row-content">
                     <div class="rp-detail-row-label">Transit &amp; Buffer</div>
@@ -4421,6 +4567,12 @@ function injectRPStyles() {
         .rp-legend-mixed    { background: var(--rp-color-mixed-container); color: var(--rp-color-mixed); }
         .rp-legend-conflict { background: var(--rp-color-conflict-container); color: var(--rp-color-conflict); }
         .rp-legend-overcap { background: #f3e5f5; color: #7b1fa2; }
+        /* Trip Builder legs. The minute inputs are edited constantly, so they get room
+           to show two or three digits instead of clipping them, and their columns do not
+           wrap. The place columns are the ones allowed to wrap. */
+        .rp-leg-min      { width: 72px; min-width: 72px; text-align: right; }
+        .rp-leg-mins-col { width: 88px; white-space: nowrap; }
+        .rp-leg-time-col { white-space: nowrap; }
 
         /* ── Grid ── */
         #rp-grid-container { flex: 1; display: flex; flex-direction: column; overflow: hidden; }

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -5,6 +5,9 @@ from frappe.utils import cint
 from one_fm.one_fm.doctype.transportation_manifest.manifest_sync import sync_manifest_details
 from one_fm.one_fm.doctype.vehicle_handover_log.vehicle_handover_log import get_handover_windows
 from one_fm.operations.doctype.route_plan.route_plan import _card_direction
+from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
+    qoa_buffer_minutes,
+)
 from one_fm.overrides.vehicle import passenger_capacity
 
 PICKUP_BUFFER = 10             # minutes
@@ -145,6 +148,9 @@ def get_route_planner_data():
             "global_end":        fmt(global_end_utc),
             "vehicles":          vehicles,
             "shipment_cards":    shipment_cards,
+            # The driver's report-time buffer, so the block drawer can print QOA without
+            # a second round trip (WI-002151 AC 1.2).
+            "qoa_buffer_minutes": qoa_buffer_minutes(),
             "handover_windows":  handover_windows
         }
 
@@ -1171,6 +1177,7 @@ def save_assignments(plan_name: str, swim_items: str, assigned_cards: str):
             "buffer_minutes":          item.get("bufferMinutes") or 0,
         })
 
+    _stamp_leg_details(doc)
     doc.save(ignore_permissions=False)
 
     # Keep persisted Transportation Shipment records in sync with the canvas:
@@ -2087,3 +2094,149 @@ def _inherit_trip_identity(manifest_doc, assignment_rows) -> bool:
         changed = True
 
     return changed
+
+
+def _local_seconds(stamp):
+    """A stored UTC timeline stamp as seconds past midnight in the site's timezone.
+
+    Rows carry UTC (``2026-08-18T11:15:00.000Z``) while the shift times, the QOA report
+    time and everything a driver reads are local, so the two have to be reconciled once,
+    here, rather than in each caller.
+    """
+    if not stamp:
+        return None
+    try:
+        import pytz
+
+        text = str(stamp).replace("T", " ").replace("Z", "").split(".")[0]
+        utc = pytz.utc.localize(frappe.utils.get_datetime(text))
+        site_tz = pytz.timezone(frappe.db.get_single_value("System Settings", "time_zone") or "UTC")
+        local = utc.astimezone(site_tz)
+        return local.hour * 3600 + local.minute * 60 + local.second
+    except Exception:
+        return None
+
+
+def _time_field(seconds):
+    """Seconds past midnight as ``HH:MM:SS`` for a Time column, or None."""
+    if seconds is None:
+        return None
+    seconds = int(seconds) % 86400
+    return f"{seconds // 3600:02d}:{(seconds % 3600) // 60:02d}:{seconds % 60:02d}"
+
+
+def _stamp_leg_details(doc):
+    """Write each leg's own facts onto its assignment row (WI-002151, WI-002171).
+
+    The canvas works these out to draw the trip modal, but a row that only carries a
+    timestamp cannot answer what the modal showed: where the leg started, what the driver's
+    report time was, how full the bus was leaving that stop, whether it rolled past
+    midnight. The manifest, any report and anyone reading the plan later all need those,
+    and re-deriving them from the timestamps loses the answer - so the save records them.
+
+    Occupancy is walked with ``leg_occupancy``, the same function the capacity validation
+    and the trip modal use, so the number stored is the number the operator was shown.
+    """
+    from collections import defaultdict
+
+    from one_fm.operations.doctype.route_plan.route_plan import leg_occupancy
+
+    rows = [row for row in doc.assignments if row.vehicle]
+    if not rows:
+        return
+
+    ship_names = list({row.transportation_shipment for row in rows if row.transportation_shipment})
+    ships = {
+        s.name: s
+        for s in frappe.get_all(
+            "Transportation Shipment",
+            filters={"name": ["in", ship_names]},
+            fields=["name", "accommodation", "stop_location", "start_time",
+                    "trip_direction", "pre_merge_trip_direction"],
+        )
+    } if ship_names else {}
+
+    camps = {}
+    for accommodation in {s.accommodation for s in ships.values() if s.accommodation}:
+        camps[accommodation] = frappe.db.get_value(
+            "Accommodation", accommodation, "transport_stop_location"
+        )
+
+    limits = {
+        v.name: passenger_capacity(v.seats, v.custom_includes_driver_seat)
+        for v in frappe.get_all(
+            "Vehicle",
+            filters={"name": ["in", list({row.vehicle for row in rows})]},
+            fields=["name", "seats", "custom_includes_driver_seat"],
+        )
+    }
+    buffer_minutes = qoa_buffer_minutes()
+
+    runs = defaultdict(list)
+    for row in rows:
+        runs[(row.vehicle, row.trip_group or f"\0{row.card_id}")].append(row)
+
+    for (vehicle, _group), run in runs.items():
+        run.sort(key=lambda row: cint(row.stop_index))
+
+        stops = []
+        for row in run:
+            shipment = ships.get(row.transportation_shipment)
+            own = (
+                _card_direction(shipment.trip_direction, shipment.pre_merge_trip_direction)
+                if shipment else _normalize_direction(row.direction)
+            )
+            stops.append({"headcount": cint(row.headcount), "boards": own == "RETURN"})
+
+        _peak, _worst, per_leg = leg_occupancy(stops)
+
+        # A stop where riders both leave and join is a handover, whichever cards carry
+        # the two halves - which is what "Combined" says.
+        movements = defaultdict(set)
+        for row, stop in zip(run, stops):
+            movements[row.stop_location].add(stop["boards"])
+
+        for position, (row, stop) in enumerate(zip(run, stops)):
+            shipment = ships.get(row.transportation_shipment)
+            boards = stop["boards"]
+            departs = _local_seconds(row.start_time)
+            arrives = _local_seconds(row.end_time)
+
+            # Where this leg departs from, and whether that is a camp. An outward leg
+            # loads at its own accommodation - but only the FIRST leg out of a given camp
+            # actually departs it: riders from two cards at the same camp board together
+            # once, and the second leg is continuing from wherever the first dropped.
+            # A run that calls at three different camps departs each of them, which is
+            # why the process owner's sample carries three separate report times.
+            previous = run[position - 1] if position else None
+            previous_camp = (
+                (ships.get(previous.transportation_shipment) or frappe._dict()).accommodation
+                if previous else None
+            )
+            camp = shipment.accommodation if shipment else None
+            departs_camp = bool(not boards and camp and camp != previous_camp)
+
+            row.max_passenger_capacity = limits.get(vehicle) or 0
+            row.boarding_count = cint(row.headcount) if boards else 0
+            row.drop_off_count = 0 if boards else cint(row.headcount)
+            row.current_passenger_count = per_leg[position]
+            row.action_type = (
+                "Combined" if len(movements.get(row.stop_location) or ()) > 1
+                else ("Boarding" if boards else "Dropping Off")
+            )
+            row.is_accommodation_origin = 1 if departs_camp else 0
+            if departs_camp:
+                origin = camps.get(camp)
+            elif boards:
+                origin = row.stop_location
+            else:
+                origin = previous.stop_location if previous else row.stop_location
+            row.origin_location = origin if origin and frappe.db.exists("Location", origin) else None
+            row.shift_start_time = shipment.start_time if shipment else None
+            row.is_next_day = (
+                1 if (departs is not None and arrives is not None and arrives < departs) else 0
+            )
+            row.qoa_time = (
+                _time_field(departs - buffer_minutes * 60)
+                if (row.is_accommodation_origin and departs is not None) else None
+            )

--- a/one_fm/operations/doctype/route_plan_assignment/route_plan_assignment.json
+++ b/one_fm/operations/doctype/route_plan_assignment/route_plan_assignment.json
@@ -1,163 +1,236 @@
 {
-  "actions": [],
-  "creation": "2026-05-04 10:00:00.000000",
-  "doctype": "DocType",
-  "editable_grid": 1,
-  "engine": "InnoDB",
-  "field_order": [
-    "card_id",
-    "transportation_shipment",
-    "vehicle",
-    "direction",
-    "column_break_1",
-    "stop_index",
-    "trip_group",
-    "trip_name",
-    "headcount",
-    "section_break_details",
-    "site",
-    "shift",
-    "column_break_2",
-    "accommodation",
-    "stop_location",
-    "section_break_times",
-    "start_time",
-    "end_time",
-    "transit_minutes",
-    "buffer_minutes"
-  ],
-  "fields": [
-    {
-      "fieldname": "card_id",
-      "fieldtype": "Data",
-      "label": "Card ID",
-      "reqd": 1,
-      "in_list_view": 1
-    },
-    {
-      "fieldname": "transportation_shipment",
-      "fieldtype": "Link",
-      "label": "Transportation Shipment",
-      "options": "Transportation Shipment",
-      "description": "Source shipment record linked into this vehicle's manifest array"
-    },
-    {
-      "fieldname": "vehicle",
-      "fieldtype": "Link",
-      "label": "Vehicle",
-      "options": "Vehicle",
-      "reqd": 1,
-      "in_list_view": 1
-    },
-    {
-      "fieldname": "direction",
-      "fieldtype": "Select",
-      "label": "Direction",
-      "options": "\nOUTBOUND\nRETURN\nMIXED",
-      "reqd": 1,
-      "in_list_view": 1
-    },
-    {
-      "fieldname": "column_break_1",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "stop_index",
-      "fieldtype": "Int",
-      "label": "Stop Index",
-      "default": "0",
-      "description": "0 = standalone, 1+ = multi-stop trip sequence"
-    },
-    {
-      "fieldname": "trip_group",
-      "fieldtype": "Data",
-      "label": "Trip Group",
-      "description": "Groups multi-stop blocks into one trip"
-    },
-    {
-      "fieldname": "trip_name",
-      "fieldtype": "Data",
-      "label": "Trip Name",
-      "description": "User-defined name for the trip"
-    },
-    {
-      "fieldname": "headcount",
-      "fieldtype": "Int",
-      "label": "Headcount",
-      "in_list_view": 1
-    },
-    {
-      "fieldname": "section_break_details",
-      "fieldtype": "Section Break",
-      "label": "Details"
-    },
-    {
-      "fieldname": "site",
-      "fieldtype": "Data",
-      "label": "Site"
-    },
-    {
-      "fieldname": "shift",
-      "fieldtype": "Data",
-      "label": "Shift"
-    },
-    {
-      "fieldname": "column_break_2",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "accommodation",
-      "fieldtype": "Data",
-      "label": "Accommodation"
-    },
-    {
-      "fieldname": "stop_location",
-      "fieldtype": "Data",
-      "label": "Stop Location"
-    },
-    {
-      "fieldname": "section_break_times",
-      "fieldtype": "Section Break",
-      "label": "Time Window"
-    },
-    {
-      "fieldname": "start_time",
-      "fieldtype": "Data",
-      "label": "Start Time",
-      "description": "ISO timestamp of block start on timeline. Date part = multi-day lock lifespan start; time part = daily trip start."
-    },
-    {
-      "fieldname": "end_time",
-      "fieldtype": "Data",
-      "label": "End Time",
-      "description": "ISO timestamp of block end on timeline. Date part = multi-day lock lifespan end; time part = daily trip end."
-    },
-    {
-      "fieldname": "transit_minutes",
-      "fieldtype": "Int",
-      "label": "Transit Minutes",
-      "description": "Driving time from the previous stop, as set in the Merge Trip modal."
-    },
-    {
-      "fieldname": "buffer_minutes",
-      "fieldtype": "Int",
-      "label": "Buffer Minutes",
-      "description": "Waiting time at this stop before departing for the next one."
-    }
-  ],
-  "index_web_pages_for_search": 0,
-  "istable": 1,
-  "links": [],
-  "modified": "2026-08-17 16:00:00.000000",
-  "modified_by": "Administrator",
-  "module": "Operations",
-  "name": "Route Plan Assignment",
-  "naming_rule": "Random",
-  "autoname": "hash",
-  "owner": "Administrator",
-  "permissions": [],
-  "sort_field": "creation",
-  "sort_order": "ASC",
-  "states": [],
-  "track_changes": 0
+ "actions": [],
+ "autoname": "hash",
+ "creation": "2026-05-04 10:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "card_id",
+  "transportation_shipment",
+  "vehicle",
+  "max_passenger_capacity",
+  "direction",
+  "action_type",
+  "column_break_1",
+  "stop_index",
+  "trip_group",
+  "trip_name",
+  "headcount",
+  "boarding_count",
+  "current_passenger_count",
+  "drop_off_count",
+  "qoa_time",
+  "shift_start_time",
+  "section_break_details",
+  "site",
+  "shift",
+  "column_break_2",
+  "accommodation",
+  "origin_location",
+  "stop_location",
+  "is_accommodation_origin",
+  "section_break_times",
+  "start_time",
+  "end_time",
+  "is_next_day",
+  "transit_minutes",
+  "buffer_minutes"
+ ],
+ "fields": [
+  {
+   "fieldname": "card_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Card ID",
+   "reqd": 1
+  },
+  {
+   "description": "Source shipment record linked into this vehicle's manifest array",
+   "fieldname": "transportation_shipment",
+   "fieldtype": "Link",
+   "label": "Transportation Shipment",
+   "options": "Transportation Shipment"
+  },
+  {
+   "fieldname": "vehicle",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Vehicle",
+   "options": "Vehicle",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "vehicle.custom_max_passenger_capacity",
+   "fieldname": "max_passenger_capacity",
+   "fieldtype": "Int",
+   "label": "Max Passenger Capacity",
+   "read_only": 1
+  },
+  {
+   "fieldname": "direction",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Direction",
+   "options": "\nOUTBOUND\nRETURN\nMIXED",
+   "reqd": 1
+  },
+  {
+   "description": "Identifies passenger movement at the leg's stop location.",
+   "fieldname": "action_type",
+   "fieldtype": "Select",
+   "label": "Action Type",
+   "options": "\nBoarding\nDropping Off\nCombined"
+  },
+  {
+   "fieldname": "column_break_1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "0 = standalone, 1+ = multi-stop trip sequence",
+   "fieldname": "stop_index",
+   "fieldtype": "Int",
+   "label": "Stop Index"
+  },
+  {
+   "description": "Groups multi-stop blocks into one trip",
+   "fieldname": "trip_group",
+   "fieldtype": "Data",
+   "label": "Trip Group"
+  },
+  {
+   "description": "User-defined name for the trip",
+   "fieldname": "trip_name",
+   "fieldtype": "Data",
+   "label": "Trip Name"
+  },
+  {
+   "fieldname": "headcount",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Headcount"
+  },
+  {
+   "description": "Number of employees boarding at this stop.",
+   "fieldname": "boarding_count",
+   "fieldtype": "Int",
+   "label": "Boarding Count"
+  },
+  {
+   "description": "The dynamic total number of people physically sitting inside the bus during that specific leg segment.",
+   "fieldname": "current_passenger_count",
+   "fieldtype": "Int",
+   "label": "Current Passenger Count"
+  },
+  {
+   "description": "Number of employees disembarking at this stop.",
+   "fieldname": "drop_off_count",
+   "fieldtype": "Int",
+   "label": "Drop Off Count"
+  },
+  {
+   "description": "Calculated QOA time (start_time - qoa_buffer_minutes) rendered ONLY for Outbound legs departing from Accommodation.",
+   "fieldname": "qoa_time",
+   "fieldtype": "Time",
+   "label": "QOA Time"
+  },
+  {
+   "description": "It will fetch defined Shift's start time (e.g., 08:00:00).",
+   "fieldname": "shift_start_time",
+   "fieldtype": "Time",
+   "label": "Shift Start Time"
+  },
+  {
+   "fieldname": "section_break_details",
+   "fieldtype": "Section Break",
+   "label": "Details"
+  },
+  {
+   "fieldname": "site",
+   "fieldtype": "Data",
+   "label": "Site"
+  },
+  {
+   "fieldname": "shift",
+   "fieldtype": "Data",
+   "label": "Shift"
+  },
+  {
+   "fieldname": "column_break_2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "accommodation",
+   "fieldtype": "Data",
+   "label": "Accommodation"
+  },
+  {
+   "fieldname": "origin_location",
+   "fieldtype": "Link",
+   "label": "Origin Location",
+   "options": "Location"
+  },
+  {
+   "fieldname": "stop_location",
+   "fieldtype": "Data",
+   "label": "Stop Location"
+  },
+  {
+   "default": "0",
+   "description": "Indicates if the leg departs from an Accommodation camp, triggering the QOA calculation from HR Settings.",
+   "fieldname": "is_accommodation_origin",
+   "fieldtype": "Check",
+   "label": "Is Accommodation Origin"
+  },
+  {
+   "fieldname": "section_break_times",
+   "fieldtype": "Section Break",
+   "label": "Time Window"
+  },
+  {
+   "description": "ISO timestamp of block start on timeline. Date part = multi-day lock lifespan start; time part = daily trip start.",
+   "fieldname": "start_time",
+   "fieldtype": "Data",
+   "label": "Start Time"
+  },
+  {
+   "description": "ISO timestamp of block end on timeline. Date part = multi-day lock lifespan end; time part = daily trip end.",
+   "fieldname": "end_time",
+   "fieldtype": "Data",
+   "label": "End Time"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_next_day",
+   "fieldtype": "Check",
+   "label": "Is Next Day"
+  },
+  {
+   "description": "Driving time from the previous stop, as set in the Merge Trip modal.",
+   "fieldname": "transit_minutes",
+   "fieldtype": "Int",
+   "label": "Transit Minutes"
+  },
+  {
+   "description": "Waiting time at this stop before departing for the next one.",
+   "fieldname": "buffer_minutes",
+   "fieldtype": "Int",
+   "label": "Buffer Minutes"
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-08-17 16:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Operations",
+ "name": "Route Plan Assignment",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "creation",
+ "sort_order": "ASC",
+ "states": [],
+ "track_changes": 0
 }

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -606,3 +606,4 @@ one_fm.patches.v15_0.backfill_employee_resignation_auto_assign #2026-08-19
 one_fm.patches.v15_0.disable_roster_double_shift_ot_checker_assignment_rules #2026-08-21 WI-001689 reverted
 one_fm.patches.v15_0.grant_transportation_manager_schedule_access #2026-08-24 WI-002162
 one_fm.patches.v15_0.mark_unflagged_mixed_trips #2026-08-25 WI-002160
+one_fm.patches.v15_0.add_transportation_qoa_buffer_to_hr_settings #2026-08-26 WI-002151

--- a/one_fm/patches/v15_0/add_transportation_qoa_buffer_to_hr_settings.py
+++ b/one_fm/patches/v15_0/add_transportation_qoa_buffer_to_hr_settings.py
@@ -1,0 +1,73 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
+	QOA_BUFFER_FIELD,
+)
+
+# The figure the process owner's sample itinerary uses on every camp pickup.
+DEFAULT_QOA_BUFFER_MINUTES = 15
+
+
+def execute():
+	"""Add the driver QOA report-time buffer to HR Settings (WI-002151 AC 1.2).
+
+	A driver reports to the accommodation camp some minutes before the bus is due to
+	leave it, and the trip modal, the block detail drawer and the printed manifest all
+	have to show that report time. The number is an HR policy rather than a per-trip
+	decision, so it lives on HR Settings and is read from there in one place.
+
+	It defaults to 15 minutes, which is the figure the process owner's own sample
+	itinerary uses on every camp pickup: a 09:00 departure reports at 08:45, an 08:20 one
+	at 08:05. HR can change it once and every trip picks the new number up.
+
+	Named ``custom_transportation_qoa_buffer_minutes`` rather than ``qoa_*``: QOA already
+	means the pass/fail attendance check the manifest records against each rider
+	(``qoa_status`` / ``qoa_reason``), and the two must not be mistaken for each other in
+	a field list.
+	"""
+	_create_field()
+	_seed_value()
+
+
+def _seed_value():
+	"""Write the buffer once, so QOA works without anyone opening HR Settings.
+
+	A field default only applies to a document being created, and HR Settings is a Single
+	that already exists - so the default alone leaves the stored value empty and every QOA
+	time reads as the departure time. Only ever written when nothing is stored: a figure
+	somebody has deliberately set, 0 included, is theirs to keep.
+	"""
+	stored = frappe.db.sql(
+		"select value from tabSingles where doctype = 'HR Settings' and field = %s",
+		QOA_BUFFER_FIELD,
+	)
+	if not stored:
+		frappe.db.set_single_value("HR Settings", QOA_BUFFER_FIELD, DEFAULT_QOA_BUFFER_MINUTES)
+
+
+def _create_field():
+	create_custom_fields({
+		"HR Settings": [
+			{
+				"fieldname": "transportation_settings_section",
+				"fieldtype": "Section Break",
+				"label": "Transportation",
+				"insert_after": "default_absence_investigation_hr_officer",
+			},
+			{
+				"fieldname": "custom_transportation_qoa_buffer_minutes",
+				"fieldtype": "Int",
+				"label": "Driver QOA Buffer (Minutes)",
+				"insert_after": "transportation_settings_section",
+				"default": "15",
+				"non_negative": 1,
+				"description": (
+					"How many minutes before a bus leaves an accommodation camp the driver "
+					"must report. Shown on the trip modal, the block details and the "
+					"manifest as QOA Time = Departure Time - this buffer. Left at 0, QOA "
+					"Time simply equals the departure time."
+				),
+			},
+		]
+	})

--- a/one_fm/tests/test_forward_departure_scheduling.py
+++ b/one_fm/tests/test_forward_departure_scheduling.py
@@ -1,0 +1,405 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002151: a run is timed forward from a stated departure, not backwards from a shift.
+
+The trip modal used to place the first stop by backing into the shift time the card is
+scheduled on. The dispatcher now states when the vehicle leaves and every arrival is
+calculated forward from it, with the driver's QOA report time derived from the same
+departure and a `(+1 Day)` badge wherever a leg crosses midnight.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
+	QOA_BUFFER_FIELD,
+	_departure_seconds,
+	_ends_at_base_camp,
+	day_offset,
+	get_merge_preview,
+	qoa_buffer_minutes,
+	walk_legs,
+)
+from one_fm.one_fm.page.transportation_schedule.transportation_schedule import (
+	_stamp_leg_details,
+)
+from one_fm.patches.v15_0.add_transportation_qoa_buffer_to_hr_settings import (
+	execute as add_qoa_buffer_field,
+)
+
+HOUR = 3600
+
+
+class TestTheRunWalksForward(FrappeTestCase):
+	"""AC 1.1: arrival = departure + buffer + transit, cascading down the run."""
+
+	LEGS = [(30, 10), (20, 5), (15, 0)]  # (transit, buffer) per stop
+
+	def test_a_stated_departure_drives_the_first_stop(self):
+		walked = walk_legs(self.LEGS, anchor=12 * HOUR, departure=6 * HOUR)
+
+		# Leaves at 06:00, arrives 10 buffer + 30 transit later.
+		self.assertEqual(walked[0], (6 * HOUR, 6 * HOUR + 40 * 60))
+
+	def test_every_later_stop_is_driven_from_the_one_before(self):
+		walked = walk_legs(self.LEGS, anchor=12 * HOUR, departure=6 * HOUR)
+
+		# A leg departs when the bus is released from the stop before it, and its buffer
+		# is dwell inside the leg - so Arrival = Departure + Buffer + Transit reads
+		# literally, which is how the process owner's sample itinerary is walked.
+		first_arrival = walked[0][1]
+		self.assertEqual(walked[1][0], first_arrival)
+		self.assertEqual(walked[1][1], walked[1][0] + (5 + 20) * 60)
+
+	def test_editing_a_leg_high_up_moves_everything_after_it(self):
+		slower = [(30, 10), (60, 5), (15, 0)]
+
+		base = walk_legs(self.LEGS, anchor=12 * HOUR, departure=6 * HOUR)
+		moved = walk_legs(slower, anchor=12 * HOUR, departure=6 * HOUR)
+
+		self.assertEqual(moved[0], base[0])                             # untouched
+		self.assertEqual(moved[2][1] - base[2][1], 40 * 60)             # +40 min downstream
+
+	def test_without_a_departure_it_still_backs_into_the_shift_time(self):
+		# Every caller that has no departure to give keeps the old reading, which is what
+		# lets a run that nobody has re-timed sit exactly where it always did.
+		walked = walk_legs(self.LEGS, anchor=12 * HOUR)
+
+		self.assertEqual(walked[0][1], 12 * HOUR)
+		self.assertEqual(walked[0][0], 12 * HOUR - 40 * 60)
+
+
+class TestMidnightRollover(FrappeTestCase):
+	"""AC 1.6: a leg that crosses midnight says which day it lands on."""
+
+	def test_a_run_inside_one_day_has_no_offset(self):
+		self.assertEqual(day_offset(23 * HOUR), 0)
+
+	def test_a_leg_past_midnight_rolls_the_day(self):
+		self.assertEqual(day_offset(24 * HOUR + 30 * 60), 1)
+
+	def test_the_walk_carries_past_midnight_rather_than_wrapping(self):
+		walked = walk_legs([(0, 0), (90, 0)], anchor=0, departure=23 * HOUR)
+
+		self.assertGreater(walked[1][1], 24 * HOUR)
+		self.assertEqual(day_offset(walked[1][1]), 1)
+
+	def test_a_missing_stamp_has_no_offset(self):
+		self.assertEqual(day_offset(None), 0)
+
+
+class TestTheStatedDepartureIsRead(FrappeTestCase):
+	"""The modal sends a clock string; a Time column hands back a timedelta."""
+
+	def test_a_clock_string_is_read(self):
+		self.assertEqual(_departure_seconds("05:30"), 5 * HOUR + 30 * 60)
+		self.assertEqual(_departure_seconds("05:30:45"), 5 * HOUR + 30 * 60 + 45)
+
+	def test_a_blank_means_nothing_was_stated(self):
+		self.assertIsNone(_departure_seconds(""))
+		self.assertIsNone(_departure_seconds(None))
+
+	def test_rubbish_is_not_mistaken_for_midnight(self):
+		# Falling back to 0 would silently move a run to midnight.
+		self.assertIsNone(_departure_seconds("not a time"))
+
+
+class TestTheQoaBuffer(FrappeTestCase):
+	"""AC 1.2: the driver's report-time buffer, read from HR Settings in one place."""
+
+	def test_it_reads_what_hr_configured(self):
+		add_qoa_buffer_field()
+		frappe.db.set_single_value("HR Settings", QOA_BUFFER_FIELD, 45)
+
+		self.assertEqual(qoa_buffer_minutes(), 45)
+
+	def test_unset_means_no_buffer_rather_than_a_guess(self):
+		add_qoa_buffer_field()
+		frappe.db.set_single_value("HR Settings", QOA_BUFFER_FIELD, 0)
+
+		# QOA Time then equals the departure time, which changes nothing on any trip.
+		self.assertEqual(qoa_buffer_minutes(), 0)
+
+	def test_it_is_named_apart_from_the_manifest_qoa(self):
+		# `qoa_status` / `qoa_reason` on the manifest are a pass/fail attendance check and
+		# have nothing to do with a report time. The two must not collide in a field list.
+		self.assertTrue(QOA_BUFFER_FIELD.startswith("custom_transportation_"))
+
+
+class TestTheRunEndsAtTheCamp(FrappeTestCase):
+	"""AC 1.5: a mixed run has to finish by taking its return riders home."""
+
+	def _card(self, direction):
+		return frappe._dict({
+			"name": frappe.generate_hash("TS", 6),
+			"trip_direction": direction,
+			"pre_merge_trip_direction": None,
+		})
+
+	def test_a_mixed_run_ending_on_a_return_leg_is_accepted(self):
+		self.assertTrue(_ends_at_base_camp([self._card("Outward"), self._card("Return")]))
+
+	def test_a_mixed_run_ending_on_an_outward_leg_is_refused(self):
+		# It would leave the return riders at a site with the bus driving away.
+		self.assertFalse(_ends_at_base_camp([self._card("Return"), self._card("Outward")]))
+
+	def test_a_plain_outbound_run_is_left_alone(self):
+		# A drop-off run legitimately finishes at a site; holding it to this would refuse
+		# every multi-stop outbound run on the board.
+		self.assertTrue(_ends_at_base_camp([self._card("Outward"), self._card("Outward")]))
+
+	def test_a_plain_return_run_is_left_alone(self):
+		self.assertTrue(_ends_at_base_camp([self._card("Return"), self._card("Return")]))
+
+
+class TestThePreviewTheModalDraws(FrappeTestCase):
+	"""End to end on real shipment records: what the trip modal is handed."""
+
+	def setUp(self):
+		add_qoa_buffer_field()
+		frappe.db.set_single_value("HR Settings", QOA_BUFFER_FIELD, 45)
+		self.outward = self._shipment("Outward", "08:00:00", "20:00:00")
+		self.back = self._shipment("Return", "20:00:00", "08:00:00")
+
+	def _shipment(self, direction, start, end):
+		doc = frappe.new_doc("Transportation Shipment")
+		doc.status = "Unassigned"
+		doc.trip_direction = direction
+		doc.start_time = start
+		doc.end_time = end
+		doc.headcount = 2
+		doc.stop_location = "Site Stop"
+		doc.accommodation = frappe.get_all("Accommodation", limit=1, pluck="name")[0]
+		doc.generation_key = frappe.generate_hash("TS-FWD", 10)
+		doc.flags.ignore_links = True
+		doc.flags.ignore_mandatory = True
+		doc.insert(ignore_permissions=True)
+		return doc.name
+
+	def _preview(self, **kwargs):
+		return get_merge_preview([self.outward, self.back], **kwargs)
+
+	def test_it_seeds_the_departure_the_run_would_have_left_on(self):
+		# Nothing moves until the dispatcher says otherwise.
+		preview = self._preview()
+
+		self.assertEqual(preview["departure"], preview["default_departure"])
+
+	def test_a_stated_departure_moves_the_whole_run(self):
+		stated = self._preview(departure="05:30")
+
+		self.assertEqual(stated["departure"], "05:30")
+		self.assertEqual(stated["stops"][0]["departs"], "05:30")
+
+	def test_qoa_is_shown_only_on_the_leg_that_leaves_the_camp(self):
+		stops = self._preview(departure="05:30")["stops"]
+
+		# 05:30 less the 45 minute buffer HR configured.
+		self.assertEqual(stops[0]["qoa_time"], "04:45")
+		self.assertIsNone(stops[1]["qoa_time"])
+
+	def test_the_time_the_modal_seeds_its_field_with_carries_seconds(self):
+		# A Frappe Time control refuses "09:00" outright.
+		self.assertEqual(self._preview(departure="05:30")["departure_input"], "05:30:00")
+
+	def test_a_second_leg_out_of_the_same_camp_does_not_report_again(self):
+		# Riders from two cards at one camp board together once, so only the first leg
+		# actually departs it. The saved assignment row is stamped by the same rule.
+		second = self._shipment("Outward", "09:00:00", "21:00:00")
+		stops = get_merge_preview([self.outward, second])["stops"]
+
+		self.assertTrue(stops[0]["is_accommodation_origin"])
+		self.assertFalse(stops[1]["is_accommodation_origin"])
+		self.assertIsNone(stops[1]["qoa_time"])
+
+	def test_each_leg_names_where_it_comes_from_and_goes_to(self):
+		stops = self._preview()["stops"]
+
+		# An outward leg loads at its camp; a return leg loads at the site it collects
+		# from. "Next stop" is the following leg's origin, not this card's own site -
+		# a run that collects from three camps before dropping anyone needs the two to
+		# be different columns.
+		self.assertEqual(stops[1]["origin_location"], stops[1]["stop_location"])
+		self.assertEqual(stops[0]["next_stop_location"], stops[1]["origin_location"])
+		self.assertEqual(stops[0]["shift_location"], stops[0]["stop_location"])
+
+	def test_the_modal_is_told_the_run_ends_at_the_camp(self):
+		preview = self._preview()
+
+		self.assertTrue(preview["ends_at_base_camp"])
+		self.assertEqual(preview["route_message"], "")
+
+	def test_the_shift_the_canvas_applies_is_a_duration_not_an_instant(self):
+		# The blocks are moved by the difference between the two, so the browser never
+		# has to rebuild a moment in time from a clock string - and an untouched run
+		# yields a shift of exactly zero, so nothing on the board moves.
+		untouched = self._preview()
+		self.assertEqual(
+			untouched["departure_seconds"] - untouched["default_departure_seconds"], 0
+		)
+
+		stated = self._preview(departure="05:30")
+		self.assertEqual(stated["departure_seconds"], 5 * HOUR + 30 * 60)
+		self.assertEqual(
+			stated["departure_seconds"] - stated["default_departure_seconds"],
+			5 * HOUR + 30 * 60 - untouched["departure_seconds"],
+		)
+
+
+class TestTheProcessOwnersSampleItinerary(FrappeTestCase):
+	"""The two runs in Transport.xlsx, walked leg by leg.
+
+	The sheet is the process owner's statement of how the cascade should read, so it is
+	replayed here rather than paraphrased: if the walk ever drifts from it, these fail.
+	"""
+
+	def _clock(self, seconds):
+		seconds = int(seconds) % 86400
+		return f"{seconds // 3600:02d}:{(seconds % 3600) // 60:02d}"
+
+	def _walk(self, departure, legs):
+		hh, mm = departure.split(":")
+		walked = walk_legs(legs, anchor=0, departure=int(hh) * HOUR + int(mm) * 60)
+		return [(self._clock(d), self._clock(a)) for d, a in walked]
+
+	def test_scenario_one_camp_to_site_and_back(self):
+		# 09:00 out with 10 buffer + 50 transit, arriving 10:00 for a 10:00 shift start,
+		# then the same again back to the camp for 11:00.
+		self.assertEqual(
+			self._walk("09:00", [(50, 10), (50, 10)]),
+			[("09:00", "10:00"), ("10:00", "11:00")],
+		)
+
+	def test_scenario_two_three_camps_two_sites_and_a_collection(self):
+		walked = self._walk("08:00", [(15, 5), (10, 5), (5, 1), (4, 0), (5, 5), (8, 2)])
+
+		self.assertEqual(walked, [
+			("08:00", "08:20"),   # Accommodation 1 -> Accommodation 2
+			("08:20", "08:35"),   # Accommodation 2 -> Accommodation 3
+			("08:35", "08:41"),   # Accommodation 3 -> Grand Hayat
+			("08:41", "08:45"),   # Grand Hayat     -> 360 Car Park
+			("08:45", "08:55"),   # 360 Car Park    -> Khaldiya
+			("08:55", "09:05"),   # Khaldiya        -> Accommodation 1
+		])
+
+	def test_every_departure_is_the_previous_arrival(self):
+		walked = self._walk("08:00", [(15, 5), (10, 5), (5, 1), (4, 0), (5, 5), (8, 2)])
+
+		for previous, current in zip(walked, walked[1:]):
+			self.assertEqual(current[0], previous[1])
+
+	def test_the_report_time_the_sample_uses_is_a_quarter_hour(self):
+		# 09:00 departure reports 08:45; 08:20 reports 08:05; 08:35 reports 08:20.
+		add_qoa_buffer_field()
+
+		self.assertEqual(
+			frappe.db.get_default(QOA_BUFFER_FIELD)
+			or frappe.get_meta("HR Settings").get_field(QOA_BUFFER_FIELD).default,
+			"15",
+		)
+
+
+class TestEachLegRecordsItsOwnFacts(FrappeTestCase):
+	"""The BA's Route Plan Assignment fields, written on save.
+
+	A row that carries only a timestamp cannot answer what the trip modal showed - where
+	the leg started, the driver's report time, how full the bus was leaving that stop,
+	whether it rolled past midnight - and the manifest and every later reader need those.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.reload_doc("one_fm", "doctype", "route_plan_assignment")
+
+	def setUp(self):
+		locations = frappe.get_all("Location", limit=1, pluck="name")
+		if not locations:
+			self.skipTest("no Location on this site to hang a stop on")
+		self.site = locations[0]
+		camps = frappe.get_all("Accommodation", limit=1, pluck="name")
+		if not camps:
+			self.skipTest("no Accommodation on this site for the run to depart")
+		self.camp = camps[0]
+		add_qoa_buffer_field()
+		frappe.db.set_single_value("HR Settings", QOA_BUFFER_FIELD, 15)
+		self.drop = self._shipment("Outward", "08:00:00")
+		self.collect = self._shipment("Return", "20:00:00")
+
+	def _shipment(self, direction, start):
+		doc = frappe.new_doc("Transportation Shipment")
+		doc.status = "Unassigned"
+		doc.trip_direction = direction
+		doc.start_time = start
+		doc.end_time = "20:00:00" if direction == "Outward" else "08:00:00"
+		doc.headcount = 4
+		doc.stop_location = self.site
+		doc.accommodation = self.camp
+		doc.generation_key = frappe.generate_hash("TS-LEG", 10)
+		doc.flags.ignore_mandatory = True
+		doc.insert(ignore_permissions=True)
+		return doc.name
+
+	def _plan(self):
+		"""A handover: 4 dropped and 4 collected at the same site, on one vehicle."""
+		vehicle = frappe.get_all("Vehicle", filters={"transport_stop_vehicle": 1},
+								 limit=1, pluck="name")
+		if not vehicle:
+			self.skipTest("no transport vehicle on this site")
+		doc = frappe.new_doc("Route Plan")
+		doc.title = frappe.generate_hash("RP-LEG", 8)
+		for index, shipment in enumerate((self.drop, self.collect), start=1):
+			doc.append("assignments", {
+				"card_id": f"TSHIP-{shipment}",
+				"transportation_shipment": shipment,
+				"vehicle": vehicle[0],
+				"direction": "OUTBOUND" if index == 1 else "RETURN",
+				"trip_group": "RUN-1",
+				"stop_index": index,
+				"headcount": 4,
+				"stop_location": self.site,
+				"start_time": "2026-08-18T05:00:00.000Z",
+				"end_time": "2026-08-18T06:00:00.000Z",
+			})
+		_stamp_leg_details(doc)
+		return doc.assignments
+
+	def test_a_stop_that_sheds_and_takes_on_is_combined(self):
+		# Both movements happen at one place, which is what a handover is.
+		self.assertEqual({row.action_type for row in self._plan()}, {"Combined"})
+
+	def test_the_counts_are_split_by_which_way_the_riders_go(self):
+		dropped, collected = self._plan()
+
+		self.assertEqual((dropped.drop_off_count, dropped.boarding_count), (4, 0))
+		self.assertEqual((collected.drop_off_count, collected.boarding_count), (0, 4))
+
+	def test_occupancy_is_walked_disembark_first(self):
+		# 4 off before 4 on, so the bus never holds 8 - the same walk the seat check uses.
+		dropped, collected = self._plan()
+
+		self.assertEqual(dropped.current_passenger_count, 0)
+		self.assertEqual(collected.current_passenger_count, 4)
+
+	def test_only_the_leg_that_leaves_the_camp_reports(self):
+		dropped, collected = self._plan()
+
+		self.assertTrue(dropped.is_accommodation_origin)
+		self.assertFalse(collected.is_accommodation_origin)
+		self.assertIsNone(collected.qoa_time)
+
+	def test_the_report_time_is_the_departure_less_the_hr_buffer(self):
+		dropped, _collected = self._plan()
+
+		# 05:00Z is 08:00 in Kuwait; 15 minutes before that is 07:45.
+		self.assertEqual(str(dropped.qoa_time), "07:45:00")
+
+	def test_the_seat_count_is_recorded_against_the_leg(self):
+		dropped, _collected = self._plan()
+
+		self.assertGreater(dropped.max_passenger_capacity, 0)
+
+	def test_the_shift_it_serves_is_recorded(self):
+		dropped, _collected = self._plan()
+
+		self.assertEqual(str(dropped.shift_start_time), "8:00:00")

--- a/one_fm/tests/test_merge_preview.py
+++ b/one_fm/tests/test_merge_preview.py
@@ -153,8 +153,12 @@ class TestTheMergeModal(FrappeTestCase):
 	def test_the_modal_shows_the_vehicle_capacity(self):
 		self.assertIn("Max Passenger Capacity", self.source)
 
-	def test_the_primary_action_is_confirm_and_merge(self):
-		self.assertIn("__('Confirm & Merge Trip')", self.source)
+	def test_the_primary_action_commits_the_merge(self):
+		# Renamed with the forward-scheduling work (WI-002151): the modal now states the
+		# departure and applies the whole itinerary, not just the merge. What has to hold
+		# is that its primary action is the thing that commits it.
+		self.assertIn("__('Confirm & Apply')", self.source)
+		self.assertIn("merge_trip_shipments", self.source)
 
 	def test_each_visit_is_its_own_container(self):
 		self.assertIn("Seq ${s.stop_index}", self.source)
@@ -162,7 +166,10 @@ class TestTheMergeModal(FrappeTestCase):
 		self.assertIn("DROPPING OFF EMPLOYEES", self.source)
 
 	def test_there_is_a_per_leg_transit_and_buffer_table(self):
-		self.assertIn("Per-Leg Transit &amp; Buffer Times", self.source)
+		# The table gained the rest of the leg picture in WI-002151 - card, direction,
+		# origin, next stop and the forward-calculated arrival - but the two editable
+		# minute fields are what re-time the run and they still have to be there.
+		self.assertIn("Legs — arrival is calculated forward from the departure above", self.source)
 		self.assertIn('data-key="transit_minutes"', self.source)
 		self.assertIn('data-key="buffer_minutes"', self.source)
 
@@ -459,9 +466,14 @@ class TestTheRunIsTimedFromTheMinutes(FrappeTestCase):
 		]
 
 	def test_the_feedbacks_merge(self):
+		# A leg now departs when the bus is released from the stop before it, with its
+		# buffer counted as dwell inside the leg (WI-002151). The arrivals are the same
+		# numbers as before; only the departure column moved, so that AC 1.1's
+		# Arrival = Departure + Buffer + Transit reads literally - which is how the
+		# process owner's sample itinerary is walked.
 		self.assertEqual(
 			self._walk([(60, 10), (15, 5)]),
-			[("12:50", "14:00"), ("14:05", "14:20")],
+			[("12:50", "14:00"), ("14:00", "14:20")],
 		)
 
 	def test_the_placement_that_preceded_it(self):
@@ -486,8 +498,67 @@ class TestTheRunIsTimedFromTheMinutes(FrappeTestCase):
 	def test_a_later_stops_dwell_pushes_the_stops_after_it(self):
 		self.assertEqual(
 			self._walk([(60, 10), (15, 30), (20, 5)])[2],
-			("14:50", "15:10"),   # stop 2's 30min dwell pushed this leg back half an hour
+			("14:45", "15:10"),   # stop 2's 30min dwell pushed this leg back half an hour
 		)
+
+	def test_a_dwell_lengthens_its_own_leg_rather_than_delaying_its_departure(self):
+		# The same total either way - what changed is which column the buffer shows in.
+		lazy = self._walk([(60, 10), (15, 30)])
+
+		self.assertEqual(lazy[1][0], lazy[0][1])            # departs when stop 1 is done
+		self.assertEqual(lazy[1], ("14:00", "14:45"))       # 30 dwell + 15 drive
 
 	def test_an_empty_run_walks_to_nothing(self):
 		self.assertEqual(self._walk([]), [])
+
+
+class TestATripIsJoinedWhole(FrappeTestCase):
+	"""Proximity chooses WHICH run to join, never how much of it takes part.
+
+	A trip whose stops spread wider than the two-hour proximity window used to arrive at
+	the merge half-present: the modal drew half an itinerary, the seat walk counted half
+	the riders - S-803 read as 3 stops peaking at 6 against a run of 9 peaking at 11 -
+	and the merge marked only those stops Mixed, leaving the rest on their old heading.
+	"""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_the_grouped_trip_is_expanded_to_all_of_its_stops(self):
+		self.assertIn("tripMap[key] = this.swimItems.filter(", self.source)
+		self.assertIn("i.vehicleId === vehicle.id && i.tripId === key", self.source)
+
+	def test_a_standalone_block_is_left_as_itself(self):
+		# Items with no tripId are each their own trip and must not be swept together.
+		self.assertIn("if (key.startsWith('_solo_')) return;", self.source)
+
+	def test_the_expansion_happens_before_the_operator_is_asked(self):
+		# The picker and the confirm both read tripMap, so it has to be whole by then.
+		self.assertLess(
+			self.source.index("tripMap[key] = this.swimItems.filter("),
+			self.source.index("const tripKeys = Object.keys(tripMap);"),
+		)
+
+
+class TestTheModalOpensOnTheRunAsItStands(FrappeTestCase):
+	"""What the operator is shown before they agree to anything.
+
+	The confirm named only the stops proximity had picked out while the merge took the
+	whole trip - so a three-stop run was described as two. And a leg that carries no
+	recorded minutes still has a length on the lane: sending nothing for it collapsed it,
+	and S-302's 07:00-09:00 run opened as 08:00-09:00 with its first hour gone.
+	"""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_the_confirm_names_every_stop_the_merge_will_take(self):
+		self.assertIn("const existingStops = tripMap[tripKeys[0]].map(", self.source)
+		self.assertNotIn("const existingStops = nearbyBlocks.map(", self.source)
+
+	def test_a_leg_with_no_recorded_minutes_sends_the_length_it_is_drawn_with(self):
+		self.assertIn("transit_minutes: span, buffer_minutes: 0", self.source)
+
+	def test_a_leg_that_has_minutes_still_sends_those(self):
+		# Real minutes always win; the span is only the fallback for an untimed leg.
+		self.assertIn("if (item.transitMinutes || item.bufferMinutes) {", self.source)


### PR DESCRIPTION
Port of #6805 onto `version-15`. Merge **first** of four.

A dispatcher states when the bus leaves and the itinerary is calculated forward from it — `Arrival = Departure + Buffer + Transit` — instead of being worked backwards from the shift start. The Trip Builder shows the run as it stands before asking to change it, each leg's own facts are recorded on its assignment row, and the driver's QOA report time comes from an HR Settings buffer rather than a number typed per trip.

## Merge order

This is a stack. Each branch contains the one before it, so merging out of order makes the earlier PRs look empty:

1. **this PR**
2. #6806 → `WI-002171-mixed-trip-handover-v15`
3. #6807 → `WI-002170-overcapacity-split-v15`
4. #6811 → `WI-002151-physical-stop-model-v15`

## Porting notes

Applied as the squashed diff of the staging branch, three-way merged onto `version-15`. One conflict, in `patches.txt`: `version-15`'s own line kept and this PR's `add_transportation_qoa_buffer_to_hr_settings` added. The PAM patch that sits beside it on staging belongs to WI-002233 and is not brought over — its file is not on this branch.

`version-15`'s shorter comment wording in the transportation files is left as it is; the port carries the code, not the prose.

## After merge

`bench migrate` — adds the HR Settings QOA buffer field and seeds it at 15 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)