### PR TITLE
WI-002308: Generate one set of cards per shift, not one per arrangement

### DIFF
--- a/one_fm/one_fm/doctype/transportation_shipment/shipment_generator.py
+++ b/one_fm/one_fm/doctype/transportation_shipment/shipment_generator.py
@@ -204,7 +204,17 @@ def build_demand_descriptors(nested_map: dict) -> list:
 					})
 
 			# ── OLM: aggregate across shifts by (stop_location, hour) ──
-			for parent_name in olm_by_site.get(operations_site, []):
+			#
+			# WI-002308: only when OSM has not already placed this shift. A site can be
+			# configured under both arrangements, and both branches used to run - so the
+			# same employees were generated onto two sets of cards at two different
+			# stops, and the board showed the shift's demand twice over with different
+			# names and headcounts.
+			#
+			# One Site Many Locations is configured against this specific site, so it is
+			# the more specific statement of where its staff are picked up, and it wins.
+			# Agreed with the process owner.
+			for parent_name in ([] if handled else olm_by_site.get(operations_site, [])):
 				olm_doc = olm_doc_map.get(parent_name)
 				if not olm_doc or not olm_doc.transport_stop_location:
 					continue

--- a/one_fm/one_fm/doctype/transportation_shipment/test_shipment_deduplication.py
+++ b/one_fm/one_fm/doctype/transportation_shipment/test_shipment_deduplication.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002308: one set of cards per shift requirement.
+
+A site configured under both One Site Many Locations and One Location Many Sites had
+both arrangements generate, so the same employees appeared on two sets of cards at two
+different stops - the board showing one shift's demand twice, with different names and
+different headcounts.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.one_fm.doctype.transportation_shipment.shipment_generator import (
+	_generation_key,
+	build_demand_descriptors,
+)
+from one_fm.one_fm.page.transportation_schedule.transportation_schedule import get_coords
+
+
+class TestOneArrangementPerShift(FrappeTestCase):
+	"""AC1: OSM and OLM never both place the same shift.
+
+	No site on this instance is configured under both today, so the pair is built here.
+	Without the fix both branches run and this class fails - which is the point of it.
+	"""
+
+	def setUp(self):
+		self.employees = frappe.get_all(
+			"Employee", filters={"status": "Active"}, fields=["name"], limit=4, pluck="name"
+		)
+		if not self.employees:
+			self.skipTest("no active employees on this site")
+
+		self.accommodation = _first_with_coords("Accommodation")
+		self.stop_a = _first_with_coords("Location")
+		self.stop_b = _first_with_coords("Location", exclude=self.stop_a)
+		if not self.accommodation or not self.stop_a or not self.stop_b:
+			self.skipTest("this site has no geocoded Accommodation and two Locations")
+
+		self.shift = frappe.db.get_value(
+			"Operations Shift", {"status": "Active", "site": ["is", "set"]}, ["name", "site"], as_dict=True
+		)
+		if not self.shift:
+			self.skipTest("no active Operations Shift with a site")
+
+		_clear_stop_configuration(self.shift.site)
+		self._configure_osm()
+		self._configure_olm()
+
+	def _configure_osm(self):
+		"""The site picks its own staff up at stop A."""
+		doc = frappe.new_doc("Site Transport Stop Location")
+		doc.site_transport_stop_location_name = "WI-002308 OSM"
+		doc.site_arrangement = "One Site Many Locations"
+		doc.site = self.shift.site
+		doc.append("transport_stop_locations", {"location": self.stop_a})
+		doc.insert(ignore_permissions=True)
+
+	def _configure_olm(self):
+		"""And stop B is a shared stop that claims the same site."""
+		doc = frappe.new_doc("Site Transport Stop Location")
+		doc.site_transport_stop_location_name = "WI-002308 OLM"
+		doc.site_arrangement = "One Location Many Sites"
+		doc.transport_stop_location = self.stop_b
+		doc.append("sites", {"sites": self.shift.site})
+		doc.insert(ignore_permissions=True)
+
+	def _demands(self):
+		nested = {
+			"Camp": {"lookup_id": self.accommodation, "shifts": {self.shift.name: self.employees}}
+		}
+		return build_demand_descriptors(nested)
+
+	def test_only_one_arrangement_places_the_shift(self):
+		routings = {d["routing"] for d in self._demands()}
+
+		self.assertEqual(routings, {"OSM"}, f"two arrangements generated: {routings}")
+
+	def test_nobody_is_carried_on_two_cards(self):
+		"""The symptom the dispatcher sees: the same person counted twice, at two stops."""
+		seen = set()
+		for demand in self._demands():
+			for emp in demand["employees"]:
+				self.assertNotIn(emp["id"], seen, f"{emp['id']} is on two cards")
+				seen.add(emp["id"])
+
+	def test_the_shift_is_placed_at_the_site_specific_stop(self):
+		"""One Site Many Locations is the more specific statement of where its staff
+		are picked up, so it is the one that wins."""
+		stops = {d["stop_location"] for d in self._demands()}
+
+		self.assertEqual(stops, {self.stop_a})
+
+	def test_an_olm_only_site_still_generates(self):
+		"""The fix must not switch OLM off - only stop it doubling up with OSM."""
+		_clear_stop_configuration(self.shift.site)
+		self._configure_olm()
+
+		demands = self._demands()
+		self.assertEqual({d["routing"] for d in demands}, {"OLM"})
+		self.assertEqual({d["stop_location"] for d in demands}, {self.stop_b})
+
+
+class TestGenerationIsIdempotent(FrappeTestCase):
+	"""AC2: running generation again re-uses the record instead of adding another."""
+
+	def test_the_key_is_stable_for_the_same_demand(self):
+		demand = {
+			"accommodation": "ACC-01",
+			"group_token": "SHIFT-01",
+			"stop_location": "LOC-01",
+			"routing": "OSM",
+		}
+		self.assertEqual(_generation_key(demand, "Outward"), _generation_key(demand, "Outward"))
+
+	def test_the_two_directions_do_not_collide(self):
+		"""They share a pair_group but must not share a key, or one overwrites the other."""
+		demand = {
+			"accommodation": "ACC-01",
+			"group_token": "SHIFT-01",
+			"stop_location": "LOC-01",
+			"routing": "OSM",
+		}
+		out_key, out_pair = _generation_key(demand, "Outward")
+		ret_key, ret_pair = _generation_key(demand, "Return")
+
+		self.assertNotEqual(out_key, ret_key)
+		self.assertEqual(out_pair, ret_pair)
+
+	def test_the_key_field_is_long_enough_to_hold_one(self):
+		"""Truncation is how Outward and Return collided before - the direction is the
+		last segment, so a short field drops exactly the part that distinguishes them."""
+		for fieldname in ("generation_key", "pair_group"):
+			field = frappe.get_meta("Transportation Shipment").get_field(fieldname)
+			self.assertGreaterEqual(int(field.length or 140), 500, fieldname)
+
+
+def _first_with_coords(doctype, exclude=None):
+	"""A record the generator will accept - it skips anything it cannot place on a map."""
+	for row in frappe.get_all(doctype, fields=["name"], limit=60):
+		if row.name != exclude and get_coords(doctype, row.name):
+			return row.name
+	return None
+
+
+def _clear_stop_configuration(site):
+	"""Take the site out of every existing stop arrangement, so the test starts from a
+	site configured exactly the way the test configures it. Rolled back with the case."""
+	for name in frappe.get_all(
+		"Site Transport Stop Location", filters={"site": site}, pluck="name"
+	):
+		frappe.delete_doc("Site Transport Stop Location", name, ignore_permissions=True, force=True)
+
+	for row in frappe.get_all(
+		"Location To Site Mapping",
+		filters={"parenttype": "Site Transport Stop Location", "sites": site},
+		fields=["parent"],
+	):
+		if frappe.db.exists("Site Transport Stop Location", row.parent):
+			frappe.delete_doc(
+				"Site Transport Stop Location", row.parent, ignore_permissions=True, force=True
+			)


