### PR TITLE
WI-002307: Take switched-off work off the planning board (version-15)

### DIFF
--- a/one_fm/one_fm/page/transportation_schedule/test_inactive_shipment_cards.py
+++ b/one_fm/one_fm/page/transportation_schedule/test_inactive_shipment_cards.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002307: cards for work that has been switched off stay off the board.
+
+A dispatcher's time goes on planning active shifts. An Inactive shipment, or one whose
+Operations Shift has been switched off, is not work anybody is going to do.
+"""
+
+from datetime import timedelta
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.one_fm.page.transportation_schedule.transportation_schedule import (
+	_build_transportation_shipment_cards,
+	_serves_only_inactive_shifts,
+	_shifts_served,
+)
+
+
+def _fmt(dt):
+	return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _to_utc(dt_str):
+	return frappe.utils.get_datetime(f"{frappe.utils.today()} {dt_str}")
+
+
+def _no_coords(doctype, name):
+	return None
+
+
+def _card_shipments():
+	return {c["shipment"] for c in _build_transportation_shipment_cards(
+		_fmt, _to_utc, _no_coords, timedelta
+	)}
+
+
+class TestWhichShiftsACardServes(FrappeTestCase):
+	"""An OLM card names its shifts in aggregated_shifts and leaves the Link blank."""
+
+	def test_a_single_shift_card(self):
+		card = frappe._dict(operations_shift="SHIFT-A", aggregated_shifts="SHIFT-A")
+		self.assertEqual(_shifts_served(card), ["SHIFT-A"])
+
+	def test_an_aggregated_card_with_no_link_set(self):
+		card = frappe._dict(operations_shift=None, aggregated_shifts="SHIFT-A, SHIFT-B")
+		self.assertEqual(_shifts_served(card), ["SHIFT-A", "SHIFT-B"])
+
+	def test_the_link_is_included_when_it_is_not_already_listed(self):
+		card = frappe._dict(operations_shift="SHIFT-C", aggregated_shifts="SHIFT-A")
+		self.assertEqual(_shifts_served(card), ["SHIFT-A", "SHIFT-C"])
+
+	def test_a_shift_is_never_counted_twice(self):
+		card = frappe._dict(operations_shift="SHIFT-A", aggregated_shifts="SHIFT-A, SHIFT-B")
+		self.assertEqual(_shifts_served(card), ["SHIFT-A", "SHIFT-B"])
+
+	def test_an_adhoc_card_serves_none(self):
+		card = frappe._dict(operations_shift=None, aggregated_shifts=None)
+		self.assertEqual(_shifts_served(card), [])
+
+
+class TestWhichCardsAreSuppressed(FrappeTestCase):
+	def test_a_card_whose_only_shift_is_off(self):
+		card = frappe._dict(operations_shift="SHIFT-A", aggregated_shifts="SHIFT-A")
+		self.assertTrue(_serves_only_inactive_shifts(card, {"SHIFT-A"}))
+
+	def test_a_card_still_serving_a_live_shift_stays(self):
+		"""The rule is every shift, not any: an OLM card carrying three still has to run
+		for the two that are live."""
+		card = frappe._dict(operations_shift=None, aggregated_shifts="SHIFT-A, SHIFT-B")
+		self.assertFalse(_serves_only_inactive_shifts(card, {"SHIFT-A"}))
+
+	def test_a_card_with_every_shift_off_goes(self):
+		card = frappe._dict(operations_shift=None, aggregated_shifts="SHIFT-A, SHIFT-B")
+		self.assertTrue(_serves_only_inactive_shifts(card, {"SHIFT-A", "SHIFT-B"}))
+
+	def test_an_adhoc_card_is_never_suppressed(self):
+		"""There is no shift to have been switched off."""
+		card = frappe._dict(operations_shift=None, aggregated_shifts=None)
+		self.assertFalse(_serves_only_inactive_shifts(card, {"SHIFT-A"}))
+
+
+class TestTheBoardDoesNotOfferThem(FrappeTestCase):
+	"""Driven through the real card builder, not asserted against its source."""
+
+	def _a_shipment(self, status="Unassigned", operations_shift=None, aggregated=None):
+		doc = frappe.new_doc("Transportation Shipment")
+		doc.status = status
+		doc.trip_direction = "Outward"
+		doc.start_time = "06:00:00"
+		doc.end_time = "18:00:00"
+		doc.operations_shift = operations_shift
+		doc.aggregated_shifts = aggregated or (operations_shift or "")
+		doc.source_doctype = "Operations Shift" if operations_shift else None
+		doc.insert(ignore_permissions=True)
+		return doc.name
+
+	def _a_shift(self, status):
+		shift = frappe.db.get_value("Operations Shift", {"status": status}, "name")
+		if not shift:
+			self.skipTest(f"no {status} Operations Shift on this site")
+		return shift
+
+	def test_an_inactive_shipment_is_not_offered(self):
+		"""AC1. The expiry engine sets this status; the board has never rendered it."""
+		name = self._a_shipment(status="Inactive", operations_shift=self._a_shift("Active"))
+
+		self.assertNotIn(name, _card_shipments())
+
+	def test_a_card_on_an_inactive_shift_is_not_offered(self):
+		"""AC2, and the part generation alone does not cover - it runs daily, and an
+		Assigned card is never pruned."""
+		name = self._a_shipment(operations_shift=self._a_shift("Inactive"))
+
+		self.assertNotIn(name, _card_shipments())
+
+	def test_a_card_on_an_active_shift_is_still_offered(self):
+		name = self._a_shipment(operations_shift=self._a_shift("Active"))
+
+		self.assertIn(name, _card_shipments())
+
+	def test_a_card_naming_no_shift_is_still_offered(self):
+		"""An ad-hoc Trip Request journey has no shift to be switched off."""
+		name = self._a_shipment()
+
+		self.assertIn(name, _card_shipments())

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -843,6 +843,52 @@ def get_route_plans():
 SHIPMENT_CARD_PREFIX = "TSHIP-"
 
 
+def _shifts_served(shipment) -> list:
+    """Every Operations Shift a card carries staff for (WI-002307).
+
+    Most cards name one. An OLM stop shared by several roles finishing together lists
+    them in ``aggregated_shifts`` and leaves ``operations_shift`` blank, because no
+    single one of them is it - so reading only the Link field would see no shift on the
+    cards that serve the most.
+    """
+    named = [s.strip() for s in (shipment.aggregated_shifts or "").split(",") if s.strip()]
+    if shipment.operations_shift and shipment.operations_shift not in named:
+        named.append(shipment.operations_shift)
+    return named
+
+
+def _inactive_shifts(shipments) -> set:
+    """Which of the shifts these cards serve have been switched off (WI-002307)."""
+    names = set()
+    for shipment in shipments:
+        names.update(_shifts_served(shipment))
+    if not names:
+        return set()
+
+    return {
+        row.name
+        for row in frappe.get_all(
+            "Operations Shift",
+            filters={"name": ["in", list(names)], "status": "Inactive"},
+            fields=["name"],
+        )
+    }
+
+
+def _serves_only_inactive_shifts(shipment, inactive_shifts) -> bool:
+    """Is there nothing left on this card worth planning (WI-002307)?
+
+    Every shift it serves has to be inactive, not just one of them. An OLM card
+    carrying three shifts still has to run for the two that are live, and hiding it
+    because the third was switched off would take real demand off the board.
+
+    A card that names no shift at all - an ad-hoc Trip Request journey - is never
+    hidden: there is no shift to have been switched off.
+    """
+    served = _shifts_served(shipment)
+    return bool(served) and all(name in inactive_shifts for name in served)
+
+
 def _build_transportation_shipment_cards(fmt, to_utc, get_coords_cached, timedelta):
     """Return draggable cards for Transportation Shipment records.
 
