### PR TITLE
WI-002306: Keep drivers off the passenger cards they are driving (version-15)

### DIFF
--- a/one_fm/one_fm/doctype/transportation_shipment/shipment_generator.py
+++ b/one_fm/one_fm/doctype/transportation_shipment/shipment_generator.py
@@ -17,6 +17,9 @@ import frappe
 from frappe import _
 from frappe.utils import get_datetime, getdate, today
 
+from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
+	driver_employees,
+)
 from one_fm.one_fm.page.transportation_schedule.transportation_schedule import (
 	get_coords,
 	get_grouped_employees_by_accommodation,
@@ -55,6 +58,13 @@ def build_demand_descriptors(nested_map: dict) -> list:
 	going roster and a cross-referenced return roster attached. Direction-specific
 	records are expanded later in generate_transportation_shipments().
 	"""
+	if not nested_map:
+		return []
+
+	# WI-002306: drivers are working the run, not riding it. Taken out here, before any
+	# routing decision, so no arrangement downstream can put one on a card and no
+	# headcount counts a seat the driver was never going to sit in.
+	nested_map = _without_drivers(nested_map)
 	if not nested_map:
 		return []
 
@@ -258,6 +268,35 @@ def build_demand_descriptors(nested_map: dict) -> list:
 	return demands
 
 
+def _without_drivers(nested_map: dict) -> dict:
+	"""The demand map with every driver removed from every shift roster (WI-002306).
+
+	A shift left with no riders is dropped, and so is an accommodation left with no
+	shifts - an empty roster produces no shipment anyway, and carrying it through only
+	means the prune pass has to clean up after it.
+	"""
+	rostered = set()
+	for acc_data in nested_map.values():
+		for emp_list in acc_data["shifts"].values():
+			rostered.update(emp_list)
+
+	drivers = driver_employees(rostered)
+	if not drivers:
+		return nested_map
+
+	trimmed = {}
+	for acc_name, acc_data in nested_map.items():
+		shifts = {}
+		for shift_name, emp_list in acc_data["shifts"].items():
+			riders = [e for e in emp_list if e not in drivers]
+			if riders:
+				shifts[shift_name] = riders
+		if shifts:
+			trimmed[acc_name] = dict(acc_data, shifts=shifts)
+
+	return trimmed
+
+
 def _attach_return_rosters(demands: list) -> None:
 	"""For each demand, find the finishing-shift roster at the same stop/accommodation.
 
@@ -444,11 +483,19 @@ def _group_passengers_by_camp(trip_request_doc) -> dict:
 	Returns an ordered {camp: [passenger_row, ...]} map. Passengers with no
 	accommodation_camp are skipped — they have no physical origin to group by,
 	so they cannot be materialized as a camp-origin demand card.
+
+	WI-002306: drivers are dropped here too, not only on the shift-generated side. The
+	canvas hides a driver card whichever source made it, so leaving one in would produce
+	a record the dispatcher can neither see nor plan - worse than not making it.
 	"""
+	drivers = driver_employees(
+		[p.employee_id for p in trip_request_doc.transport_request_passenger if p.employee_id]
+	)
+
 	groups = {}
 	for passenger in trip_request_doc.transport_request_passenger:
 		camp = passenger.accommodation_camp
-		if not camp:
+		if not camp or passenger.employee_id in drivers:
 			continue
 		groups.setdefault(camp, []).append(passenger)
 	return groups

--- a/one_fm/one_fm/doctype/transportation_shipment/test_driver_exclusion.py
+++ b/one_fm/one_fm/doctype/transportation_shipment/test_driver_exclusion.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002306: drivers are working the run, not riding it.
+
+A driver on a passenger card is a seat counted twice and a dispatcher scheduling
+somebody who is already committed to that vehicle.
+"""
+
+from datetime import datetime, timedelta
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.one_fm.page.transportation_schedule.transportation_schedule import (
+	_build_transportation_shipment_cards,
+)
+
+
+def _fmt(dt):
+	return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _to_utc(dt_str):
+	return frappe.utils.get_datetime(f"{frappe.utils.today()} {dt_str}")
+
+
+def _no_coords(doctype, name):
+	"""Coordinates are irrelevant to which cards are offered, and a lookup per card is
+	the slowest part of the builder."""
+	return None
+
+from one_fm.one_fm.doctype.transportation_shipment.shipment_generator import (
+	_without_drivers,
+	build_demand_descriptors,
+)
+from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
+	DRIVER_DESIGNATIONS,
+	driver_employees,
+)
+
+
+def _an_employee(designation):
+	"""An active employee holding this designation, or None if the site has none."""
+	return frappe.db.get_value(
+		"Employee", {"status": "Active", "designation": designation}, "name"
+	)
+
+
+class TestDriverDesignations(FrappeTestCase):
+	def test_every_driver_designation_is_a_real_one(self):
+		"""A designation renamed away silently stops excluding anybody."""
+		for designation in DRIVER_DESIGNATIONS:
+			with self.subTest(designation=designation):
+				self.assertTrue(
+					frappe.db.exists("Designation", designation),
+					f"{designation!r} is not a Designation on this site",
+				)
+
+	def test_it_covers_the_designations_the_drivers_actually_hold(self):
+		"""The story says "Driver", which no active employee holds - the real ones are
+		Bus, Heavy and Light. Agreed with the process owner."""
+		for designation in ("Bus Driver", "Heavy Driver", "Light Driver"):
+			self.assertIn(designation, DRIVER_DESIGNATIONS)
+
+
+class TestDriverLookup(FrappeTestCase):
+	def test_it_finds_a_driver(self):
+		driver = _an_employee("Heavy Driver") or _an_employee("Light Driver")
+		if not driver:
+			self.skipTest("no active driver on this site")
+
+		self.assertEqual(driver_employees([driver]), {driver})
+
+	def test_it_leaves_a_non_driver_alone(self):
+		rider = frappe.db.get_value(
+			"Employee",
+			{"status": "Active", "designation": ["not in", DRIVER_DESIGNATIONS]},
+			"name",
+		)
+		if not rider:
+			self.skipTest("no active non-driver on this site")
+
+		self.assertEqual(driver_employees([rider]), set())
+
+	def test_an_empty_roster_asks_the_database_nothing(self):
+		self.assertEqual(driver_employees([]), set())
+		self.assertEqual(driver_employees(None), set())
+
+
+class TestTheDemandMapDropsDrivers(FrappeTestCase):
+	"""AC1: no shipment is generated with a driver on it."""
+
+	def setUp(self):
+		self.driver = _an_employee("Heavy Driver") or _an_employee("Light Driver")
+		self.rider = frappe.db.get_value(
+			"Employee",
+			{"status": "Active", "designation": ["not in", DRIVER_DESIGNATIONS]},
+			"name",
+		)
+		if not self.driver or not self.rider:
+			self.skipTest("this site has no active driver and non-driver to contrast")
+
+	def _map(self, roster):
+		return {"Camp A": {"lookup_id": "ACC-01", "shifts": {"SHIFT-01": list(roster)}}}
+
+	def test_a_driver_is_taken_off_a_mixed_roster(self):
+		trimmed = _without_drivers(self._map([self.rider, self.driver]))
+
+		self.assertEqual(trimmed["Camp A"]["shifts"]["SHIFT-01"], [self.rider])
+
+	def test_a_shift_of_only_drivers_is_dropped_entirely(self):
+		"""An empty roster produces no shipment anyway - carrying it through only leaves
+		the prune pass to clean up after it."""
+		self.assertEqual(_without_drivers(self._map([self.driver])), {})
+
+	def test_a_roster_with_no_driver_is_returned_untouched(self):
+		original = self._map([self.rider])
+
+		self.assertIs(_without_drivers(original), original)
+
+	def test_nothing_is_generated_for_a_driver_only_shift(self):
+		"""The whole point: the demand descriptor never reaches the writer."""
+		self.assertEqual(build_demand_descriptors(self._map([self.driver])), [])
+
+
+class TestTheCanvasRefusesDriverCards(FrappeTestCase):
+	"""AC2/AC3: records made before the fix, and Assigned ones that cannot be pruned.
+
+	Driven through the real card builder rather than asserted against its source: a
+	source check passes just as happily when the filter is there but never reached.
+	"""
+
+	def setUp(self):
+		self.driver = _an_employee("Heavy Driver") or _an_employee("Light Driver")
+		self.rider = frappe.db.get_value(
+			"Employee",
+			{"status": "Active", "designation": ["not in", DRIVER_DESIGNATIONS]},
+			"name",
+		)
+		if not self.driver or not self.rider:
+			self.skipTest("this site has no active driver and non-driver to contrast")
+
+	def _a_shipment(self, riders):
+		doc = frappe.new_doc("Transportation Shipment")
+		doc.status = "Unassigned"
+		doc.trip_direction = "Outward"
+		doc.start_time = "06:00:00"
+		doc.end_time = "18:00:00"
+		doc.headcount = len(riders)
+		doc.source_doctype = "Operations Shift"
+		for emp in riders:
+			doc.append("transportation_shipment_employee", {"employee_id": emp})
+		doc.insert(ignore_permissions=True)
+		return doc.name
+
+	def _card_ids(self):
+		return {c["shipment"] for c in _build_transportation_shipment_cards(
+			_fmt, _to_utc, _no_coords, timedelta
+		)}
+
+	def test_a_driver_only_card_is_not_offered(self):
+		name = self._a_shipment([self.driver])
+
+		self.assertNotIn(name, self._card_ids())
+
+	def test_a_card_carrying_a_passenger_is_still_offered(self):
+		"""The filter has to be "all of them", not "any of them" - a card with real riders
+		on it is real demand whoever else is listed."""
+		name = self._a_shipment([self.rider, self.driver])
+
+		self.assertIn(name, self._card_ids())
+
+	def test_an_ordinary_card_is_untouched(self):
+		name = self._a_shipment([self.rider])
+
+		self.assertIn(name, self._card_ids())

