### PR TITLE
WI-001687: Put Double Shift OT Allowed back on Operations Shift

### DIFF
--- a/one_fm/one_fm/page/roster/test_roster_client_queries.py
+++ b/one_fm/one_fm/page/roster/test_roster_client_queries.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""Every field roster.js asks the server for has to exist on the doctype.
+
+The OT modal asked Operations Shift for double_shift_ot_allowed. WI-001425 added that
+field; the revert of #6413 removed it three days before this code was written, and only
+the table column survived. Server-side lookups still worked - the column is there - but
+the browser goes through reportview, which checks the doctype's fields and refuses the
+whole query with "Field not permitted in query". So Site and Project were never filled
+in either, and the warning the field guarded was never once shown.
+
+Nothing else would notice: the page has no tests, the JS throws inside a promise, and
+the only visible sign is a dialog that flashes and goes.
+"""
+
+import os
+import re
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+ROSTER_JS = os.path.join(os.path.dirname(__file__), "roster.js")
+
+# frappe.db.get_value("DocType", <anything>, ["a", "b"]) - literal doctype, literal fields.
+GET_VALUE = re.compile(
+	r"""frappe\.db\.get_value\(\s*["']([^"']+)["']\s*,[^,\[]*,\s*\[([^\]]*)\]""",
+	re.VERBOSE,
+)
+
+
+class TestRosterClientQueries(FrappeTestCase):
+	def test_every_field_it_asks_for_exists(self):
+		with open(ROSTER_JS) as handle:
+			source = handle.read()
+
+		calls = GET_VALUE.findall(source)
+		self.assertTrue(calls, "no frappe.db.get_value calls found - has the pattern changed?")
+
+		for doctype, raw_fields in calls:
+			if not frappe.db.exists("DocType", doctype):
+				continue  # a doctype from another app, or built at runtime
+			meta = frappe.get_meta(doctype)
+			for field in re.findall(r"""["']([A-Za-z_][A-Za-z0-9_]*)["']""", raw_fields):
+				with self.subTest(doctype=doctype, field=field):
+					self.assertTrue(
+						meta.get_field(field) or field in frappe.model.default_fields,
+						f"roster.js asks {doctype} for {field!r}, which the doctype does not "
+						"have - reportview refuses the whole query, so the other fields in it "
+						"come back empty too",
+					)

--- a/one_fm/operations/doctype/operations_shift/operations_shift.json
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.json
@@ -16,6 +16,7 @@
   "shift_number",
   "shift_type",
   "day_off_ot_allowed",
+  "double_shift_ot_allowed",
   "automate_roster",
   "shift_timing_override_required",
   "supervisor",
@@ -199,6 +200,12 @@
   },
   {
    "default": "0",
+   "fieldname": "double_shift_ot_allowed",
+   "fieldtype": "Check",
+   "label": "Double Shift OT Allowed"
+  },
+  {
+   "default": "0",
    "description": "Enable this only if this post requires a different shift timing on specific day(s) of the week (e.g., a different timing on Friday).",
    "fieldname": "shift_timing_override_required",
    "fieldtype": "Check",
@@ -226,7 +233,7 @@
    "link_fieldname": "shift"
   }
  ],
- "modified": "2026-08-12 14:00:00.000000",
+ "modified": "2026-09-06 22:30:00.000000",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Operations Shift",


### PR DESCRIPTION
Found while testing WI-002283. Not caused by it — broken on `staging` since July.

Choosing a shift in **Change Employee Schedule (OT)** pops a message and vanishes:

> Field not permitted in query: double_shift_ot_allowed

## What happened

| date | |
|---|---|
| 8 Jul | WI-001425 adds `double_shift_ot_allowed` to Operations Shift |
| 21 Jul | the revert of #6413 removes it from the doctype — **the table column survives** |
| 24 Jul | WI-001687 writes `roster.js` against it |
| 25 Jul | WI-001688 writes the checker against it |

That revert was meant for **production**, where the feature is still under development. Taking the field off staging as well was a mistake, and the code built on it stayed.

Only the DocField went; MariaDB kept the column. That is why it went unnoticed — a server-side `frappe.db.get_value` still works, because the column is there. The browser goes through `reportview`, which validates against the **doctype**, and refuses the whole query.

## The damage was wider than the message

`res.message` came back `undefined`, the destructuring threw inside the promise, and **Site and Project were never filled in either** — the two read-only fields sat empty in the modal. And the warning the field guarded had not been shown once since the day it was written, on any shift.

The other two schedule modals ask the same doctype for `site` and `project` alone, which is why only the OT one misbehaved.

## The fix

The field goes back exactly as it was before the revert — a `Check` defaulting to `0`, labelled **Double Shift OT Allowed**, sitting after Day Off OT Allowed.

**No patch needed.** The column was never dropped, so the two shifts that had it enabled still do — `Security-Aramex Warehouse-Day-1` and `-Night-1` — and 966 read `0`.

`roster.js` is unchanged; it was right all along.

**Roster Double Shift OT Checker** reads the same field through the query builder. It went straight to the surviving column and so never errored, but it was testing a flag no form could set. With the field back it reads what supervisors actually choose.

## Verified

- the field is in `frappe.get_meta("Operations Shift")` again, `Check`, default `0`
- the exact browser query now returns `['site', 'project', 'double_shift_ot_allowed']` instead of raising
- the two enabled shifts kept their values
- `test_roster_double_shift_ot_checker` — 7 tests pass

## Test

Walks every `frappe.db.get_value` in `roster.js` that names a literal doctype and field list, and checks each field against that doctype. This is what would have caught a revert pulling a field out from under its callers; it fails if this one goes missing again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
