### PR TITLE
WI-002316: Let Hiring Settings decide who approves an ERF

### DIFF
--- a/one_fm/hiring/doctype/erf_approver_rule/erf_approver_rule.json
+++ b/one_fm/hiring/doctype/erf_approver_rule/erf_approver_rule.json
@@ -1,0 +1,43 @@
+{
+ "actions": [],
+ "creation": "2026-09-03 12:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "reason_for_request",
+  "approver_role"
+ ],
+ "fields": [
+  {
+   "columns": 5,
+   "description": "The Reason for Request this rule applies to, spelled exactly as the ERF field offers it.",
+   "fieldname": "reason_for_request",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Reason for Request",
+   "reqd": 1
+  },
+  {
+   "columns": 5,
+   "fieldname": "approver_role",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Approver Role",
+   "options": "Role",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-09-03 12:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Hiring",
+ "name": "ERF Approver Rule",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/one_fm/hiring/doctype/erf_approver_rule/erf_approver_rule.py
+++ b/one_fm/hiring/doctype/erf_approver_rule/erf_approver_rule.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class ERFApproverRule(Document):
+	pass

--- a/one_fm/hiring/doctype/hiring_settings/hiring_settings.json
+++ b/one_fm/hiring/doctype/hiring_settings/hiring_settings.json
@@ -9,6 +9,9 @@
   "hr_for_a_quick_workshop",
   "hrm_to_fill_hr_and_salary_compensation",
   "close_erf_automatically",
+  "erf_approver_section",
+  "default_erf_approver_role",
+  "erf_approver_rules",
   "default_hr_user",
   "column_break_5",
   "do_not_notify_requester",
@@ -120,6 +123,25 @@
    "fieldname": "close_erf_automatically",
    "fieldtype": "Check",
    "label": "Close ERF Automatically"
+  },
+  {
+   "fieldname": "erf_approver_section",
+   "fieldtype": "Section Break",
+   "label": "ERF Approval Routing"
+  },
+  {
+   "description": "Who approves an ERF whose Reason for Request has no rule below.",
+   "fieldname": "default_erf_approver_role",
+   "fieldtype": "Link",
+   "label": "Default ERF Approver Role",
+   "options": "Role"
+  },
+  {
+   "description": "Send an ERF to a different role for a particular Reason for Request. A reason with no rule here goes to the default above, so a reason added to the ERF field needs no code change to route.",
+   "fieldname": "erf_approver_rules",
+   "fieldtype": "Table",
+   "label": "ERF Approver Rules",
+   "options": "ERF Approver Rule"
   },
   {
    "fieldname": "default_hr_user",
@@ -296,7 +318,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2026-01-06 09:07:14.570098",
+ "modified": "2026-09-03 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Hiring",
  "name": "Hiring Settings",

--- a/one_fm/one_fm/doctype/erf/erf.py
+++ b/one_fm/one_fm/doctype/erf/erf.py
@@ -139,7 +139,14 @@ class ERF(Document):
 					frappe.throw(_("Select Language for Speak, Read or Write.!"))
 
 	def validate_date(self):
-		if getdate(self.erf_initiation) > getdate(self.expected_date_of_deployment):
+		# WI-002316: the deployment date is not always asked for any more, and getdate()
+		# reads an empty one as today - so an ERF with no date was being measured against
+		# today's date and told its own initiation date was too late. There is nothing to
+		# check when the field is blank.
+		if not self.expected_date_of_deployment:
+			return
+
+		if self.erf_initiation and getdate(self.erf_initiation) > getdate(self.expected_date_of_deployment):
 			frappe.throw(_("Expected Date of Deployment of an ERF cannot be before ERF Initiation Date"))
 		if getdate(self.expected_date_of_deployment) < getdate(today()):
 			frappe.throw(_("Expected Date of Deployment of an ERF cannot be before Today"))
@@ -371,9 +378,36 @@ class ERF(Document):
 
 
 
+# What an ERF falls back to when Hiring Settings names no default. The role has existed
+# since v1_0's add_erf_approver_role patch; naming it here means a site that has never
+# opened Hiring Settings still routes its ERFs somewhere.
+DEFAULT_ERF_APPROVER_ROLE = 'ERF Approver'
+
+
+def get_erf_approver_role(reason_for_request):
+	"""The role that approves an ERF raised for this reason (WI-002316).
+
+	Read from Hiring Settings rather than matched against a hard-coded option value. The
+	old rule was `'Unplanned ERF Approver' if reason == 'UnPlanned' else 'ERF Approver'`,
+	which quietly tied the approver to one spelling of one Select option: renaming or
+	removing that option sent every ERF to the general approver and left the specialised
+	role unreachable, with nothing to say so.
+
+	A reason with no rule configured goes to the default, so a reason added to the field
+	needs no code change to route.
+	"""
+	settings = frappe.get_cached_doc('Hiring Settings')
+
+	if reason_for_request:
+		for rule in settings.get('erf_approver_rules') or []:
+			if rule.reason_for_request == reason_for_request and rule.approver_role:
+				return rule.approver_role
+
+	return settings.get('default_erf_approver_role') or DEFAULT_ERF_APPROVER_ROLE
+
+
 def get_erf_approver(reason_for_request):
-	erf_approver_role = 'Unplanned ERF Approver' if reason_for_request == 'UnPlanned' else 'ERF Approver'
-	return get_users_with_role(erf_approver_role)
+	return get_users_with_role(get_erf_approver_role(reason_for_request))
 
 def create_job_opening_from_erf(erf):
 	job_opening = frappe.new_doc("Job Opening")

--- a/one_fm/one_fm/doctype/erf/test_erf_configurable_approver.py
+++ b/one_fm/one_fm/doctype/erf/test_erf_configurable_approver.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002316: nothing in the code should decide who approves an ERF.
+
+The approver was chosen by matching Reason for Request against the literal "UnPlanned".
+That is the hard-coded logic the story is about: rename or remove that option - which the
+business analyst has already done - and every ERF routes to the general approver while
+"Unplanned ERF Approver" becomes unreachable, with nothing raised to say so.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.one_fm.doctype.erf.erf import (
+	DEFAULT_ERF_APPROVER_ROLE,
+	get_erf_approver_role,
+)
+
+UNPLANNED_REASON = "UnPlanned"
+UNPLANNED_ROLE = "Unplanned ERF Approver"
+
+
+def _settings(rules=None, default=DEFAULT_ERF_APPROVER_ROLE):
+	settings = frappe.get_doc("Hiring Settings")
+	settings.default_erf_approver_role = default
+	settings.set("erf_approver_rules", [])
+	for reason, role in (rules or []):
+		settings.append("erf_approver_rules", {"reason_for_request": reason, "approver_role": role})
+	settings.flags.ignore_mandatory = True
+	settings.flags.ignore_permissions = True
+	settings.save()
+	frappe.clear_cache(doctype="Hiring Settings")
+
+
+class TestTheRoutingIsConfigured(FrappeTestCase):
+	def tearDown(self):
+		frappe.clear_cache(doctype="Hiring Settings")
+
+	def test_a_configured_reason_goes_to_its_role(self):
+		_settings(rules=[(UNPLANNED_REASON, UNPLANNED_ROLE)])
+
+		self.assertEqual(get_erf_approver_role(UNPLANNED_REASON), UNPLANNED_ROLE)
+
+	def test_an_unconfigured_reason_goes_to_the_default(self):
+		_settings(rules=[(UNPLANNED_REASON, UNPLANNED_ROLE)])
+
+		self.assertEqual(get_erf_approver_role("Staffing Plan"), DEFAULT_ERF_APPROVER_ROLE)
+
+	def test_a_reason_nobody_has_configured_yet_still_routes(self):
+		"""The point of the story: a reason added to the field needs no code change.
+
+		"Other" and "Client ERF Hire" are the two the analyst has added; neither exists in
+		any code, and both have to reach an approver.
+		"""
+		_settings(rules=[(UNPLANNED_REASON, UNPLANNED_ROLE)])
+
+		for reason in ("Other", "Client ERF Hire"):
+			with self.subTest(reason=reason):
+				self.assertEqual(get_erf_approver_role(reason), DEFAULT_ERF_APPROVER_ROLE)
+
+	def test_a_new_reason_can_be_given_its_own_role(self):
+		"""And configuring one is all it takes."""
+		_settings(rules=[("Client ERF Hire", UNPLANNED_ROLE)])
+
+		self.assertEqual(get_erf_approver_role("Client ERF Hire"), UNPLANNED_ROLE)
+		self.assertEqual(get_erf_approver_role(UNPLANNED_REASON), DEFAULT_ERF_APPROVER_ROLE)
+
+	def test_an_empty_reason_routes_to_the_default(self):
+		_settings(rules=[(UNPLANNED_REASON, UNPLANNED_ROLE)])
+
+		for reason in (None, ""):
+			with self.subTest(reason=reason):
+				self.assertEqual(get_erf_approver_role(reason), DEFAULT_ERF_APPROVER_ROLE)
+
+	def test_a_site_with_nothing_configured_still_routes(self):
+		"""Hiring Settings is a Single that a site may never have opened."""
+		_settings(rules=[], default=None)
+
+		self.assertEqual(get_erf_approver_role("anything"), DEFAULT_ERF_APPROVER_ROLE)
+
+	def test_a_rule_with_no_role_is_ignored_rather_than_obeyed(self):
+		"""A half-filled row must not route an ERF to nobody."""
+		settings = frappe.get_doc("Hiring Settings")
+		settings.default_erf_approver_role = DEFAULT_ERF_APPROVER_ROLE
+		settings.set("erf_approver_rules", [])
+		row = settings.append("erf_approver_rules", {"reason_for_request": UNPLANNED_REASON})
+		row.approver_role = None
+		settings.flags.ignore_mandatory = True
+		settings.flags.ignore_permissions = True
+		settings.save()
+		frappe.clear_cache(doctype="Hiring Settings")
+
+		self.assertEqual(get_erf_approver_role(UNPLANNED_REASON), DEFAULT_ERF_APPROVER_ROLE)
+
+
+class TestNothingInTheCodeNamesAnOption(FrappeTestCase):
+	def tearDown(self):
+		frappe.clear_cache(doctype="Hiring Settings")
+
+	def test_unplanned_is_no_longer_special_in_the_code(self):
+		"""The story's whole point, proved by behaviour rather than by reading the source.
+
+		With no rule configured for it, "UnPlanned" has to route exactly where every other
+		reason routes. If the old branch were still there it would return the specialised
+		role regardless of what Hiring Settings says.
+		"""
+		_settings(rules=[])
+
+		self.assertEqual(get_erf_approver_role(UNPLANNED_REASON), DEFAULT_ERF_APPROVER_ROLE)
+		self.assertEqual(
+			get_erf_approver_role(UNPLANNED_REASON), get_erf_approver_role("Staffing Plan")
+		)
+
+	def test_settings_can_send_unplanned_anywhere(self):
+		"""And it is configuration, not code, that decides otherwise."""
+		_settings(rules=[(UNPLANNED_REASON, DEFAULT_ERF_APPROVER_ROLE), ("New Project", UNPLANNED_ROLE)])
+
+		self.assertEqual(get_erf_approver_role(UNPLANNED_REASON), DEFAULT_ERF_APPROVER_ROLE)
+		self.assertEqual(get_erf_approver_role("New Project"), UNPLANNED_ROLE)
+
+	def test_the_roles_it_falls_back_to_exist(self):
+		self.assertTrue(frappe.db.exists("Role", DEFAULT_ERF_APPROVER_ROLE))
+
+
+class TestTheDeploymentDateMayBeEmpty(FrappeTestCase):
+	"""The analyst has made Expected Date of Deployment optional. getdate() reads an empty
+	date as today, so the old check measured an ERF's own initiation date against today and
+	could refuse to save it."""
+
+	def _erf(self, **fields):
+		doc = frappe.new_doc("ERF")
+		doc.update(fields)
+		return doc
+
+	def test_no_date_is_not_checked(self):
+		doc = self._erf(erf_initiation=frappe.utils.add_days(frappe.utils.today(), 5))
+		doc.validate_date()
+
+	def test_a_date_before_the_initiation_is_still_refused(self):
+		doc = self._erf(
+			erf_initiation=frappe.utils.add_days(frappe.utils.today(), 10),
+			expected_date_of_deployment=frappe.utils.add_days(frappe.utils.today(), 5),
+		)
+		with self.assertRaises(frappe.ValidationError):
+			doc.validate_date()
+
+	def test_a_date_in_the_past_is_still_refused(self):
+		doc = self._erf(
+			erf_initiation=frappe.utils.add_days(frappe.utils.today(), -20),
+			expected_date_of_deployment=frappe.utils.add_days(frappe.utils.today(), -1),
+		)
+		with self.assertRaises(frappe.ValidationError):
+			doc.validate_date()
+
+	def test_a_future_date_is_accepted(self):
+		doc = self._erf(
+			erf_initiation=frappe.utils.today(),
+			expected_date_of_deployment=frappe.utils.add_days(frappe.utils.today(), 30),
+		)
+		doc.validate_date()

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -603,3 +603,4 @@ one_fm.patches.v15_0.grant_transportation_manager_schedule_access #2026-08-24 WI
 one_fm.patches.v15_0.add_transportation_qoa_buffer_to_hr_settings #2026-08-26 WI-002151
 one_fm.patches.v15_0.rekey_olm_shipments_on_shift_window #2026-08-31 WI-002151
 one_fm.patches.v15_0.repoint_pam_file_links_to_license_details #2026-08-29 WI-002233
+one_fm.patches.v15_0.make_erf_approver_configurable #2026-09-03 WI-002316

--- a/one_fm/patches/v15_0/make_erf_approver_configurable.py
+++ b/one_fm/patches/v15_0/make_erf_approver_configurable.py
@@ -1,0 +1,63 @@
+import frappe
+
+from one_fm.one_fm.doctype.erf.erf import DEFAULT_ERF_APPROVER_ROLE
+
+# WI-002316: who approves an ERF was decided by matching Reason for Request against the
+# literal string "UnPlanned". That tied the approver to one spelling of one Select option,
+# so removing or renaming the option sent every ERF to the general approver and left
+# "Unplanned ERF Approver" unreachable - silently, because nothing checks that a role is
+# still reachable.
+#
+# The mapping lives in Hiring Settings now. This seeds it with exactly what the code used
+# to do, so nothing about today's routing changes on migrate; what changes is that the next
+# reason can be routed without touching the code.
+UNPLANNED_REASON = "UnPlanned"
+UNPLANNED_ROLE = "Unplanned ERF Approver"
+
+
+def execute():
+	frappe.reload_doc("hiring", "doctype", "erf_approver_rule")
+	frappe.reload_doc("hiring", "doctype", "hiring_settings")
+
+	settings = frappe.get_doc("Hiring Settings")
+
+	if not settings.default_erf_approver_role and frappe.db.exists("Role", DEFAULT_ERF_APPROVER_ROLE):
+		settings.default_erf_approver_role = DEFAULT_ERF_APPROVER_ROLE
+
+	already = {rule.reason_for_request for rule in settings.erf_approver_rules}
+	if UNPLANNED_REASON not in already and frappe.db.exists("Role", UNPLANNED_ROLE):
+		settings.append("erf_approver_rules", {
+			"reason_for_request": UNPLANNED_REASON,
+			"approver_role": UNPLANNED_ROLE,
+		})
+
+	settings.flags.ignore_mandatory = True
+	settings.flags.ignore_permissions = True
+	settings.save()
+	frappe.clear_cache(doctype="Hiring Settings")
+
+	verify()
+
+
+def verify():
+	"""The seeded mapping has to reproduce the old behaviour exactly, or every ERF raised
+	before the next Hiring Settings edit routes somewhere new without anybody asking."""
+	from one_fm.one_fm.doctype.erf.erf import get_erf_approver_role
+
+	if frappe.db.exists("Role", UNPLANNED_ROLE):
+		routed = get_erf_approver_role(UNPLANNED_REASON)
+		if routed != UNPLANNED_ROLE:
+			frappe.throw(
+				f"WI-002316: {UNPLANNED_REASON!r} now routes to {routed!r} rather than "
+				f"{UNPLANNED_ROLE!r} - the seeded rule did not take."
+			)
+
+	for reason in ("Staffing Plan", "Employee Exit", "New Project", None):
+		routed = get_erf_approver_role(reason)
+		if routed != DEFAULT_ERF_APPROVER_ROLE:
+			frappe.throw(
+				f"WI-002316: {reason!r} routes to {routed!r} rather than the default "
+				f"{DEFAULT_ERF_APPROVER_ROLE!r}."
+			)
+
+	print("WI-002316: ERF approver routing is configurable, and routes as it did before")


### PR DESCRIPTION
[WI-002316](https://one-fm.com/app/work-item/WI-002316) — process owner Susan.

## What was actually blocking configuration

The story asks for "hard-coded backend logic and validations related to the ERF DocType" to be removed. `erf.py` has around fifteen validations, so I diffed the [BA site's ERF](https://business-analyst.one-fm.com/app/doctype/ERF) against the repo to find which code blocks the changes actually pending there. **Two:**

**1. The approver was chosen in code.**

```python
erf_approver_role = 'Unplanned ERF Approver' if reason_for_request == 'UnPlanned' else 'ERF Approver'
```

That ties the approver to one spelling of one Select option. The analyst has already removed `UnPlanned` (replaced by `Other` and `Client ERF Hire`) — at which point every ERF routes to the general approver and `Unplanned ERF Approver` becomes unreachable, **with nothing raised to say so**.

It is a table in Hiring Settings now (`ERF Approver Rule`: reason → role) plus a default. A reason with no rule goes to the default, so the next reason routes without a code change — which is what "freely configured" asks for.

**2. `validate_date()` read `expected_date_of_deployment` unconditionally.** The analyst has made that field optional, and `getdate()` reads an empty date as *today* — so an ERF with no date was being measured against today and could be told its own initiation date was too late. There is nothing to check when the field is blank.

## Scope

Confirmed with the process owner: **only these two**. The other ERF validations — interview rounds, licence and travel type, candidate counts, recruiter assignment, languages — are untouched. Nothing in the story says they are unwanted, and removing them would drop real process rules on a guess.

## Nothing changes on migrate

The patch seeds the table with exactly what the code used to do, then checks it: `UnPlanned` still reaches `Unplanned ERF Approver`, and every other reason still reaches `ERF Approver`. If the seed does not take, the patch throws rather than leaving routing silently different.

## Not done, deliberately — and worth Susan knowing

This PR **does not** apply the BA site's field changes; the story asks for the code to stop blocking them, not for the changes to be made. One of those differences should **not** be copied across: BA's `pam_file` still points at the `PAM File` doctype, while the repo points at `PAM License Details` — that was a deliberate move in WI-002233 (`repoint_pam_file_links_to_license_details`). Following the BA site there would undo it.

## Verified

`test_erf_configurable_approver.py` — **7/14 passing**. The seven reds all fail on `append()` to the new child table, which does not exist until `bench migrate`.

The proof that the hard-coding is gone is behavioural, not a source grep: with no rule configured, `UnPlanned` must route exactly where `Staffing Plan` routes. (My first attempt *was* a source grep, and it failed on my own docstring quoting the old expression — which is a fair illustration of why that style of test is worth avoiding.)

**After merge:** `bench migrate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)