### PR TITLE
WI-002309: Show the dispatcher how much of the day is still unplanned

### DIFF
--- a/one_fm/one_fm/page/transportation_schedule/test_schedule_progress_counters.py
+++ b/one_fm/one_fm/page/transportation_schedule/test_schedule_progress_counters.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002309: Total Cards Planned / Total Cards Remaining on the schedule header.
+
+The counters live in the page's Vue computed block, so they are extracted and *run*
+here rather than asserted against as source text. A source check passes just as
+happily when the expression is present and wrong - which is how a canvas fix has been
+reported done twice before while the browser still disagreed.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+PAGE_JS = ("one_fm", "one_fm", "page", "transportation_schedule", "transportation_schedule.js")
+
+# Six cards on the board, two of them already dropped on a lane.
+CARDS = [{"id": f"TSHIP-{n}"} for n in range(1, 7)]
+ASSIGNED = ["TSHIP-1", "TSHIP-2"]
+
+
+def _computed(js, name):
+	"""The body of one computed property, as a callable JS function expression."""
+	match = re.search(rf"\n\s*{name}\(\) \{{(.*?)\n\s*\}},", js, re.S)
+	if not match:
+		raise AssertionError(f"computed {name!r} not found in the page script")
+	return "function () {" + match.group(1) + "\n}"
+
+
+class TestTheCounters(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.js = frappe.read_file(frappe.get_app_path(*PAGE_JS))
+
+	def _run(self, cards=CARDS, assigned=ASSIGNED, filtered=None):
+		"""Evaluate the three computed properties against a board state."""
+		if not shutil.which("node"):
+			self.skipTest("node is not available to run the page script")
+
+		harness = f"""
+			const planned = {_computed(self.js, 'totalCardsPlanned')};
+			const remaining = {_computed(self.js, 'totalCardsRemaining')};
+			const allPlanned = {_computed(self.js, 'allCardsPlanned')};
+			const state = {{
+				planData: {{ shipment_cards: {json.dumps(cards)} }},
+				assignedCards: new Set({json.dumps(assigned)}),
+				searchQuery: {json.dumps(filtered or "")},
+			}};
+			state.totalCardsPlanned = planned.call(state);
+			state.totalCardsRemaining = remaining.call(state);
+			console.log(JSON.stringify({{
+				planned: state.totalCardsPlanned,
+				remaining: state.totalCardsRemaining,
+				done: allPlanned.call(state),
+			}}));
+		"""
+		out = subprocess.run(
+			["node", "-e", harness], capture_output=True, text=True, timeout=30
+		)
+		self.assertEqual(out.returncode, 0, out.stderr)
+		return json.loads(out.stdout)
+
+	def test_it_counts_what_is_on_the_lanes_and_what_is_left(self):
+		"""AC1: the two summary metrics."""
+		result = self._run()
+
+		self.assertEqual(result["planned"], 2)
+		self.assertEqual(result["remaining"], 4)
+
+	def test_the_two_always_account_for_every_card(self):
+		result = self._run()
+
+		self.assertEqual(result["planned"] + result["remaining"], len(CARDS))
+
+	def test_a_drop_moves_one_card_from_remaining_to_planned(self):
+		"""AC2: assigning a third card increments one and decrements the other."""
+		before = self._run()
+		after = self._run(assigned=ASSIGNED + ["TSHIP-3"])
+
+		self.assertEqual(after["planned"], before["planned"] + 1)
+		self.assertEqual(after["remaining"], before["remaining"] - 1)
+
+	def test_unassigning_moves_it_back(self):
+		before = self._run()
+		after = self._run(assigned=ASSIGNED[:1])
+
+		self.assertEqual(after["planned"], before["planned"] - 1)
+		self.assertEqual(after["remaining"], before["remaining"] + 1)
+
+	def test_searching_does_not_change_the_totals(self):
+		"""These are scheduling progress, not a view of the filtered sidebar. A counter
+		that drops because somebody typed in the search box is worse than none."""
+		self.assertEqual(self._run(), self._run(filtered="mahboula"))
+
+	def test_an_empty_board_reads_zero_and_zero(self):
+		result = self._run(cards=[], assigned=[])
+
+		self.assertEqual((result["planned"], result["remaining"]), (0, 0))
+		self.assertFalse(result["done"], "nothing planned is not the same as all planned")
+
+	def test_it_says_when_everything_is_placed(self):
+		result = self._run(assigned=[c["id"] for c in CARDS])
+
+		self.assertEqual(result["remaining"], 0)
+		self.assertTrue(result["done"])
+
+
+class TestTheCountersAreOnTheHeader(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.js = frappe.read_file(frappe.get_app_path(*PAGE_JS))
+
+	def test_both_metrics_are_rendered_in_the_header_toolbar(self):
+		header = re.search(r'<div id="rp-header-right">.*?\n  </div>', self.js, re.S)
+		self.assertIsNotNone(header, msg="header toolbar not found")
+
+		self.assertIn("Total Cards Planned", header.group(0))
+		self.assertIn("Total Cards Remaining", header.group(0))

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
@@ -179,6 +179,22 @@ function mountRoutePlannerApp(wrapper, data) {
                     .map(([value, label]) => ({ value, label }));
             },
 
+            // WI-002309: how much of today's demand is placed, and how much is left.
+            // Counted over every card rather than the filtered pool, because this is
+            // scheduling progress - it must not move because somebody typed in the
+            // search box. The sidebar keeps its own filtered count next to the title.
+            totalCardsPlanned() {
+                return this.assignedCards.size;
+            },
+
+            totalCardsRemaining() {
+                return this.planData.shipment_cards.filter(c => !this.assignedCards.has(c.id)).length;
+            },
+
+            allCardsPlanned() {
+                return this.totalCardsPlanned > 0 && this.totalCardsRemaining === 0;
+            },
+
             poolGroups() {
                 const map = {};
                 this.filteredPoolCards.forEach(c => {
@@ -3856,6 +3872,20 @@ function injectRPVueTemplate() {
       </div>
     </div>
     <div id="rp-header-right">
+      <!-- WI-002309: scheduling progress at a glance. Both counters are derived from
+           the same reactive state the lanes are drawn from, so a drag updates them
+           with the block rather than on the next load. -->
+      <div class="rp-metrics">
+        <div class="rp-metric" title="Shipment cards placed on a vehicle lane">
+          <span class="rp-metric-label">Total Cards Planned</span>
+          <span class="rp-metric-value">{{ totalCardsPlanned }}</span>
+        </div>
+        <div :class="['rp-metric', allCardsPlanned ? 'rp-metric-done' : '']"
+             title="Shipment cards still waiting in the unassigned sidebar">
+          <span class="rp-metric-label">Total Cards Remaining</span>
+          <span class="rp-metric-value">{{ totalCardsRemaining }}</span>
+        </div>
+      </div>
       <div v-if="currentPlan" class="text-muted" style="font-size:12px; margin-right: 12px; display: flex; align-items: center; gap: 4px; color: var(--green, #16a34a)">
         <span class="rp-icon" style="font-size:16px;">check_circle</span> Auto-Saved
       </div>
@@ -4875,6 +4905,19 @@ function injectRPStyles() {
             border-right: 1px solid var(--md-sys-color-outline-variant);
             display: flex; flex-direction: column; overflow: hidden;
         }
+        /* WI-002309: the two progress counters in the header toolbar. */
+        .rp-metrics { display: flex; gap: 8px; margin-right: 12px; }
+        .rp-metric {
+          display: flex; flex-direction: column; align-items: flex-start;
+          padding: 4px 10px; border-radius: 6px; line-height: 1.2;
+          border: 1px solid var(--border-color, #d1d5db);
+          background: var(--fg-color, #fff);
+        }
+        .rp-metric-label { font-size: 10px; text-transform: uppercase; letter-spacing: .04em; color: var(--text-muted, #6b7280); white-space: nowrap; }
+        .rp-metric-value { font-size: 16px; font-weight: 600; color: var(--text-color, #111827); }
+        .rp-metric-done { border-color: var(--green, #16a34a); }
+        .rp-metric-done .rp-metric-value { color: var(--green, #16a34a); }
+
         #rp-pool-header {
             display: flex; align-items: center; justify-content: space-between;
             padding: 12px 16px; border-bottom: 1px solid var(--md-sys-color-surface-container-high); flex-shrink: 0;
@@ -5382,6 +5425,11 @@ function injectRPStyles() {
         /* ── Dark mode: Pool panel ── */
         #rp-shell.rp-dark #rp-pool-panel { background: var(--md-sys-color-surface); border-color: var(--md-sys-color-outline-variant); }
         #rp-shell.rp-dark #rp-pool-header { border-color: var(--md-sys-color-outline-variant); }
+        #rp-shell.rp-dark .rp-metric {
+          border-color: var(--md-sys-color-outline-variant);
+          background: var(--md-sys-color-surface-container, #1f2937);
+        }
+        #rp-shell.rp-dark .rp-metric-value { color: var(--md-sys-color-on-surface, #e5e7eb); }
         #rp-shell.rp-dark #rp-search-input {
             background: var(--md-sys-color-surface-container-high); color: var(--md-sys-color-on-surface);
             border-color: var(--md-sys-color-outline-variant);


### PR DESCRIPTION
[WI-002309](https://one-fm.com/app/work-item/WI-002309) — process owner Irfan.

Standalone off staging — client script only, no overlap with #6846–#6848.

## What the criteria asked for

- **AC1** — two summary metric cards in the header toolbar: **Total Cards Planned** (cards assigned to vehicle timeline lanes) and **Total Cards Remaining** (unassigned cards in the sidebar).
- **AC2** — dragging a card onto a lane increments one and decrements the other immediately, with no page refresh.

## How

Both are Vue computed properties over the state the lanes are already drawn from — `assignedCards` and `planData.shipment_cards` — so AC2 is reactivity rather than new plumbing: the counters move with the block, and with an unassign too. Remaining turns green when it reaches zero.

## One judgement call

The counters are computed over **every** card, not the filtered pool.

The sidebar already prints its own filtered count beside the title (`N cards`), and that answers a different question. A *progress* counter that drops because somebody typed in the search box or picked a shift-start filter would be worse than no counter at all — it would say the day was nearly planned when it was only nearly filtered. The two counts now answer their own questions and neither has to lie.

## About the test

The counters are **extracted from the page script and executed under node**, not asserted against as source text. That is deliberate: a source-assertion test has passed on this canvas before while the browser still rendered the wrong thing, so this runs the real expressions against a six-card board and checks the arithmetic — including that a drop moves exactly one card across, that an unassign moves it back, that the two always account for every card, and that a search query changes neither.

`test_schedule_progress_counters.py` — **8/8 passing**.

No migrate needed. The page script is served raw, so a hard refresh picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)