### PR TITLE
Time a multi-camp run, read the manifest as one journey, and hold the confirm

### DIFF
--- a/one_fm/one_fm/doctype/transportation_shipment/transportation_shipment.py
+++ b/one_fm/one_fm/doctype/transportation_shipment/transportation_shipment.py
@@ -729,26 +729,21 @@ def get_merge_preview(shipments, vehicle: str = None, timings=None, departure=No
 	exceeded = bool(limit) and peak > limit
 	alignment = _shift_alignment(docs)
 
-	# AC 3.6: a collection the bus has to be driven to cannot be left untimed. The drive
-	# INTO a stop is the previous stop's leg - minutes belong to the leg out of a row -
-	# so that is the row the operator has to fill in.
-	untimed = []
-	for position, stop in enumerate(stops):
-		if position == 0 or stop["kind"] != SITE_STOP or not stop["boarding_cards"]:
-			continue
-		into = stops[position - 1]
-		# Only the handover drive the AC describes: dropped at Site A, collecting at
-		# Site B. Arriving from the camp is the ordinary outbound leg, and a collection
-		# at the place the bus is already standing is no drive at all - a stop where
-		# riders both get off and get on is one stop, not two.
-		if into["kind"] != SITE_STOP or into["place"] == stop["place"]:
-			continue
-		if not (into["transit_minutes"] or into["buffer_minutes"]):
-			untimed.append(stop)
+	# Every drive the bus makes has to be timed. Minutes belong to the leg OUT of a
+	# stop, so a stop whose next stop is somewhere else needs a transit time - without
+	# one the run says the bus is in two places at the same minute, and the manifest
+	# prints it that way. Two rows at one place is not a drive: the bus is already
+	# standing there, which is what a handover and a second card at one site are.
+	# AC 3.6's collection drive is the case this was first written for, and is covered.
+	untimed = [
+		(stop, stops[position + 1])
+		for position, stop in enumerate(stops[:-1])
+		if stops[position + 1]["place"] != stop["place"] and not stop["transit_minutes"]
+	]
 	handover_message = "" if not untimed else _(
-		"Leg {0} collects at {1}. Enter the buffer and transit minutes for the drive to "
-		"it before the pickup can be scheduled."
-	).format(untimed[0]["stop_index"], untimed[0]["place"])
+		"Leg {0} leaves {1} for {2} with no transit time. Every drive needs its minutes "
+		"before the trip can be confirmed."
+	).format(untimed[0][0]["stop_index"], untimed[0][0]["place"], untimed[0][1]["place"])
 
 	# AC 1.5, literally now that a run is its stops: the last one is the base camp.
 	ends_home = bool(itinerary) and itinerary[-1]["kind"] == HOME_STOP

--- a/one_fm/one_fm/page/transportation_manifest_page/test_transportation_manifest_page.py
+++ b/one_fm/one_fm/page/transportation_manifest_page/test_transportation_manifest_page.py
@@ -133,7 +133,9 @@ class TestTheManifestPrintsTheDriversReportTime(FrappeTestCase):
 	def test_both_itineraries_pass_it_in(self):
 		# A merged run and an ordinary one render through different functions.
 		self.assertIn("o.vehicleLabel, true, o.qoaTime", self.page)
-		self.assertIn("false, legs.qoa_time", self.page)
+		# The camp-by-camp path takes each camp's own report time, and only the first
+		# camp falls back to the run's.
+		self.assertIn("leg.qoa_time || (index === 0 ? legs.qoa_time : null)", self.page)
 
 	def test_a_run_without_one_prints_nothing(self):
 		# AC 1.2: QOA is hidden where it does not apply, not shown empty.
@@ -167,3 +169,43 @@ class TestTheManifestMarksADayRollover(FrappeTestCase):
 	def test_it_is_measured_from_when_the_run_left(self):
 		self.assertIn("runStartISO: firstTimeISO", self.page)
 		self.assertIn("runStartISO: o.firstTimeISO", self.page)
