### PR TITLE
WI-002313: Offer Create Visa Cancellation on a completed Visa Request

### DIFF
--- a/one_fm/visa_management/doctype/visa_request/test_visa_cancellation_button.py
+++ b/one_fm/visa_management/doctype/visa_request/test_visa_cancellation_button.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002313: the Create Visa Cancellation button on a completed Visa Request.
+
+A placeholder: the DocType it will raise does not exist yet. What is worth pinning is the
+one thing the acceptance criteria states - which state the button appears in - because that
+state name is a string in a client script and a rename would take the button away silently.
+"""
+
+from pathlib import Path
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+COMPLETED = "Completed"
+BUTTON = "Create Visa Cancellation"
+
+SCRIPT = Path(frappe.get_app_path("one_fm")) / "visa_management" / "doctype" / "visa_request" / "visa_request.js"
+
+
+class TestTheButtonIsOfferedOnACompletedRequest(FrappeTestCase):
+	def setUp(self):
+		self.script = SCRIPT.read_text()
+
+	def test_the_script_offers_the_button(self):
+		self.assertIn(BUTTON, self.script)
+
+	def test_it_is_gated_on_the_completed_state(self):
+		self.assertIn(f"const COMPLETED_STATE = '{COMPLETED}';", self.script)
+		self.assertIn("frm.doc.workflow_state !== COMPLETED_STATE", self.script)
+
+	def test_the_state_it_is_gated_on_is_one_the_workflow_has(self):
+		"""The whole risk in a state name living in a client script."""
+		states = {state.state for state in frappe.get_doc("Workflow", "Visa Request").states}
+		self.assertIn(COMPLETED, states)
+
+	def test_completed_is_still_the_end_of_the_visa(self):
+		"""The button means "the visa exists, cancel it" - which is only true once the
+		request is submitted."""
+		state = next(
+			s for s in frappe.get_doc("Workflow", "Visa Request").states if s.state == COMPLETED
+		)
+		self.assertEqual(state.doc_status, "1")

--- a/one_fm/visa_management/doctype/visa_request/visa_request.js
+++ b/one_fm/visa_management/doctype/visa_request/visa_request.js
@@ -5,6 +5,9 @@
 // Kept in step with REAPPLY_REASONS in visa_request.py - the server refuses anything else,
 // so a button offered outside these would only produce an error dialog.
 const PAM_REJECTED_STATE = 'Rejected By PAM';
+
+// WI-002313: the state a completed visa can be cancelled from.
+const COMPLETED_STATE = 'Completed';
 const REAPPLY_REASONS = [
 	"The occupation requires amendment to specify the worker's specialization",
 	"The worker's gender does not match the profession"
@@ -13,6 +16,7 @@ const REAPPLY_REASONS = [
 frappe.ui.form.on("Visa Request", {
 	refresh: function(frm) {
 		add_reapply_button(frm);
+		add_visa_cancellation_button(frm);
 	},
 
 	before_workflow_action: async function(frm) {
@@ -218,6 +222,29 @@ function add_reapply_button(frm) {
 				});
 			}
 		);
+	});
+}
+
+
+// WI-002313: a completed visa is the one a recruiter asks to cancel - the workflow's own
+// "Request to Cancel" is offered at Pending Recruiter Confirmation, which is the state
+// before the visa exists to cancel.
+//
+// ponytail: the button is a placeholder. The Visa Cancellation DocType it will raise does
+// not exist yet - the business analyst is creating it - and the Completed state is
+// submitted (docstatus 1) while every cancellation state in the workflow is a draft, so
+// there is no legal transition to send it down either. Replace the handler with the
+// document creation once the DocType lands; the visibility rule above is the AC and stays.
+function add_visa_cancellation_button(frm) {
+	if (frm.is_new()) return;
+	if (frm.doc.workflow_state !== COMPLETED_STATE) return;
+
+	frm.add_custom_button(__('Create Visa Cancellation'), () => {
+		frappe.msgprint({
+			title: __('Not Available Yet'),
+			indicator: 'orange',
+			message: __('The Visa Cancellation process is not set up yet. This button will raise one from {0} once it is.', [frm.doc.name])
+		});
 	});
 }
 


### PR DESCRIPTION
[WI-002313](https://one-fm.com/app/work-item/WI-002313) — process owner Ambrin.

## What the criterion asked for

> Given a Visa Request is in the workflow state **Completed**, when the user opens it, then the **Create Visa Cancellation** button should be visible.

That is the whole AC, and that is what this does — `add_visa_cancellation_button` in `visa_request.js`, following the shape of the existing `Reapply Visa` button.

## It is a placeholder, deliberately

The AC never says what the button *does*, and two things make it impossible to guess:

- There is **no `Visa Cancellation` DocType** — not in this repo, not on the live site. I checked both.
- The existing cancellation path is the workflow transition `Request to Cancel`, offered at `Pending Recruiter Confirmation` — the state *before* the visa exists to cancel. And `Completed` is `docstatus 1` while every cancellation state in that workflow is `docstatus 0`, so there is no legal Frappe transition from one to the other either.

The process owner's answer: **add the button as a placeholder; the DocType is coming from the BA and we rework then.** Clicking it says the process is not set up yet rather than failing. The handler carries a `ponytail:` marker naming exactly what replaces it.

## Verified

`test_visa_cancellation_button.py` — 4/4 passing on this bench. It pins the one thing the AC states: that the gate is `Completed`, that `Completed` is a state the Visa Request workflow actually has, and that it is still the submitted one. A state name living in a client script is the kind of thing a rename takes away with nothing to show for it.

No migrate needed — client script only. `bench build` / a hard refresh to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)