### PR TITLE
WI-002179: Price an extension by the month, from one Action and one master row

### DIFF
--- a/one_fm/grd/doctype/grd_renewal_extension_cost/grd_renewal_extension_cost.json
+++ b/one_fm/grd/doctype/grd_renewal_extension_cost/grd_renewal_extension_cost.json
@@ -21,7 +21,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Action",
-   "options": "\nNew Kuwaiti\nOverseas\nOverseas (Government)\nRenewal (Kuwaiti)\nRenewal Expat\nExtend 1 month\nExtend 2 months\nExtend 3 months\nLocal Transfer\nCancellation"
+   "options": "\nNew Kuwaiti\nOverseas\nOverseas (Government)\nRenewal (Kuwaiti)\nRenewal Expat\nExtension\nLocal Transfer\nCancellation"
   },
   {
    "depends_on": "eval: doc.renewal_or_extend == \"Renewal (Kuwaiti)\" || doc.renewal_or_extend == \"Renewal Expat\"",

--- a/one_fm/grd/doctype/preparation/preparation.js
+++ b/one_fm/grd/doctype/preparation/preparation.js
@@ -9,6 +9,9 @@ frappe.ui.form.on('Preparation Record',{
 	no_of_years: function(frm, cdt, cdn){
 		set_preparation_record_costing(frm, cdt, cdn);
 	},
+	no_of_months: function(frm, cdt, cdn){
+		set_preparation_record_costing(frm, cdt, cdn);
+	},
 	work_permit_amount: function(frm, cdt, cdn) {
 		var child = locals[cdt][cdn];
 		caclulate_renewal_extension_cost_total(frm, child);
@@ -40,6 +43,9 @@ frappe.ui.form.on('Preparation Record',{
 // in step with YEAR_SCOPED_ACTIONS in preparation.py and with the costing table's own
 // depends_on.
 const YEAR_SCOPED_ACTIONS = ['Renewal (Kuwaiti)', 'Renewal Expat'];
+// WI-002179: the one Action that is priced by the month. Kept in step with
+// EXTENSION_ACTION in preparation.py and with the No. of Months field's own depends_on.
+const EXTENSION_ACTION = 'Extension';
 const COST_COMPONENT_FIELDS = [
 	'work_permit_amount',
 	'medical_insurance_amount',
@@ -55,13 +61,23 @@ var set_preparation_record_costing = function(frm, cdt, cdn) {
 
 	// The years only mean something for a renewal. Cleared otherwise, because the field is
 	// hidden rather than emptied when the Action changes, and a stale "1 Year" left on an
-	// Extend row is a year the master lookup would have been scoped by.
+	// Extension row is a year the master lookup would have been scoped by.
 	if(YEAR_SCOPED_ACTIONS.includes(row.renewal_or_extend)){
 		if(!row.no_of_years){
 			frappe.model.set_value(row.doctype, row.name, 'no_of_years', '1 Year');
 		}
 	} else if(row.no_of_years){
 		frappe.model.set_value(row.doctype, row.name, 'no_of_years', '');
+	}
+
+	// WI-002179: the months are the same story the other way round. An extension always has
+	// a duration - one month unless the operator says otherwise - and a renewal never does.
+	if(row.renewal_or_extend === EXTENSION_ACTION){
+		if(!row.no_of_months){
+			frappe.model.set_value(row.doctype, row.name, 'no_of_months', '1 Month');
+		}
+	} else if(row.no_of_months){
+		frappe.model.set_value(row.doctype, row.name, 'no_of_months', '');
 	}
 
 	// Cleared before the fetch, not inside a successful callback. Switching to an Action
@@ -75,7 +91,11 @@ var set_preparation_record_costing = function(frm, cdt, cdn) {
 		// WI-002092: the row's fees, already multiplied out for a multi-year renewal. The
 		// master lookup returns the annual rate, which is not what the row carries.
 		method: 'one_fm.grd.doctype.preparation.preparation.get_preparation_row_costing',
-		args: {'renewal_or_extend': row.renewal_or_extend, 'no_of_years': row.no_of_years},
+		args: {
+			'renewal_or_extend': row.renewal_or_extend,
+			'no_of_years': row.no_of_years,
+			'no_of_months': row.no_of_months
+		},
 		callback: function(r) {
 			if(!r.message){
 				// WI-002092: say so rather than leave four zeros and no explanation. The
@@ -84,7 +104,9 @@ var set_preparation_record_costing = function(frm, cdt, cdn) {
 				frappe.show_alert({
 					message: __('No master fee row in HR Settings for {0}{1}.', [
 						row.renewal_or_extend,
-						row.no_of_years ? __(' at {0}', [row.no_of_years]) : ''
+						row.no_of_years || row.no_of_months
+							? __(' at {0}', [row.no_of_years || row.no_of_months])
+							: ''
 					]),
 					indicator: 'orange'
 				}, 7);

--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -117,11 +117,21 @@ YEAR_SCOPED_ACTIONS = ('Renewal (Kuwaiti)', 'Renewal Expat')
 #
 # The civil ID is deliberately absent: one card is issued for the whole period, whatever it
 # costs, so multiplying it would charge the employee for cards that were never printed.
-PER_YEAR_COST_FIELDS = (
+#
+# WI-002179: an extension is bought the same way, by the month rather than by the year, so
+# the same three scale and the same one stays flat.
+DURATION_SCALED_COST_FIELDS = (
     'work_permit_amount',
     'medical_insurance_amount',
     'residency_stamp_amount',
 )
+
+# WI-002179: one Action for every extension, however long it runs for. "Extend 1 month",
+# "Extend 2 months" and "Extend 3 months" were three master fee rows saying the same thing
+# three times, and adding a fourth duration meant adding a fourth option and a fourth row.
+# The duration is a number on the Preparation row now, and the master row holds the monthly
+# rate.
+EXTENSION_ACTION = 'Extension'
 
 
 # WI-002101: the batch type, the series it is named under, and the Actions its rows may
@@ -129,9 +139,9 @@ PER_YEAR_COST_FIELDS = (
 # statement - an Onboarding batch named PRE-ONB- that could still carry a Cancellation row
 # would be lying about what it is.
 #
-# The Action values are the Preparation Record field's own options, spelling included:
-# WI-002101 writes "Renewal (Non Kuwaiti)" and "Extend 1 Month" where the field now has
-# "Renewal Expat" (WI-002178) and "Extend 1 month". The field's spelling is what every
+# The Action values are the Preparation Record field's own options: WI-002101 writes
+# "Renewal (Non Kuwaiti)" and "Extend 1 Month" where the field now has "Renewal Expat"
+# (WI-002178) and a single "Extension" (WI-002179). The field's own spelling is what every
 # existing row and every lookup keyed on it already uses.
 CATEGORIES = {
     'Onboarding': {
@@ -147,9 +157,7 @@ CATEGORIES = {
         'actions': (
             'Renewal (Kuwaiti)',
             'Renewal Expat',
-            'Extend 1 month',
-            'Extend 2 months',
-            'Extend 3 months',
+            EXTENSION_ACTION,
         ),
     },
 }
@@ -538,6 +546,10 @@ class Preparation(Document):
 
             preparation.renewal_or_extend = extension_type if renew_all else ""
             preparation.no_of_years = no_of_years if renew_all else ""
+            # "Renew all" makes every row a renewal, which is priced by the year. A months
+            # value left on the row from an extension is hidden but not harmless - it is
+            # what the fees would be multiplied by if the Action were switched back.
+            preparation.no_of_months = ""
             # A nationality with no master row configured used to fail here on
             # `None.work_permit_amount`, taking the whole "renew all" action down with it
             # (WI-002031). The row is left at zero instead, which the operator can see and
@@ -594,7 +606,8 @@ def create_preparation_record():
             new_row['renewal_or_extend'] = "Renewal (Kuwaiti)"
         else:
             if employee.relieving_date: 
-                new_row['renewal_or_extend'] = "Extend 3 months"
+                new_row['renewal_or_extend'] = EXTENSION_ACTION
+                new_row['no_of_months'] = "3 Months"
             else:
                 new_row['renewal_or_extend'] = "Renewal Expat"
         doc.append("preparation_record", new_row)
@@ -676,7 +689,7 @@ def get_grd_renewal_extension_cost(renewal_or_extend: str, no_of_years: str = No
     are the ones whose master rows are keyed by it.
 
     Deliberately not scoped by years for any other Action: the field is hidden for them
-    but not cleared, so a row switched from Renewal Expat to Extend 1 month still
+    but not cleared, so a row switched from Renewal Expat to Extension still
     carries "1 Year", and filtering on it would find nothing and quietly return no fees.
     """
     if not frappe.has_permission('Preparation', 'write'):
@@ -723,29 +736,36 @@ def _master_fee_rows(renewal_or_extend, no_of_years=None):
 
     return query.run(as_dict=True)
 
-def years_in(no_of_years):
-    """The number of years "2 Years" means (WI-002092).
+def duration_in(duration):
+    """How many periods "2 Years" or "2 Months" means (WI-002092, WI-002179).
 
-    Anything unparseable is one year: the field offers "1 Year", "2 Years" and "3 Years",
-    and a row that somehow carries something else should be charged the single-year rate
-    rather than nothing at all.
+    Anything unparseable is one: the fields offer "1 Year"/"2 Years"/"3 Years" and
+    "1 Month"/"2 Months"/"3 Months", and a row that somehow carries something else should be
+    charged the single-period rate rather than nothing at all.
     """
-    years = cint(cstr(no_of_years).split()[0]) if no_of_years else 0
-    return years or 1
+    periods = cint(cstr(duration).split()[0]) if duration else 0
+    return periods or 1
 
 
 @frappe.whitelist()
-def get_preparation_row_costing(renewal_or_extend: str, no_of_years: str = None):
+def get_preparation_row_costing(
+    renewal_or_extend: str, no_of_years: str = None, no_of_months: str = None
+):
     """The fees a Preparation row should carry for this Action and duration (WI-002092).
 
-    The master row in HR Settings holds the annual rate. A renewal taken for two or three
-    years pays the work permit, the medical insurance and the residency stamp once per year,
-    so those are multiplied out here - and the civil ID is not, because one card is issued
-    for the whole period.
+    The master row in HR Settings holds the rate for one period. A renewal taken for two or
+    three years pays the work permit, the medical insurance and the residency stamp once per
+    year, so those are multiplied out here - and the civil ID is not, because one card is
+    issued for the whole period.
+
+    WI-002179: an extension is the same arithmetic on a shorter period. One "Extension" row
+    in HR Settings holds the monthly rate, and the number of months on the Preparation row
+    is what it is multiplied by - so a duration nobody configured a row for still costs the
+    right amount, which three fixed "Extend N months" options could never do.
 
     Scaled here rather than in the master lookup so that lookup keeps returning what HR
-    Settings actually holds: the master table's own Total Amount is the annual figure, and
-    the two would otherwise disagree about what a row means.
+    Settings actually holds: the master table's own Total Amount is the rate for one period,
+    and the two would otherwise disagree about what a row means.
 
     Called by the form as well as by the "renew all" action, so the browser and the server
     cannot scale a row differently.
@@ -755,12 +775,15 @@ def get_preparation_row_costing(renewal_or_extend: str, no_of_years: str = None)
         return costing
 
     costing = dict(costing)
-    if renewal_or_extend not in YEAR_SCOPED_ACTIONS:
+    if renewal_or_extend in YEAR_SCOPED_ACTIONS:
+        periods = duration_in(no_of_years)
+    elif renewal_or_extend == EXTENSION_ACTION:
+        periods = duration_in(no_of_months)
+    else:
         return costing
 
-    years = years_in(no_of_years)
-    for field in PER_YEAR_COST_FIELDS:
-        costing[field] = flt(costing.get(field)) * years
+    for field in DURATION_SCALED_COST_FIELDS:
+        costing[field] = flt(costing.get(field)) * periods
 
     return costing
 
@@ -863,7 +886,7 @@ def handle_renewal_changes(old_,new_,source):
         old (dict): a dict containing details of the old row
         new (dict): a dict containing details of the new row
     """
-    if old_.renewal_or_extend == "Renewal" and new_.renewal_or_extend in ['Extend 1 month','Extend 2 months','Extend 3 months']:
+    if old_.renewal_or_extend == "Renewal" and new_.renewal_or_extend == EXTENSION_ACTION:
         handle_extension(source,new_)
     elif new_.renewal_or_extend == "Cancellation":
         handle_cancelation(source,new_)

--- a/one_fm/grd/doctype/preparation/test_action_fee_master.py
+++ b/one_fm/grd/doctype/preparation/test_action_fee_master.py
@@ -130,10 +130,10 @@ class TestActionFeeMaster(FrappeTestCase):
 	def test_a_non_renewal_action_ignores_a_stale_year(self):
 		# The field is hidden but not cleared when the Action changes, so an Extend row can
 		# still carry "1 Year". Scoping by it would find nothing and return no fees.
-		_master_rows([{"renewal_or_extend": "Extend 1 month", "work_permit_amount": 25}])
+		_master_rows([{"renewal_or_extend": "Extension", "work_permit_amount": 25}])
 
 		self.assertEqual(
-			get_grd_renewal_extension_cost("Extend 1 month", "1 Year")["work_permit_amount"], 25
+			get_grd_renewal_extension_cost("Extension", "1 Year")["work_permit_amount"], 25
 		)
 
 	def test_an_unconfigured_action_returns_nothing_rather_than_a_wrong_row(self):

--- a/one_fm/grd/doctype/preparation/test_extension_costing.py
+++ b/one_fm/grd/doctype/preparation/test_extension_costing.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002179: one Extension Action, priced by the number of months on the row."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.grd.doctype.preparation.preparation import (
+	CATEGORIES,
+	DURATION_SCALED_COST_FIELDS,
+	EXTENSION_ACTION,
+	duration_in,
+	get_grd_renewal_extension_cost,
+	get_preparation_row_costing,
+)
+
+MONTHLY = {
+	"work_permit_amount": 20,
+	"medical_insurance_amount": 12,
+	"residency_stamp_amount": 8,
+	"civil_id_amount": 5,
+}
+
+REMOVED_ACTIONS = ("Extend 1 month", "Extend 2 months", "Extend 3 months")
+
+
+def _master_rows(rows):
+	settings = frappe.get_doc("HR Settings")
+	settings.set("renewal_extension_cost", [])
+	for row in rows:
+		settings.append("renewal_extension_cost", row)
+	settings.flags.ignore_permissions = True
+	settings.save()
+	frappe.clear_cache(doctype="HR Settings")
+
+
+def _options(doctype, fieldname):
+	return frappe.get_meta(doctype).get_field(fieldname).options.split("\n")
+
+
+class TestExtensionIsOneAction(FrappeTestCase):
+	def test_both_action_fields_offer_extension(self):
+		for doctype in ("GRD Renewal Extension Cost", "Preparation Record"):
+			with self.subTest(doctype=doctype):
+				self.assertIn(EXTENSION_ACTION, _options(doctype, "renewal_or_extend"))
+
+	def test_neither_still_offers_a_per_month_action(self):
+		for doctype in ("GRD Renewal Extension Cost", "Preparation Record"):
+			options = _options(doctype, "renewal_or_extend")
+			for action in REMOVED_ACTIONS:
+				with self.subTest(doctype=doctype, action=action):
+					self.assertNotIn(action, options)
+
+	def test_the_row_offers_a_duration_in_months(self):
+		field = frappe.get_meta("Preparation Record").get_field("no_of_months")
+		self.assertEqual(field.label, "No. of Months")
+		self.assertEqual(field.options.split("\n"), ["", "1 Month", "2 Months", "3 Months"])
+
+	def test_the_months_are_shown_only_for_an_extension(self):
+		"""AC2: the field appears on the row form when the Action is Extension."""
+		field = frappe.get_meta("Preparation Record").get_field("no_of_months")
+		self.assertEqual(field.depends_on, f'eval:doc.renewal_or_extend == "{EXTENSION_ACTION}"')
+
+	def test_a_renewal_batch_may_carry_it(self):
+		self.assertIn(EXTENSION_ACTION, CATEGORIES["Renewal"]["actions"])
+		for action in REMOVED_ACTIONS:
+			self.assertNotIn(action, CATEGORIES["Renewal"]["actions"])
+
+
+class TestExtensionCosting(FrappeTestCase):
+	"""AC3: the monthly rate multiplied by the months, with the civil ID left flat."""
+
+	def setUp(self):
+		_master_rows([dict(MONTHLY, renewal_or_extend=EXTENSION_ACTION)])
+
+	def test_the_monthly_fees_are_multiplied_by_the_months(self):
+		for months, multiplier in (("1 Month", 1), ("2 Months", 2), ("3 Months", 3)):
+			with self.subTest(months=months):
+				costing = get_preparation_row_costing(EXTENSION_ACTION, no_of_months=months)
+				for field in DURATION_SCALED_COST_FIELDS:
+					self.assertEqual(costing[field], MONTHLY[field] * multiplier, field)
+
+	def test_the_civil_id_is_never_multiplied(self):
+		"""One card is issued for the whole extension, whatever it costs."""
+		for months in ("1 Month", "2 Months", "3 Months"):
+			with self.subTest(months=months):
+				costing = get_preparation_row_costing(EXTENSION_ACTION, no_of_months=months)
+				self.assertEqual(costing["civil_id_amount"], MONTHLY["civil_id_amount"])
+
+	def test_an_extension_with_no_duration_is_charged_one_month(self):
+		"""Better the one-month rate than nothing at all - the row is still visibly wrong."""
+		costing = get_preparation_row_costing(EXTENSION_ACTION)
+		for field in DURATION_SCALED_COST_FIELDS:
+			self.assertEqual(costing[field], MONTHLY[field], field)
+
+	def test_a_stale_year_does_not_narrow_the_lookup(self):
+		"""The years field is hidden for an extension but not cleared when the Action changes."""
+		costing = get_preparation_row_costing(EXTENSION_ACTION, "3 Years", "2 Months")
+		self.assertEqual(
+			costing["work_permit_amount"], MONTHLY["work_permit_amount"] * 2
+		)
+
+	def test_the_master_table_still_reads_as_the_monthly_rate(self):
+		"""The multiplication is the Preparation row's, not HR Settings'."""
+		self.assertEqual(
+			get_grd_renewal_extension_cost(EXTENSION_ACTION)["work_permit_amount"],
+			MONTHLY["work_permit_amount"],
+		)
+
+	def test_one_master_row_serves_every_duration(self):
+		"""The point of the story: a duration nobody configured a row for still costs right."""
+		self.assertEqual(len(frappe.get_doc("HR Settings").renewal_extension_cost), 1)
+		self.assertTrue(get_preparation_row_costing(EXTENSION_ACTION, no_of_months="3 Months"))
+
+
+class TestDurationIn(FrappeTestCase):
+	def test_it_reads_months_as_well_as_years(self):
+		self.assertEqual(duration_in("1 Month"), 1)
+		self.assertEqual(duration_in("2 Months"), 2)
+		self.assertEqual(duration_in("3 Months"), 3)

--- a/one_fm/grd/doctype/preparation/test_multi_year_costing.py
+++ b/one_fm/grd/doctype/preparation/test_multi_year_costing.py
@@ -6,11 +6,11 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from one_fm.grd.doctype.preparation.preparation import (
-	PER_YEAR_COST_FIELDS,
+	DURATION_SCALED_COST_FIELDS,
 	YEAR_SCOPED_ACTIONS,
 	get_grd_renewal_extension_cost,
 	get_preparation_row_costing,
-	years_in,
+	duration_in,
 )
 
 RENEWAL = YEAR_SCOPED_ACTIONS[1]  # Renewal Expat
@@ -34,15 +34,15 @@ def _master_rows(rows):
 
 class TestYearsIn(FrappeTestCase):
 	def test_it_reads_the_number_off_the_option(self):
-		self.assertEqual(years_in("1 Year"), 1)
-		self.assertEqual(years_in("2 Years"), 2)
-		self.assertEqual(years_in("3 Years"), 3)
+		self.assertEqual(duration_in("1 Year"), 1)
+		self.assertEqual(duration_in("2 Years"), 2)
+		self.assertEqual(duration_in("3 Years"), 3)
 
 	def test_anything_unparseable_is_charged_a_single_year(self):
 		"""Better the single-year rate than nothing at all."""
 		for value in (None, "", "Years", "one year"):
 			with self.subTest(value=value):
-				self.assertEqual(years_in(value), 1)
+				self.assertEqual(duration_in(value), 1)
 
 
 class TestMultiYearCosting(FrappeTestCase):
@@ -51,14 +51,14 @@ class TestMultiYearCosting(FrappeTestCase):
 			dict(ANNUAL, renewal_or_extend=RENEWAL, no_of_years="1 Year"),
 			dict(ANNUAL, renewal_or_extend=RENEWAL, no_of_years="2 Years"),
 			dict(ANNUAL, renewal_or_extend=RENEWAL, no_of_years="3 Years"),
-			dict(ANNUAL, renewal_or_extend="Extend 1 month"),
+			dict(ANNUAL, renewal_or_extend="Local Transfer"),
 		])
 
 	def test_the_annual_fees_are_multiplied_by_the_years(self):
 		for years, multiplier in (("1 Year", 1), ("2 Years", 2), ("3 Years", 3)):
 			with self.subTest(years=years):
 				costing = get_preparation_row_costing(RENEWAL, years)
-				for field in PER_YEAR_COST_FIELDS:
+				for field in DURATION_SCALED_COST_FIELDS:
 					self.assertEqual(costing[field], ANNUAL[field] * multiplier, field)
 
 	def test_the_civil_id_is_never_multiplied(self):
@@ -79,10 +79,10 @@ class TestMultiYearCosting(FrappeTestCase):
 		)
 
 	def test_an_action_with_no_duration_is_not_multiplied(self):
-		"""An extension is a one-off. The years field is hidden for it but not cleared, so a
-		stale "3 Years" must not treble an extension's fees."""
-		costing = get_preparation_row_costing("Extend 1 month", "3 Years")
-		for field in PER_YEAR_COST_FIELDS:
+		"""A transfer is a one-off. The years field is hidden for it but not cleared, so a
+		stale "3 Years" must not treble its fees."""
+		costing = get_preparation_row_costing("Local Transfer", "3 Years")
+		for field in DURATION_SCALED_COST_FIELDS:
 			self.assertEqual(costing[field], ANNUAL[field], field)
 
 	def test_an_unconfigured_action_still_returns_nothing(self):
@@ -119,7 +119,7 @@ class TestMultiYearCosting(FrappeTestCase):
 
 	def test_the_multiplied_fields_are_the_three_annual_ones(self):
 		self.assertEqual(
-			PER_YEAR_COST_FIELDS,
+			DURATION_SCALED_COST_FIELDS,
 			("work_permit_amount", "medical_insurance_amount", "residency_stamp_amount"),
 		)
 
@@ -140,7 +140,7 @@ class TestADurationWithNoMasterRowOfItsOwn(FrappeTestCase):
 			with self.subTest(years=years):
 				costing = get_preparation_row_costing(RENEWAL, years)
 				self.assertTrue(costing, f"nothing fetched for {years}")
-				for field in PER_YEAR_COST_FIELDS:
+				for field in DURATION_SCALED_COST_FIELDS:
 					self.assertEqual(costing[field], ANNUAL[field] * multiplier, field)
 
 	def test_the_exact_duration_still_wins_when_it_is_configured(self):

--- a/one_fm/grd/doctype/preparation/test_preparation_new_actions.py
+++ b/one_fm/grd/doctype/preparation/test_preparation_new_actions.py
@@ -227,7 +227,7 @@ class TestNewActionDocuments(FrappeTestCase):
 
 		for action, category, expected_date in (
 			("Renewal Expat", "Renewal", add_days(expiry, -14)),
-			("Extend 2 months", "Extend", add_days(expiry, -7)),
+			("Extension", "Extend", add_days(expiry, -7)),
 			("Transfer", "Transfer", getdate(nowdate())),
 		):
 			with self.subTest(action=action):

--- a/one_fm/grd/doctype/preparation_record/preparation_record.json
+++ b/one_fm/grd/doctype/preparation_record/preparation_record.json
@@ -15,6 +15,7 @@
   "residency_expiry_date",
   "renewal_or_extend",
   "no_of_years",
+  "no_of_months",
   "column_break_11",
   "work_permit_amount",
   "medical_insurance_amount",
@@ -69,7 +70,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Action",
-   "options": "\nNew Kuwaiti\nOverseas\nOverseas (Government)\nRenewal (Kuwaiti)\nRenewal Expat\nExtend 1 month\nExtend 2 months\nExtend 3 months\nLocal Transfer\nCancellation"
+   "options": "\nNew Kuwaiti\nOverseas\nOverseas (Government)\nRenewal (Kuwaiti)\nRenewal Expat\nExtension\nLocal Transfer\nCancellation"
   },
   {
    "allow_on_submit": 1,
@@ -101,6 +102,14 @@
    "fieldtype": "Select",
    "label": "No. of Years",
    "options": "\n1 Year\n2 Years\n3 Years"
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval:doc.renewal_or_extend == \"Extension\"",
+   "fieldname": "no_of_months",
+   "fieldtype": "Select",
+   "label": "No. of Months",
+   "options": "\n1 Month\n2 Months\n3 Months"
   },
   {
    "bold": 1,
@@ -172,7 +181,7 @@
  "grid_page_length": 50,
  "istable": 1,
  "links": [],
- "modified": "2026-08-24 10:00:00.000000",
+ "modified": "2026-09-02 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Preparation Record",

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -604,3 +604,4 @@ one_fm.patches.v15_0.add_transportation_qoa_buffer_to_hr_settings #2026-08-26 WI
 one_fm.patches.v15_0.rekey_olm_shipments_on_shift_window #2026-08-31 WI-002151
 one_fm.patches.v15_0.repoint_pam_file_links_to_license_details #2026-08-29 WI-002233
 one_fm.patches.v15_0.rename_renewal_expat_and_hr_costing #2026-09-02 WI-002178
+one_fm.patches.v15_0.consolidate_extension_actions #2026-09-02 WI-002179

--- a/one_fm/patches/v15_0/consolidate_extension_actions.py
+++ b/one_fm/patches/v15_0/consolidate_extension_actions.py
@@ -15,6 +15,12 @@ MONTHS_BY_ACTION = {
 
 EXTENSION = "Extension"
 
+# The costing table is read from HR Settings and nowhere else (`_master_fee_rows` filters
+# on this parent). A superseded "GRD Settings" Single still holds the rows it was copied
+# from when update_hr_settings_with_grd_settings moved them - a dead copy that nothing
+# reads and that no form can save, so it is neither migrated nor counted here.
+COSTING_PARENT = {"parent": "HR Settings", "parenttype": "HR Settings"}
+
 # The master row that holds the monthly rate. The other two hold two and three times it,
 # which is what the Preparation row multiplies out now - keeping them would double-count.
 MONTHLY_MASTER_ROW = "Extend 1 month"
@@ -82,15 +88,16 @@ def collapse_master_rows():
 def verify(moved, kept):
 	"""A row left on a removed option cannot be saved again, so the move is checked."""
 	for action in MONTHS_BY_ACTION:
-		for doctype, fieldname in (
-			("Preparation Record", "renewal_or_extend"),
-			("GRD Renewal Extension Cost", "renewal_or_extend"),
+		for doctype, filters in (
+			("Preparation Record", {}),
+			("GRD Renewal Extension Cost", COSTING_PARENT),
 		):
-			left_behind = frappe.db.count(doctype, {fieldname: action})
+			left_behind = frappe.db.count(doctype, dict(filters, renewal_or_extend=action))
 			if left_behind:
 				frappe.throw(
 					f"WI-002179: {left_behind} {doctype} rows still carry {action!r}, which "
-					f"{fieldname} no longer offers - they would fail validation on the next save."
+					"renewal_or_extend no longer offers - they would fail validation on the "
+					"next save."
 				)
 
 	print(f"WI-002179: moved {moved} Preparation rows to {EXTENSION!r}; master row total {kept}")

--- a/one_fm/patches/v15_0/consolidate_extension_actions.py
+++ b/one_fm/patches/v15_0/consolidate_extension_actions.py
@@ -1,0 +1,96 @@
+import frappe
+
+# WI-002179: "Extend 1 month", "Extend 2 months" and "Extend 3 months" were three Actions,
+# three master fee rows and three ways of saying the same thing. There is one "Extension"
+# Action now, and the duration is a number on the Preparation row.
+#
+# The Action is a Select, so a row left on a spelling the field no longer offers fails
+# validation on its next save. Every stored row is moved here, and the duration it was
+# carrying in its name is written to No. of Months so nothing is lost in the move.
+MONTHS_BY_ACTION = {
+	"Extend 1 month": "1 Month",
+	"Extend 2 months": "2 Months",
+	"Extend 3 months": "3 Months",
+}
+
+EXTENSION = "Extension"
+
+# The master row that holds the monthly rate. The other two hold two and three times it,
+# which is what the Preparation row multiplies out now - keeping them would double-count.
+MONTHLY_MASTER_ROW = "Extend 1 month"
+
+
+def execute():
+	frappe.reload_doc("grd", "doctype", "grd_renewal_extension_cost")
+	frappe.reload_doc("grd", "doctype", "preparation_record")
+
+	moved = move_preparation_rows()
+	kept = collapse_master_rows()
+
+	verify(moved, kept)
+
+
+def move_preparation_rows():
+	"""Every Preparation row keeps the duration its old Action name spelled out."""
+	moved = 0
+	for action, months in MONTHS_BY_ACTION.items():
+		rows = frappe.get_all("Preparation Record", filters={"renewal_or_extend": action}, pluck="name")
+		for name in rows:
+			frappe.db.set_value(
+				"Preparation Record", name,
+				{"renewal_or_extend": EXTENSION, "no_of_months": months},
+				update_modified=False,
+			)
+		moved += len(rows)
+
+	return moved
+
+
+def collapse_master_rows():
+	"""Three master fee rows become the one that states the monthly rate."""
+	settings = frappe.get_doc("HR Settings")
+	extend_rows = [
+		row for row in settings.renewal_extension_cost
+		if row.renewal_or_extend in MONTHS_BY_ACTION
+	]
+	if not extend_rows:
+		return None
+
+	# Sorted so the one-month row is first whatever order the table is in.
+	extend_rows.sort(key=lambda row: row.renewal_or_extend != MONTHLY_MASTER_ROW)
+	keeper = extend_rows[0]
+
+	if keeper.renewal_or_extend != MONTHLY_MASTER_ROW:
+		print(
+			f"WI-002179: HR Settings had no {MONTHLY_MASTER_ROW!r} row, so "
+			f"{keeper.renewal_or_extend!r} became the Extension row. Its amounts are for that "
+			"many months, not for one - HR has to restate them as a monthly rate."
+		)
+
+	keeper.renewal_or_extend = EXTENSION
+	for row in extend_rows[1:]:
+		settings.renewal_extension_cost.remove(row)
+
+	settings.flags.ignore_mandatory = True
+	settings.flags.ignore_permissions = True
+	settings.save()
+	frappe.clear_cache(doctype="HR Settings")
+
+	return keeper.total_amount
+
+
+def verify(moved, kept):
+	"""A row left on a removed option cannot be saved again, so the move is checked."""
+	for action in MONTHS_BY_ACTION:
+		for doctype, fieldname in (
+			("Preparation Record", "renewal_or_extend"),
+			("GRD Renewal Extension Cost", "renewal_or_extend"),
+		):
+			left_behind = frappe.db.count(doctype, {fieldname: action})
+			if left_behind:
+				frappe.throw(
+					f"WI-002179: {left_behind} {doctype} rows still carry {action!r}, which "
+					f"{fieldname} no longer offers - they would fail validation on the next save."
+				)
+
+	print(f"WI-002179: moved {moved} Preparation rows to {EXTENSION!r}; master row total {kept}")


### PR DESCRIPTION
[WI-002179](https://one-fm.com/app/work-item/WI-002179) — process owner Ambrin.

> **Stacked on #6838 (WI-002178).** Both change the same Action option list, so this one is based on it and should merge after it.

## What the criteria asked for

- **HR Costing table** — `Extend 1 month`, `Extend 2 months` and `Extend 3 months` are gone from the Action dropdown, replaced by a single **`Extension`**.
- **Preparation Record row** — selecting `Extension` shows a new **No. of Months** field (1 / 2 / 3 Months); it is hidden for every other Action.
- **Costing** — choosing a duration fetches the `Extension` base rate from HR Settings, multiplies **Work Permit**, **Medical Insurance** and **Residency Stamp** by the months, leaves **Civil ID** flat, and repopulates **Total Amount**.

## How

An extension is now the same arithmetic a multi-year renewal already did on a shorter period, so both go through one path: `get_preparation_row_costing` picks the multiplier from `no_of_years` or `no_of_months` and scales `DURATION_SCALED_COST_FIELDS`. `years_in` became `duration_in` — it already parsed `"2 Years"`, and `"2 Months"` is the same shape.

The point of the story is the last line of that: HR configures **one** monthly rate, and a duration nobody made a row for still costs the right amount. Three fixed options could never do that.

## The patch

`consolidate_extension_actions` moves every stored Preparation row to `Extension` and writes the duration its old Action name spelled out into No. of Months, then collapses the three master rows onto the one that states the **monthly** rate. If HR never configured an `Extend 1 month` row it keeps whichever exists and **prints that HR has to restate the amounts** — a two-month row's figures are not a monthly rate and the patch cannot know them.

## The sub-document question

The criteria's last bullet asked us to check the category on Work Permit, Medical Insurance, Residency and PACI for an Extension row. Confirmed with the process owner: **Residency only, unchanged**. An extension opens a Residency categorised `Extend` and opens none of the other three — which is what `MOI_CATEGORY_BY_ACTION`'s fallback already does for any Action not in the map, `Extension` included.

## Verified

`test_extension_costing.py` covers the option lists, the field and its `depends_on`, the multiplication, the flat civil ID, a stale No. of Years not narrowing the lookup, and one master row serving every duration. The arithmetic was run against a mocked master row on this bench and is correct; the schema-dependent assertions are red until `bench migrate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)