+
+
+class TestTheManifestReadsAsOneJourney(FrappeTestCase):
+	"""Top to bottom, in the order the bus drives it.
+
+	Grouped by camp, a run loading at two camps read as two blocks whose times
+	interleaved - Mahboula's 08:37 drop printed above Farwaniya's 08:15 departure. No
+	driver can follow that, and it is the same run either way.
+	"""
+
+	def setUp(self):
+		self.page = frappe.read_file(frappe.get_app_path(
+			"one_fm", "one_fm", "page", "transportation_manifest_page",
+			"transportation_manifest_page.js"
+		))
+		self.server = frappe.read_file(frappe.get_app_path(
+			"one_fm", "one_fm", "page", "transportation_schedule",
+			"transportation_schedule.py"
+		))
+
+	def test_the_plan_sends_the_camps_in_the_order_they_are_loaded(self):
+		self.assertIn('held.setdefault("camps_ordered", []).append({', self.server)
+		self.assertIn('camp["stop_index"]', self.server)
+
+	def test_each_camp_departs_at_its_own_time(self):
+		self.assertIn("const leg = campLegs[index] || {};", self.page)
+		self.assertIn("html += renderDepartCard(departAt, cg,", self.page)
+
+	def test_each_camp_reports_its_own_driver_time(self):
+		self.assertIn("leg.qoa_time || (index === 0 ? legs.qoa_time : null)", self.page)
+
+	def test_the_stops_follow_in_the_order_the_bus_reaches_them(self):
+		self.assertIn("new Date(a.stop.time) - new Date(b.stop.time)", self.page)
+
+	def test_the_camp_by_camp_nesting_is_gone(self):
+		# It listed a camp's drops under it, so the two blocks' clocks interleaved.
+		self.assertNotIn("dropByCamp", self.page)
+
+	def test_the_drive_home_runs_from_the_last_stop_reached(self):
+		self.assertIn("renderTransit(calcTransit(prevTime, lastTimeISO))", self.page)