### PR DESCRIPTION
[WI-002308](https://one-fm.com/app/work-item/WI-002308) — process owner Irfan.

> **Stacked on #6847 (WI-002307), which is stacked on #6846 (WI-002306).** Merge order: 6846 → 6847 → 6848.

## The bug, exactly

`build_demand_descriptors` evaluates the OSM arrangement and then the OLM arrangement for the same shift, and **both branches set `handled` and both emit demands**. A site configured under *both* One Site Many Locations and One Location Many Sites therefore generated a full set of cards from each — the same employees, at two different stops, with different names and different headcounts. The dispatcher had no way to tell which was the real one, and the seats were counted twice.

## AC1 — which arrangement wins

Confirmed with the process owner: **OSM**. One Site Many Locations is configured against that specific site, so it is the more specific statement of where its staff are picked up. A site with only a shared stop is untouched — this stops OLM doubling up with OSM, it does not switch OLM off, and there is a test saying so.

## AC2 — falls out of AC1

Reruns were already idempotent: each demand carries a `generation_key`, an existing record is refreshed rather than duplicated, and `_prune_stale` deletes unassigned cards whose key has disappeared. So once only one arrangement generates, the losing arrangement's unassigned cards are cleaned up on the next Generate run without a patch.

**Worth knowing:** cards already *assigned* to a vehicle are never pruned, by design. Any duplicate that has already been planned onto a lane has to be removed from the plan by hand — the generator will not take work off a dispatcher's board.

## About the test

No site on this bench is configured both ways today, so the test **builds the pair** — an OSM record and an OLM record naming the same site — rather than hunting for one and skipping.

That matters: my first version of this test looked for a dual-configured site, found one that only looked dual (the OLM child row pointed at an OSM-typed parent), and **passed with the fix removed**. The rewritten version was verified by removing the fix again: three checks fail, one of them naming the employee found on two cards at once.

`test_shipment_deduplication.py` — **7/7 passing** with the fix, 3 failing without it.

No migrate needed. Run **Generate Shipments** after deploy to prune the duplicates already on the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)