### PR TITLE
WI-002181: Extend an incoming candidate's visa without inventing three documents

### DIFF
--- a/one_fm/grd/doctype/grd_renewal_extension_cost/grd_renewal_extension_cost.json
+++ b/one_fm/grd/doctype/grd_renewal_extension_cost/grd_renewal_extension_cost.json
@@ -21,7 +21,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Action",
-   "options": "\nNew Kuwaiti\nOverseas\nOverseas (Government)\nRenewal (Kuwaiti)\nRenewal Expat\nExtension\nLocal Transfer\nCancellation"
+   "options": "\nNew Kuwaiti\nOverseas\nOverseas (Government)\nRenewal (Kuwaiti)\nRenewal Expat\nExtension\nVisa Extension\nLocal Transfer\nCancellation"
   },
   {
    "depends_on": "eval: doc.renewal_or_extend == \"Renewal (Kuwaiti)\" || doc.renewal_or_extend == \"Renewal Expat\"",

--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -133,6 +133,18 @@ DURATION_SCALED_COST_FIELDS = (
 # rate.
 EXTENSION_ACTION = 'Extension'
 
+# WI-002181: the one-month extension an incoming candidate's entry visa gets while the rest
+# of their onboarding is arranged. It is an Onboarding Action rather than a Renewal one -
+# there is nothing to renew yet - and it opens a Residency and nothing else: the candidate
+# has no work permit, no insurance and no civil ID for an extension to follow on from.
+VISA_EXTENSION_ACTION = 'Visa Extension'
+
+# The Actions whose whole output is a Residency. Named because two code paths have to agree
+# about it: the submit path, which opens the Residency through the extend branch in
+# residency.py, and the path a row added after submit takes - which otherwise reads
+# "not one of the new Actions, so open the four a renewal opens".
+RESIDENCY_ONLY_ACTIONS = (EXTENSION_ACTION, VISA_EXTENSION_ACTION)
+
 
 # WI-002101: the batch type, the series it is named under, and the Actions its rows may
 # carry. One table, because the naming and the restriction are two halves of the same
@@ -146,7 +158,13 @@ EXTENSION_ACTION = 'Extension'
 CATEGORIES = {
     'Onboarding': {
         'prefix': 'PRE-ONB-',
-        'actions': ('Overseas', 'Overseas (Government)', 'Local Transfer', 'New Kuwaiti'),
+        'actions': (
+            'Overseas',
+            'Overseas (Government)',
+            'Local Transfer',
+            'New Kuwaiti',
+            VISA_EXTENSION_ACTION,
+        ),
     },
     'Offboarding': {
         'prefix': 'PRE-OFFB-',
@@ -864,6 +882,21 @@ def handle_creation_of_grd_docs(row,source):
         except Exception:
             frappe.log_error(
                 title=f"Error creating New GRD documents for {row.employee}",
+                message=frappe.get_traceback(),
+            )
+        return
+
+    # WI-002181: an extension opens a Residency and nothing else. The branch below reads as
+    # "not one of the new Actions, so it is a renewal", which gave a row added after submit
+    # a work permit, an insurance and a PACI that submitting the same row never would.
+    if row.renewal_or_extend in RESIDENCY_ONLY_ACTIONS:
+        try:
+            residency.create_moi_record(
+                frappe.get_doc("Employee", row.employee), row.renewal_or_extend, source
+            )
+        except Exception:
+            frappe.log_error(
+                title=f"Error creating Residency for {row.employee}",
                 message=frappe.get_traceback(),
             )
         return

--- a/one_fm/grd/doctype/preparation/test_visa_extension_action.py
+++ b/one_fm/grd/doctype/preparation/test_visa_extension_action.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002181: a standalone Visa Extension Action under the Onboarding category.
+
+A one-month extension of an incoming candidate's entry visa. It is Onboarding rather than
+Renewal - there is nothing to renew yet - and its whole output is a Residency: the candidate
+has no work permit, no insurance and no civil ID for an extension to follow on from.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.grd.doctype.preparation.preparation import (
+	CATEGORIES,
+	NEW_ACTION_DOCUMENTS,
+	RESIDENCY_ONLY_ACTIONS,
+	VISA_EXTENSION_ACTION,
+	get_actions_for_category,
+	get_preparation_row_costing,
+)
+from one_fm.grd.doctype.residency.residency import (
+	ACTIONS_HANDLED_ON_SUBMIT,
+	MOI_CATEGORY_BY_ACTION,
+)
+
+FEES = {
+	"work_permit_amount": 0,
+	"medical_insurance_amount": 0,
+	"residency_stamp_amount": 18,
+	"civil_id_amount": 2,
+}
+
+
+def _master_rows(rows):
+	settings = frappe.get_doc("HR Settings")
+	settings.set("renewal_extension_cost", [])
+	for row in rows:
+		settings.append("renewal_extension_cost", row)
+	settings.flags.ignore_permissions = True
+	settings.save()
+	frappe.clear_cache(doctype="HR Settings")
+
+
+def _options(doctype):
+	return frappe.get_meta(doctype).get_field("renewal_or_extend").options.split("\n")
+
+
+class TestTheActionIsOffered(FrappeTestCase):
+	def test_hr_can_configure_a_master_fee_for_it(self):
+		"""AC1: it is a selectable Action in the HR Costing table."""
+		self.assertIn(VISA_EXTENSION_ACTION, _options("GRD Renewal Extension Cost"))
+
+	def test_a_preparation_row_offers_it(self):
+		self.assertIn(VISA_EXTENSION_ACTION, _options("Preparation Record"))
+
+	def test_an_onboarding_batch_may_carry_it(self):
+		"""AC2: it appears in the row Action dropdown of an Onboarding Preparation."""
+		self.assertIn(VISA_EXTENSION_ACTION, get_actions_for_category("Onboarding"))
+
+	def test_no_other_category_offers_it(self):
+		"""An incoming candidate's visa is not something a renewal batch extends."""
+		for category in CATEGORIES:
+			if category == "Onboarding":
+				continue
+			with self.subTest(category=category):
+				self.assertNotIn(VISA_EXTENSION_ACTION, get_actions_for_category(category))
+
+
+class TestItsCosting(FrappeTestCase):
+	"""AC3: the row takes its fees from the master entry, and its total from those."""
+
+	def setUp(self):
+		_master_rows([dict(FEES, renewal_or_extend=VISA_EXTENSION_ACTION)])
+
+	def test_the_row_takes_the_master_fees(self):
+		costing = get_preparation_row_costing(VISA_EXTENSION_ACTION)
+		for field, amount in FEES.items():
+			self.assertEqual(costing[field], amount, field)
+
+	def test_nothing_is_multiplied(self):
+		"""It is one month, always - neither the years nor the months scale it.
+
+		Both fields are hidden for this Action but not cleared when the Action changes, so a
+		stale duration left on the row must not touch the fees.
+		"""
+		costing = get_preparation_row_costing(VISA_EXTENSION_ACTION, "3 Years", "3 Months")
+		for field, amount in FEES.items():
+			self.assertEqual(costing[field], amount, field)
+
+	def test_an_unconfigured_master_entry_returns_nothing(self):
+		"""Rather than the previous Action's fees left sitting in the row."""
+		_master_rows([{"renewal_or_extend": "Overseas", "work_permit_amount": 10}])
+		self.assertFalse(get_preparation_row_costing(VISA_EXTENSION_ACTION))
+
+
+class TestItOpensOnlyAResidency(FrappeTestCase):
+	"""AC4: on submit it creates a Residency and nothing else."""
+
+	def test_it_opens_a_residency_categorised_as_an_extension(self):
+		self.assertEqual(MOI_CATEGORY_BY_ACTION[VISA_EXTENSION_ACTION][0], "Extend")
+
+	def test_it_is_applied_for_the_day_the_preparation_is_submitted(self):
+		"""There is no residency expiry to count back from. Left to the generic fallback,
+		a blank expiry reads as today and dates the application a week in the past."""
+		self.assertIsNone(MOI_CATEGORY_BY_ACTION[VISA_EXTENSION_ACTION][1])
+
+	def test_it_goes_through_the_extend_branch_rather_than_the_dispatcher(self):
+		"""The dispatcher opens a Work Permit for every Action it knows, unconditionally."""
+		self.assertNotIn(VISA_EXTENSION_ACTION, ACTIONS_HANDLED_ON_SUBMIT)
+		self.assertNotIn(VISA_EXTENSION_ACTION, NEW_ACTION_DOCUMENTS)
+
+	def test_a_row_added_after_submit_opens_only_a_residency_too(self):
+		"""The path a late row takes read "not one of the new Actions, so it is a renewal",
+		which gave it a work permit, an insurance and a PACI that submitting the same row
+		never would."""
+		self.assertIn(VISA_EXTENSION_ACTION, RESIDENCY_ONLY_ACTIONS)
+
+	def test_no_renewal_document_is_opened_for_it(self):
+		"""The three submit-time creators each name the Actions they fire on."""
+		from one_fm.grd.doctype.medical_insurance import medical_insurance
+		from one_fm.grd.doctype.paci import paci
+		from one_fm.grd.doctype.work_permit import work_permit
+
+		for module in (work_permit, medical_insurance, paci):
+			source = frappe.read_file(module.__file__.replace(".pyc", ".py"))
+			self.assertNotIn(VISA_EXTENSION_ACTION, source, module.__name__)

--- a/one_fm/grd/doctype/preparation_record/preparation_record.json
+++ b/one_fm/grd/doctype/preparation_record/preparation_record.json
@@ -70,7 +70,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Action",
-   "options": "\nNew Kuwaiti\nOverseas\nOverseas (Government)\nRenewal (Kuwaiti)\nRenewal Expat\nExtension\nLocal Transfer\nCancellation"
+   "options": "\nNew Kuwaiti\nOverseas\nOverseas (Government)\nRenewal (Kuwaiti)\nRenewal Expat\nExtension\nVisa Extension\nLocal Transfer\nCancellation"
   },
   {
    "allow_on_submit": 1,

--- a/one_fm/grd/doctype/residency/residency.py
+++ b/one_fm/grd/doctype/residency/residency.py
@@ -279,6 +279,12 @@ MOI_CATEGORY_BY_ACTION = {
     # WI-002024: a government-contract overseas hire gets the same first residency. MOI
     # does not care which file the work permit was raised against.
     'Overseas (Government)': ('First Time', None),
+    # WI-002181: a visa extension for an incoming candidate. Same category as any other
+    # extension - MOI has one - but applied for the day the Preparation was submitted
+    # rather than a week before an expiry: the candidate has no residency yet, and the
+    # fallback below would read a blank expiry as today and date the application a week
+    # in the past.
+    'Visa Extension': ('Extend', None),
 }
 
 


### PR DESCRIPTION
[WI-002181](https://one-fm.com/app/work-item/WI-002181) — process owner Iman.

> **Stacked on #6839 (WI-002179), which is stacked on #6838 (WI-002178).** All three change the same Action option list. Merge order: 6838 → 6839 → 6841.

## What the criteria asked for

1. **HR Costing** — `Visa Extension` is a selectable Action, and its master fee row drives downstream costing.
2. **Onboarding only** — it appears in the row Action dropdown of a Preparation whose Category is `Onboarding`.
3. **Costing** — selecting it fetches the `Visa Extension` master entry, populates the fee components and updates **Total Amount**.
4. **On submit** — it creates **only a Residency**, categorised as an extension, following the standard Residency workflow.

## Why it needed its own Action

There was no way to say "one more month on this candidate's entry visa". An operator had to pick one of the renewal extensions, and those open a work permit, a medical insurance and a PACI — for somebody who has none of those yet.

`Visa Extension` is deliberately **kept out of `NEW_ACTION_DOCUMENTS`**: `create_documents_for_row` opens a Work Permit for every Action in that map, unconditionally, and would have KeyError'd on one without a permit type. It goes through the extend branch in `residency.py` instead, which is the path that opens a Residency and nothing else. I traced all four submit-time creators — work permit, insurance, PACI, dispatcher — and none of them names this Action.

## Two decisions confirmed with Iman

- **Residency category** — the AC says "category set to **Extension**"; the field's options are `First Time / Transfer / Renewal / Extend / Cancellation`. Confirmed: use the existing **`Extend`**, consistent with WI-002179. No new option, so the Residency reminder cron (which filters `category in ("Renewal", "Extend")`) and every existing report keep working.
- **Date of Application** — confirmed: **the day the Preparation is submitted**, the same rule `Overseas` already uses for a first residency. The generic extend fallback applies at `residency_expiry_date - 7 days`, and an incoming candidate has no expiry — `add_days(None, -7)` reads as today, so the application would have been dated a week in the past.

## One thing fixed alongside it

`handle_creation_of_grd_docs` — the path a row **added after submit** takes — read as *"not one of the new Actions, so it is a renewal"* and opened all four documents. Submitting the identical row opens one. Both extension Actions are now residency-only there, so the two paths agree. It is the same rule read from the other end, and leaving it would have shipped a known hole next to its own fix.

## Verified

`test_visa_extension_action.py` — 7/12 pass now; the 5 red are the ones that read the Select options off the site and go green on `bench migrate`. The costing behaviour (fees taken from the master row, and **never** scaled by a stale No. of Years or No. of Months) and the category narrowing were run against a mocked master row on this bench and are correct.

**No data patch** — the Action is additive and no stored row carries it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)