--- a/one_fm/one_fm/doctype/transportation_shipment/test_driver_exclusion.py
+++ b/one_fm/one_fm/doctype/transportation_shipment/test_driver_exclusion.py
@@ -163,6 +163,16 @@ class TestTheCanvasRefusesDriverCards(FrappeTestCase):
 
 		self.assertNotIn(name, self._card_ids())
 
+	def test_an_assigned_driver_only_card_is_kept(self):
+		"""It is sitting on a lane in a saved plan and a placed block resolves its card
+		from this list, so withdrawing it would empty somebody's plan. This also pins
+		that the guard reads a real status - an unselected field reads back as None and
+		silently keeps every card."""
+		name = self._a_shipment([self.driver])
+		frappe.db.set_value("Transportation Shipment", name, "status", "Assigned")
+
+		self.assertIn(name, self._card_ids())
+
 	def test_a_card_carrying_a_passenger_is_still_offered(self):
 		"""The filter has to be "all of them", not "any of them" - a card with real riders
 		on it is real demand whoever else is listed."""

--- a/one_fm/one_fm/doctype/transportation_shipment/transportation_shipment.py
+++ b/one_fm/one_fm/doctype/transportation_shipment/transportation_shipment.py
@@ -8,6 +8,37 @@ from frappe.utils import cint
 
 TRIP_REQUEST = "Trip Request"
 