@@ -909,6 +955,13 @@ def _build_transportation_shipment_cards(fmt, to_utc, get_coords_cached, timedel
             "mobile": row.cell_number or "",
             "is_reliever": row.employee_id in reliever_ids,
         })
+
+    # WI-002307: a card for a shift that has been switched off is not work anybody is
+    # going to plan. Generation already stops making them and prunes the Unassigned
+    # ones, but that only runs daily or on the button - the dispatcher opening the board
+    # in between would still be looking at them, and an Assigned card is never pruned.
+    inactive_shifts = _inactive_shifts(shipments)
+    shipments = [s for s in shipments if not _serves_only_inactive_shifts(s, inactive_shifts)]
 
     # Fallback times for shipments without an Operations Shift (ad-hoc journeys).
     trq_names = list({


### PR DESCRIPTION
Backport of #6847 to `version-15`.

A card for a shift somebody has switched off is not work anybody is going to plan. Generation already stops making them and prunes the Unassigned ones, but that only runs daily or on the button - a dispatcher opening the board in between still sees them, and an Assigned card is never pruned. So the canvas refuses them itself.

A card is withheld only when **every** shift it serves is inactive: an OLM card covers several shifts, and one switched off does not make the run stop.

**Conflict resolved during the backport:** #6847 was branched on top of #6846, so its diff carried #6846's driver-card block as context. This branch keeps only the WI-002307 filter - the driver work ships separately as #6863.

13 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