--- a/one_fm/one_fm/page/transportation_manifest_page/transportation_manifest_page.js
+++ b/one_fm/one_fm/page/transportation_manifest_page/transportation_manifest_page.js
@@ -740,24 +740,19 @@ function renderManifest($container, data) {
 			// banner is followed by the drop-off stop(s) its passengers ride to,
 			// then the next camp block. Camps run in strict stop-sequence order.
 			const boardingByCamp = {};   // seq -> { seq, label, employees, names }
-			const dropByCamp = {};       // seq -> [ orderedStops item ]
 			orderedStops.forEach(item => {
 				if (item.stop.type !== "dropoff") return;
-				let campSeq = 1;
 				(shipmentEmployees[item.stop.raw] ?? []).forEach(e => {
 					const eName = (typeof e === "object" && e !== null) ? (e.name || "") : (e || "");
 					if (!eName) return;
 					const seq = (e && e.stop_sequence) ? e.stop_sequence : 1;
 					const label = (e && e.pickup_camp_label) ? e.pickup_camp_label : accommodation;
-					campSeq = seq;
 					if (!boardingByCamp[seq]) boardingByCamp[seq] = { seq: seq, label: label, employees: [], names: new Set() };
 					if (!boardingByCamp[seq].names.has(eName)) {
 						boardingByCamp[seq].names.add(eName);
 						boardingByCamp[seq].employees.push(e);
 					}
 				});
-				if (!dropByCamp[campSeq]) dropByCamp[campSeq] = [];
-				dropByCamp[campSeq].push(item);
 			});
 
 			const activeStop = meta.active_stop_sequence || 0;
@@ -777,28 +772,35 @@ function renderManifest($container, data) {
 				});
 			} else {
 
+			// The journey, top to bottom, in the order the bus drives it: it loads at
+			// each camp in turn and only then starts calling at sites. Grouped by camp
+			// instead, a run loading at two camps read as two separate blocks whose
+			// times interleaved - Mahboula's 08:37 drop was printed above Farwaniya's
+			// 08:15 departure - which is not a sequence any driver can follow.
 			const campGroups = Object.values(boardingByCamp).sort((a, b) => a.seq - b.seq);
+			const campLegs = legs.camps_ordered || [];
 
-			// Camp block: DEPART banner, then that camp's drop-off stop(s)
-			campGroups.forEach(cg => {
-				html += renderDepartCard(firstTimeISO, cg, activeStop, manifestName, pr.label,
-					false, legs.qoa_time);
-				let prevTime = firstTimeISO;
-				(dropByCamp[cg.seq] || []).forEach(item => {
+			let prevTime = firstTimeISO;
+			campGroups.forEach((cg, index) => {
+				// Matched by position: both lists are in the order the run needs them.
+				const leg = campLegs[index] || {};
+				const departAt = leg.departure
+					? new Date(leg.departure).toISOString() : firstTimeISO;
+				if (index > 0) html += renderTransit(calcTransit(prevTime, departAt));
+				html += renderDepartCard(departAt, cg, activeStop, manifestName, pr.label,
+					false, leg.qoa_time || (index === 0 ? legs.qoa_time : null));
+				prevTime = departAt;
+			});
+
+			// Then every stop the bus calls at, once, in the order it reaches them.
+			orderedStops
+				.slice()
+				.sort((a, b) => new Date(a.stop.time) - new Date(b.stop.time))
+				.forEach(item => {
 					html += renderTransit(calcTransit(prevTime, item.stop.time, item.stop));
 					html += renderSiteStopCard({ ...item, runStartISO: firstTimeISO });
 					prevTime = item.stop.time;
 				});
-			});
-
-			// Any non-drop-off stops (e.g. return pickups) keep chronological order
-			const otherStops = orderedStops.filter(item => item.stop.type !== "dropoff");
-			let prevOtherTime = firstTimeISO;
-			otherStops.forEach(item => {
-				html += renderTransit(calcTransit(prevOtherTime, item.stop.time, item.stop));
-				html += renderSiteStopCard({ ...item, runStartISO: firstTimeISO });
-				prevOtherTime = item.stop.time;
-			});
 
 			// Return employees
 			const returningEmployees = [];
@@ -817,10 +819,7 @@ function renderManifest($container, data) {
 			});
 
 			// Transit to return
-			const lastSiteStop = orderedStops[orderedStops.length - 1]?.stop;
-			if (lastSiteStop) {
-				html += renderTransit(calcTransit(lastSiteStop.time, lastTimeISO));
-			}
+			html += renderTransit(calcTransit(prevTime, lastTimeISO));
 
 			// RETURN card
 			html += renderReturnCard(lastTimeISO, homeCamp, returningEmployees, firstTimeISO);

--- a/one_fm/one_fm/page/transportation_schedule/test_transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/test_transportation_schedule.py
@@ -305,3 +305,28 @@ class TestWhenTheBusIsWhere(FrappeTestCase):
 		)
 
 		self.assertEqual(visit_times("08:27", "08:58", "OUTBOUND"), ("08:27", "08:27"))
+
+
+class TestEachCardBoardsAtItsOwnCamp(FrappeTestCase):
+	"""A run that loads at two camps has two departures, not one repeated.
+
+	Keyed by the run alone, both camps of 13/52665 printed 07:45 on the driver's page -
+	the bus reaches the second at 08:20.
+	"""
+
+	def setUp(self):
+		self.source = frappe.read_file(frappe.get_app_path(
+			"one_fm", "one_fm", "page", "transportation_schedule",
+			"transportation_schedule.py"
+		))
+
+	def test_the_departure_is_recorded_per_camp(self):
+		self.assertIn('camp_departure[(row.trip_group, place)] = row.start_time', self.source)
+
+	def test_a_card_boards_at_the_camp_it_belongs_to(self):
+		self.assertIn(
+			"camp_departure.get((row.trip_group, row.origin_location))", self.source
+		)
+
+	def test_a_camp_with_no_leg_recorded_falls_back_to_the_run(self):
+		self.assertIn("or camp_departure.get(row.trip_group),", self.source)

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -1427,6 +1427,11 @@ def get_manifest_data_for_plan(plan_name: str):
 		if cint(row.is_camp_leg) and row.vehicle:
 			leg_rows.setdefault(row.vehicle, []).append(row)
 			if not cint(row.is_home_leg) and row.trip_group and row.start_time:
+				# Per camp, not per run: a bus that loads at two camps leaves the second
+				# when it gets there. Keyed by the run alone, both camps printed the same
+				# departure on the driver's page.
+				place = row.origin_location or row.stop_location
+				camp_departure[(row.trip_group, place)] = row.start_time
 				held = camp_departure.get(row.trip_group)
 				camp_departure[row.trip_group] = min(held, row.start_time) if held else row.start_time
 	if not rows:
@@ -1814,8 +1819,12 @@ def get_manifest_data_for_plan(plan_name: str):
 
 			own_dir = _own_dir_by_shipment.get(row.transportation_shipment) \
 				or _normalize_direction(row.direction)
+			# The camp THIS card boards at, falling back to the run's own departure for a
+			# card whose camp has no leg recorded.
 			boards_at, alights_at = visit_times(
-				i_s, i_e, own_dir, camp_departure.get(row.trip_group)
+				i_s, i_e, own_dir,
+				camp_departure.get((row.trip_group, row.origin_location))
+				or camp_departure.get(row.trip_group),
 			)
 
 			visits.append({
@@ -1909,10 +1918,25 @@ def get_manifest_data_for_plan(plan_name: str):
 					if held.get("departure") and leg.start_time else \
 					(leg.start_time or held.get("departure"))
 				held.setdefault("camp", place)
+				# In the order the bus loads at them, each with its own departure and
+				# report time - the driver's page reads a run as one journey, and a run
+				# that loads at two camps leaves the second when it gets there.
+				held.setdefault("camps_ordered", []).append({
+					"place": place,
+					"stop_index": cint(leg.stop_index),
+					"departure": leg.start_time,
+					"arrival": leg.end_time,
+					"qoa_time": str(leg.qoa_time) if leg.qoa_time else None,
+					"transit_minutes": leg.transit_minutes or 0,
+					"buffer_minutes": leg.buffer_minutes or 0,
+				})
 				# The driver's report time, which AC 1.2 puts on an accommodation pickup
 				# wherever the leg is shown - the manifest included.
 				if leg.qoa_time and not held.get("qoa_time"):
 					held["qoa_time"] = str(leg.qoa_time)
+
+		for held in trip_legs.values():
+			held.get("camps_ordered", []).sort(key=lambda camp: camp["stop_index"])
 
 		routes.append({
 			"vehicleIndex": vi, "vehicleLabel": v_label,
@@ -2385,26 +2409,20 @@ def _stamp_leg_details(doc, leg_timings=None):
 			for card in stop["boarding"]:
 				serves[card.name] = (stop, per_stop[position])
 
-		# The first card out of each camp, and when the bus leaves that camp - which is
-		# the earliest leg belonging to a card boarding there, not this card's own.
-		camp_first, camp_departs = {}, {}
-		# When the dispatcher has stated a departure, that IS when the bus leaves the
-		# first camp. Reading it off the blocks gave the moment the bus reaches the first
-		# SITE instead, so the driver's report time came out one camp leg too late.
-		stated = _local_seconds((leg_timings or {}).get(group_key, {}).get("departure"))
+		# The first card out of each camp, and when the bus leaves each one. A run can
+		# load at more than one camp, and it leaves the second when it gets there - not
+		# when it left the first. Stamping the stated departure on every camp had two
+		# camps of one run both reporting at 07:45 on the driver's page, and gave the
+		# second camp a QOA measured off a site it reaches an hour later.
+		held = (leg_timings or {}).get(group_key, {})
+		camp_first, camp_departs = {}, _walk_camp_departures(
+			itinerary, ordered, _local_seconds(held.get("departure")), held.get("camps") or {}
+		)
 		for stop in itinerary:
 			if stop["kind"] != CAMP_STOP or stop["place"] in camp_first:
 				continue
 			boarding = [card.name for card in stop["boarding"]]
 			camp_first[stop["place"]] = boarding[0] if boarding else None
-			leaving = [
-				_local_seconds(row.start_time) for row in ordered
-				if row.transportation_shipment in boarding and _local_seconds(row.start_time) is not None
-			]
-			camp_departs[stop["place"]] = (
-				stated if (stated is not None and not camp_departs)
-				else (min(leaving) if leaving else None)
-			)
 
 		for row in ordered:
 			card = by_name[row.transportation_shipment]
@@ -2453,6 +2471,68 @@ def camp_leg_group(card_id) -> str:
 	return str(card_id or "").split("|")[1] if "|" in str(card_id or "") else ""
 
 
+def _walk_camp_departures(itinerary, ordered, departure, minutes) -> dict:
+	"""{camp place: when the bus leaves it}, chained through the camps in order.
+
+	The camps are the front of a run: the bus loads at each in turn and only then calls
+	at its first site. So the second camp's departure is the first one's plus the drive
+	between them, and the chain has to land on the first card's own start - which is
+	where the canvas already put it, from the same numbers.
+
+	Falls back to the first card's start for every camp when no departure was stated,
+	which is a run saved before the camp legs were recorded.
+	"""
+	from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import CAMP_STOP
+
+	camps, seen = [], set()
+	for stop in itinerary:
+		if stop["kind"] == CAMP_STOP and stop["place"] not in seen:
+			seen.add(stop["place"])
+			camps.append(stop["place"])
+	if not camps:
+		return {}
+
+	first_stop = next(
+		(_local_seconds(row.start_time) for row in ordered
+		 if _local_seconds(row.start_time) is not None), None
+	)
+	if departure is None:
+		return {place: first_stop for place in camps}
+
+	departs, cursor = {}, departure
+	for place in camps:
+		departs[place] = cursor
+		leg = (minutes.get(place) or {})
+		cursor += (cint(leg.get("transit_minutes")) + cint(leg.get("buffer_minutes"))) * 60
+
+	# The last camp hands over to the first site. If the minutes do not add up to it -
+	# a leg never timed - the chain still ends where the run really starts calling.
+	if first_stop is not None and camps:
+		last = camps[-1]
+		if departs[last] > first_stop:
+			departs[last] = first_stop
+	return departs
+
+
+def _time_stamp(ordered, seconds):
+	"""A local second-of-day put back onto the run's own date, stored as the rows are.
+
+	The rows carry UTC and everything a driver reads is local, so a time worked out in
+	local seconds has to travel back the same way `_local_seconds` brought it out.
+	"""
+	if seconds is None or not ordered:
+		return None
+	anchor = ordered[0].start_time
+	base = _local_seconds(anchor)
+	if base is None:
+		return None
+	from datetime import timedelta as _delta
+
+	text = str(anchor).replace("T", " ").replace("Z", "").split(".")[0]
+	moved = frappe.utils.get_datetime(text) + _delta(seconds=seconds - base)
+	return moved.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
 def _camp_leg_rows(itinerary, ordered, per_stop, vehicle, camp_departs,
 				   buffer_minutes, limits, group_key, minutes=None) -> list:
 	"""The rows for the stops no card is filed against: the camps the bus loads at.
@@ -2475,6 +2555,11 @@ def _camp_leg_rows(itinerary, ordered, per_stop, vehicle, camp_departs,
 	rows = []
 	seen = set()
 	first = ordered[0]
+	camp_order = [
+		stop["place"] for n, stop in enumerate(itinerary)
+		if stop["kind"] == CAMP_STOP
+		and stop["place"] not in {s["place"] for s in itinerary[:n] if s["kind"] == CAMP_STOP}
+	]
 	for position, stop in enumerate(itinerary):
 		homeward = stop["kind"] == HOME_STOP
 		if not homeward and (stop["kind"] != CAMP_STOP or stop["place"] in seen):
@@ -2487,13 +2572,21 @@ def _camp_leg_rows(itinerary, ordered, per_stop, vehicle, camp_departs,
 			((minutes or {}).get("home") or {}) if homeward
 			else ((minutes or {}).get("camps") or {}).get(stop["place"]) or {}
 		)
+		# Where this camp hands over: the next camp, or the first site if it is the last.
+		next_departure = next(
+			(camp_departs[place] for place in camp_order[camp_order.index(stop["place"]) + 1:]
+			 if place in camp_departs), None
+		) if not homeward and stop["place"] in camp_order else None
 		# The ride home is the last thing the bus does and nothing is dropped there, so
 		# without a row of its own the run simply stopped at its last site and the drawer
-		# had nothing to show for the drive back. The camp is the first.
+		# had nothing to show for the drive back. The camps are the front of it, each
+		# leaving when the bus gets there and handing over to the next stop.
 		window = (
 			(ordered[-1].end_time, (minutes or {}).get("arrival")) if homeward
-			else ((minutes or {}).get("departure") or (serving or first).start_time,
-				  (serving or first).start_time)
+			else (_time_stamp(ordered, camp_departs.get(stop["place"])) or first.start_time,
+				  # The last camp hands over to the first SITE, not to the card that
+				  # happens to board there - that one can be dropped much later.
+				  _time_stamp(ordered, next_departure) or first.start_time)
 		)
 		rows.append({
 			"card_id": f"{CAMP_LEG_PREFIX}|{group_key}|{stop['stop_index']}",

--- a/one_fm/tests/test_forward_departure_scheduling.py
+++ b/one_fm/tests/test_forward_departure_scheduling.py
@@ -449,6 +449,65 @@ class TestEachLegRecordsItsOwnFacts(FrappeTestCase):
 
 		self.assertEqual(str(camp.qoa_time), "07:15:00")
 
+	def test_a_second_camp_leaves_when_the_bus_reaches_it(self):
+		# A run can load at more than one camp, and it leaves the second when it gets
+		# there - not when it left the first. Both camps of one run were stamped with the
+		# stated departure, so the driver's page printed the same time twice and the
+		# second camp reported for a bus already an hour into its run.
+		from one_fm.one_fm.page.transportation_schedule.transportation_schedule import (
+			_walk_camp_departures,
+		)
+
+		itinerary = [
+			{"kind": "camp", "place": "Camp A", "stop_index": 1},
+			{"kind": "camp", "place": "Camp B", "stop_index": 2},
+			{"kind": "site", "place": "Site", "stop_index": 3},
+		]
+		ordered = [frappe._dict(start_time="2026-08-18T05:48:00.000Z")]
+
+		departs = _walk_camp_departures(
+			itinerary, ordered, 7 * 3600 + 45 * 60,
+			{"Camp A": {"transit_minutes": 30, "buffer_minutes": 5},
+			 "Camp B": {"transit_minutes": 25, "buffer_minutes": 3}},
+		)
+
+		# 07:45, then 35 minutes later, and the chain lands on the first site at 08:48.
+		self.assertEqual(departs["Camp A"], 7 * 3600 + 45 * 60)
+		self.assertEqual(departs["Camp B"], 8 * 3600 + 20 * 60)
+
+	def test_the_last_camp_hands_over_to_the_first_site(self):
+		# A leg that was never timed must not leave the chain short of where the run
+		# actually starts calling.
+		from one_fm.one_fm.page.transportation_schedule.transportation_schedule import (
+			_walk_camp_departures,
+		)
+
+		itinerary = [
+			{"kind": "camp", "place": "Camp A", "stop_index": 1},
+			{"kind": "camp", "place": "Camp B", "stop_index": 2},
+		]
+		ordered = [frappe._dict(start_time="2026-08-18T05:48:00.000Z")]
+
+		departs = _walk_camp_departures(
+			itinerary, ordered, 7 * 3600 + 45 * 60,
+			{"Camp A": {"transit_minutes": 300, "buffer_minutes": 0}},
+		)
+
+		self.assertEqual(departs["Camp B"], 8 * 3600 + 48 * 60)
+
+	def test_a_run_with_no_departure_recorded_falls_back_to_its_first_stop(self):
+		from one_fm.one_fm.page.transportation_schedule.transportation_schedule import (
+			_walk_camp_departures,
+		)
+
+		itinerary = [{"kind": "camp", "place": "Camp A", "stop_index": 1}]
+		ordered = [frappe._dict(start_time="2026-08-18T05:48:00.000Z")]
+
+		self.assertEqual(
+			_walk_camp_departures(itinerary, ordered, None, {}),
+			{"Camp A": 8 * 3600 + 48 * 60},
+		)
+
 	def test_the_ride_home_is_a_row_of_its_own(self):
 		# The last thing the bus does, and the only leg nothing is dropped at - so the
 		# drawer had nothing to show for the drive back and the run appeared to end at

--- a/one_fm/tests/test_mixed_trip_handover.py
+++ b/one_fm/tests/test_mixed_trip_handover.py
@@ -85,6 +85,11 @@ class TestShiftHandoverAlignment(FrappeTestCase):
 class TestTheDriveBetweenTwoSites(FrappeTestCase):
 	"""AC 3.6: dropping at Site A and collecting at Site B means driving between them."""
 
+	# The run out of the camp, timed, so these tests are about the handover drive and
+	# not about the leg that brings the bus to the first site - every drive now needs
+	# its minutes, and the camp's is a drive like any other.
+	CAMP_LEG = {"leg-1": {"transit_minutes": 20, "buffer_minutes": 5}}
+
 	def setUp(self):
 		self.drop = self._shipment("Outward", "08:00:00", "20:00:00", "Site A")
 		self.collect = self._shipment("Return", "20:00:00", "08:00:00", "Site B")
@@ -109,7 +114,7 @@ class TestTheDriveBetweenTwoSites(FrappeTestCase):
 	def test_an_untimed_drive_to_another_site_blocks_the_merge(self):
 		# Camp, drop at Site A, collect at Site B, home. The drive from A to B is the
 		# leg OUT of the Site A row, so that is the row that has to be timed.
-		preview = get_merge_preview([self.drop, self.collect])
+		preview = get_merge_preview([self.drop, self.collect], timings=dict(self.CAMP_LEG))
 
 		self.assertFalse(preview["can_merge"])
 		self.assertIn("Site B", preview["handover_message"])
@@ -117,7 +122,10 @@ class TestTheDriveBetweenTwoSites(FrappeTestCase):
 	def test_entering_the_drive_releases_it(self):
 		preview = get_merge_preview(
 			[self.drop, self.collect],
-			timings={"leg-2": {"transit_minutes": 25, "buffer_minutes": 5}},
+			timings=dict(self.CAMP_LEG, **{
+				"leg-2": {"transit_minutes": 25, "buffer_minutes": 5},
+				"leg-3": {"transit_minutes": 20, "buffer_minutes": 0},
+			}),
 		)
 
 		self.assertTrue(preview["can_merge"])
@@ -125,7 +133,9 @@ class TestTheDriveBetweenTwoSites(FrappeTestCase):
 
 	def test_a_handover_at_the_same_site_needs_no_drive(self):
 		# The bus is already there: one stop, riders off then on, nothing to drive.
-		preview = get_merge_preview([self.drop, self.same_site])
+		preview = get_merge_preview([self.drop, self.same_site], timings=dict(self.CAMP_LEG, **{
+			"leg-2": {"transit_minutes": 20, "buffer_minutes": 0},
+		}))
 
 		handover = next(s for s in preview["stops"] if s["place"] == "Site A")
 		self.assertEqual(handover["action_type"], "Combined")
@@ -189,3 +199,86 @@ class TestTheManifestSaysWhatHappensAtTheStop(FrappeTestCase):
 
 		self.assertIn("DROPPING OFF EMPLOYEES", source)
 		self.assertIn("EMPLOYEES BOARDING", source)
+
+
+class TestEveryDriveNeedsItsMinutes(FrappeTestCase):
+	"""Confirm is blocked until every drive the bus makes has a transit time.
+
+	A stop dropped into the middle of a run arrived with 0 transit, so it shared a clock
+	time with the stop before it - the run said the bus was in two places at the same
+	minute, and the manifest printed it that way.
+	"""
+
+	def setUp(self):
+		self.first = self._shipment("Outward", "08:00:00", "20:00:00", "Site A")
+		self.second = self._shipment("Outward", "09:00:00", "21:00:00", "Site B")
+
+	def _shipment(self, direction, start, end, stop):
+		doc = frappe.new_doc("Transportation Shipment")
+		doc.status = "Unassigned"
+		doc.trip_direction = direction
+		doc.start_time = start
+		doc.end_time = end
+		doc.headcount = 2
+		doc.stop_location = stop
+		doc.accommodation = frappe.get_all("Accommodation", limit=1, pluck="name")[0]
+		doc.generation_key = frappe.generate_hash("TS-DRV", 10)
+		doc.flags.ignore_links = True
+		doc.flags.ignore_mandatory = True
+		doc.insert(ignore_permissions=True)
+		return doc.name
+
+	def test_an_untimed_leg_in_the_middle_blocks_the_confirm(self):
+		# The camp leg and the ride home are timed; Site A's drive to Site B is not.
+		preview = get_merge_preview([self.first, self.second], timings={
+			"leg-1": {"transit_minutes": 25, "buffer_minutes": 5},
+			"leg-3": {"transit_minutes": 20, "buffer_minutes": 0},
+		})
+
+		self.assertFalse(preview["can_merge"])
+		self.assertIn("Site A", preview["handover_message"])
+		self.assertIn("Site B", preview["handover_message"])
+
+	def test_timing_it_releases_the_confirm(self):
+		preview = get_merge_preview([self.first, self.second], timings={
+			"leg-1": {"transit_minutes": 25, "buffer_minutes": 5},
+			"leg-2": {"transit_minutes": 15, "buffer_minutes": 1},
+			"leg-3": {"transit_minutes": 20, "buffer_minutes": 0},
+		})
+
+		self.assertTrue(preview["can_merge"])
+		self.assertEqual(preview["handover_message"], "")
+
+	def test_the_drive_out_of_the_camp_counts_as_a_drive(self):
+		# It is the leg that sets the departure, and leaving it at zero is what put a
+		# run's first block on top of its second.
+		preview = get_merge_preview([self.first, self.second], timings={
+			"leg-2": {"transit_minutes": 15, "buffer_minutes": 1},
+			"leg-3": {"transit_minutes": 20, "buffer_minutes": 0},
+		})
+
+		self.assertFalse(preview["can_merge"])
+
+	def test_a_buffer_alone_is_not_a_drive(self):
+		# Dwelling at a stop for five minutes does not move the bus to the next one.
+		preview = get_merge_preview([self.first, self.second], timings={
+			"leg-1": {"transit_minutes": 25, "buffer_minutes": 5},
+			"leg-2": {"transit_minutes": 0, "buffer_minutes": 5},
+			"leg-3": {"transit_minutes": 20, "buffer_minutes": 0},
+		})
+
+		self.assertFalse(preview["can_merge"])
+
+	def test_a_handover_is_one_stop_and_so_one_drive_out_of_it(self):
+		# Riders getting off and others getting on at one place is a single visit, so
+		# there is one leg out of it to time, not two.
+		same = self._shipment("Return", "20:00:00", "08:00:00", "Site B")
+
+		preview = get_merge_preview([self.first, self.second, same], timings={
+			"leg-1": {"transit_minutes": 25, "buffer_minutes": 5},
+			"leg-2": {"transit_minutes": 15, "buffer_minutes": 1},
+			"leg-3": {"transit_minutes": 20, "buffer_minutes": 0},
+		})
+
+		self.assertEqual([stop["place"] for stop in preview["stops"]].count("Site B"), 1)
+		self.assertTrue(preview["can_merge"])


### PR DESCRIPTION
The same three fixes as #6836, onto `staging`. Sits on top of #6805, #6806, #6807 and #6811, all already merged here.

## A run that loads at two camps has two departures

Both the departure and the driver's report time were taken from the run **as a whole**, so every camp got the first one's. 13/52665 printed **07:45** against both its camps, and gave the second a QOA of 08:58 — measured off a site the bus does not reach until 09:13. The camp row's window then ran from that departure to whenever the card boarding there happened to be dropped, which is not a leg the bus drives.

The camps are chained now, each leaving when the bus reaches it:

```
Mahboula   07:45 → 08:20    30 transit + 5 buffer    QOA 07:30
Farwaniya  08:20 → 08:48    25 transit + 3 buffer    QOA 08:05
KNCC       08:48 → 09:13    23 transit + 2 buffer
Max Farw.  09:13 → 09:44    30 transit + 1 buffer
Fun City   09:44 → 09:54    10 transit
home       09:54
```

Every leg's minutes are now its span, which is what makes the manifest's drive labels agree with the times printed beside them.

## The manifest reads as one journey

It grouped a run camp by camp — a camp's DEPART banner, then the stops its passengers ride to. For a two-camp run the two blocks' clocks interleaved: Mahboula's 08:37 drop printed above Farwaniya's 08:15 departure. It's one journey, so it reads as one: each camp in turn at its own time and its own report time, then every stop once in the order the bus reaches them.

## Confirm is held until every drive is timed

The rule existed but was written for the one case its criterion described — dropped at Site A, collecting at Site B — so any other leg could sit at zero. That is how a card merged into the middle of a run came to share a clock time with the stop before it (08:58 at Max Farwaniya and 08:58 at Fun City).

It is the general rule now: a stop whose next stop is somewhere else needs a transit time. A buffer is not a drive, and two rows at one place are not a drive either — a handover is a single visit with a single leg out of it.

## Verified

Re-stamped against the live plan `RP-2026-06-1754678`; the table above is that run's real output. Suite: 18 + 97 + 48 + 22 + 26 + 15 + 12 + 16 + 71 + 18 + 33 + 11, all green.

No schema change and no patch — `bench restart` is enough. The corrected times reach a run when it is next saved, so re-confirm a merge on 13/52665 to see it.

**Note:** the confirm rule is stricter than before, so re-opening an older merged run may show the banner and a disabled Confirm where it previously let you through. That is intended, but it surfaces on existing runs, not only new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)