+# WI-002306: the designations that mean "this person drives the bus", so they are
+# never booked onto one as a passenger. A driver on a passenger card is a seat
+# counted twice and a dispatcher scheduling somebody who is already working the run.
+#
+# The story says "designation == Driver", but that designation has no active
+# employees - the 24 real drivers are Bus, Heavy and Light. Held as one list, agreed
+# with the process owner, so adding a fifth is a one-line change rather than a hunt
+# through three modules.
+DRIVER_DESIGNATIONS = ("Driver", "Bus Driver", "Heavy Driver", "Light Driver")
+
+
+def driver_employees(employee_ids) -> set:
+    """Which of these employees drive, so they can be left off passenger cards.
+
+    One query for the whole set rather than a designation lookup per rider: this runs
+    once per generation pass over every shift roster on site, and once more each time
+    the canvas loads its cards.
+    """
+    employee_ids = [e for e in set(employee_ids or []) if e]
+    if not employee_ids:
+        return set()
+
+    return {
+        row.name
+        for row in frappe.get_all(
+            "Employee",
+            filters={"name": ["in", employee_ids], "designation": ["in", DRIVER_DESIGNATIONS]},
+            fields=["name"],
+        )
+    }
+
 
 class TransportationShipment(Document):
 	def validate(self):

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -863,7 +863,11 @@ def _build_transportation_shipment_cards(fmt, to_utc, get_coords_cached, timedel
         "Transportation Shipment",
         filters={"status": ["in", ["Unassigned", "Assigned"]]},
         fields=[
-            "name", "accommodation", "accommodation_name", "operations_shift",
+            "name",
+            # Selected, not just filtered on: the driver-card guard below compares
+            # against it, and an unselected field reads back as None (WI-002306).
+            "status",
+            "accommodation", "accommodation_name", "operations_shift",
             # Every shift the card serves, for the OLM stops one card covers several of.
             "aggregated_shifts",
             "operations_site", "stop_location", "headcount", "trip_direction",

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -11,6 +11,7 @@ from one_fm.operations.doctype.route_plan.route_plan import (
     row_headcount,
 )
 from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
+    driver_employees,
     qoa_buffer_minutes,
 )
 from one_fm.overrides.vehicle import passenger_capacity
@@ -909,6 +910,19 @@ def _build_transportation_shipment_cards(fmt, to_utc, get_coords_cached, timedel
             "mobile": row.cell_number or "",
             "is_reliever": row.employee_id in reliever_ids,
         })
+
+    # WI-002306 AC2/AC3: a card whose riders are all drivers is not assignable demand -
+    # nobody on it is travelling as a passenger. Generation stops making these, but
+    # records made before that still exist, and an Assigned one cannot be pruned, so the
+    # canvas has to refuse them itself rather than wait for a Generate run.
+    drivers = driver_employees([row.employee_id for row in emp_rows])
+    driver_only = {
+        ship
+        for ship, emps in emps_by_ship.items()
+        if emps and all(e["id"] in drivers for e in emps)
+    }
+    if driver_only:
+        shipments = [s for s in shipments if s.name not in driver_only]
 
     # Fallback times for shipments without an Operations Shift (ad-hoc journeys).
     trq_names = list({

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -921,8 +921,16 @@ def _build_transportation_shipment_cards(fmt, to_utc, get_coords_cached, timedel
         for ship, emps in emps_by_ship.items()
         if emps and all(e["id"] in drivers for e in emps)
     }
+    # Only the ones nobody has planned yet. An Assigned card is sitting on a lane in a
+    # saved plan, and a placed block resolves its card from this list - drop it and the
+    # block loses its detail panel, its trip chain and its manifest row. Withdrawing a
+    # card from the demand pool is this story's job; quietly emptying somebody's plan is
+    # not.
     if driver_only:
-        shipments = [s for s in shipments if s.name not in driver_only]
+        shipments = [
+            s for s in shipments
+            if s.name not in driver_only or s.status != "Unassigned"
+        ]
 
     # Fallback times for shipments without an Operations Shift (ad-hoc journeys).
     trq_names = list({


### PR DESCRIPTION
Backport of #6846 to `version-15`.

A driver is working the run, not riding it. Counting one as a passenger books a seat twice and offers the dispatcher somebody already committed to that vehicle.

- `driver_employees()` on the Transportation Shipment controller resolves drivers in one query over `DRIVER_DESIGNATIONS` (`Driver`, `Bus Driver`, `Heavy Driver`, `Light Driver` - the story says "Driver", which no active employee holds; the real ones are Bus/Heavy/Light, agreed with the process owner).
- Generation strips drivers from the rosters before descriptors are built, so a driver-only shift produces no shipment at all, and the prune pass removes existing Unassigned driver-only ones (AC1).
- The canvas refuses driver-only cards it is handed between Generate runs (AC2/AC3), but only the **Unassigned** ones - an Assigned card sits on a lane in a saved plan, and a placed block resolves its card from this list.

**One extra commit not in #6846:** that canvas guard compared `s.status` against `"Unassigned"`, but `status` was only *filtered* on and never *selected*, so it read back as `None` and the guard kept every card. Dormant rather than visibly wrong - the Generate path is unaffected, and the only driver-only card in live data is Assigned, which the guard keeps anyway - but the safety net never fired. Selecting it makes it work, and a new test pins the Assigned case, which had been passing for the wrong reason. **Same fix for `staging` in #6868.**

13 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
