### PR TITLE
WI-002184: Let the Client Event Draft assignment stay open

### DIFF
--- a/one_fm/custom/assignment_rule/assigning_operations_manager_for_approval_client_event.json
+++ b/one_fm/custom/assignment_rule/assigning_operations_manager_for_approval_client_event.json
@@ -1,23 +1,38 @@
 {
-  "name": "Client Event - Pending Operations Manager",
-  "document_type": "Client Event",
-  "priority": 0,
-  "disabled": 0,
-  "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.\n        <br>\n        The details of the request are as follows:\n        <br>\n        </p><table cellpadding=\"0\" cellspacing=\"0\" border=\"1\" style=\"border-collapse: collapse;\">\n            <thead>\n                <tr>\n                    <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th>\n                    <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th>\n                </tr>\n            </thead>\n        <tbody>\n        \n            <tr>\n                <td style=\"padding: 10px;\">Event Name</td>\n                <td style=\"padding: 10px;\">{{event_name}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Start Date</td>\n                <td style=\"padding: 10px;\">{{start_date}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Event Start Datetime</td>\n                <td style=\"padding: 10px;\">{{event_start_datetime}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Event Location</td>\n                <td style=\"padding: 10px;\">{{event_location}}</td>\n            </tr>\n            </tbody></table><p></p>",
-  "is_assignment_rule_with_workflow": 1,
-  "assign_condition": "workflow_state == \"Pending Operations Manager\"",
-  "close_condition": "workflow_state != \"Pending Operations Manager\"",
-  "rule": "Based on Field",
-  "field": "operations_manager",
-  "doctype": "Assignment Rule",
-  "users": [],
-  "assignment_days": [
-    { "day": "Monday" },
-    { "day": "Tuesday" },
-    { "day": "Wednesday" },
-    { "day": "Thursday" },
-    { "day": "Friday" },
-    { "day": "Saturday" },
-    { "day": "Sunday" }
-  ]
+ "name": "Client Event - Pending Operations Manager",
+ "document_type": "Client Event",
+ "priority": 0,
+ "disabled": 0,
+ "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.\n        <br>\n        The details of the request are as follows:\n        <br>\n        </p><table cellpadding=\"0\" cellspacing=\"0\" border=\"1\" style=\"border-collapse: collapse;\">\n            <thead>\n                <tr>\n                    <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th>\n                    <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th>\n                </tr>\n            </thead>\n        <tbody>\n        \n            <tr>\n                <td style=\"padding: 10px;\">Event Name</td>\n                <td style=\"padding: 10px;\">{{event_name}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Start Date</td>\n                <td style=\"padding: 10px;\">{{start_date}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Event Start Datetime</td>\n                <td style=\"padding: 10px;\">{{event_start_datetime}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Event Location</td>\n                <td style=\"padding: 10px;\">{{event_location}}</td>\n            </tr>\n            </tbody></table><p></p>",
+ "is_assignment_rule_with_workflow": 1,
+ "assign_condition": "workflow_state == \"Pending Operations Manager\"",
+ "rule": "Based on Field",
+ "field": "operations_manager",
+ "doctype": "Assignment Rule",
+ "users": [],
+ "assignment_days": [
+  {
+   "day": "Monday"
+  },
+  {
+   "day": "Tuesday"
+  },
+  {
+   "day": "Wednesday"
+  },
+  {
+   "day": "Thursday"
+  },
+  {
+   "day": "Friday"
+  },
+  {
+   "day": "Saturday"
+  },
+  {
+   "day": "Sunday"
+  }
+ ],
+ "unassign_condition": "workflow_state != \"Pending Operations Manager\"",
+ "close_condition": ""
 }

--- a/one_fm/custom/assignment_rule/assigning_project_manager_for_approval_client_event.json
+++ b/one_fm/custom/assignment_rule/assigning_project_manager_for_approval_client_event.json
@@ -6,7 +6,6 @@
  "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.\n        <br>\n        The details of the request are as follows:\n        <br>\n        </p><table cellpadding=\"0\" cellspacing=\"0\" border=\"1\" style=\"border-collapse: collapse;\">\n            <thead>\n                <tr>\n                    <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th>\n                    <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th>\n                </tr>\n            </thead>\n        <tbody>\n        \n            <tr>\n                <td style=\"padding: 10px;\">Event Name</td>\n                <td style=\"padding: 10px;\">{{event_name}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Start Date</td>\n                <td style=\"padding: 10px;\">{{start_date}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Event Start Datetime</td>\n                <td style=\"padding: 10px;\">{{event_start_datetime}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Event Location</td>\n                <td style=\"padding: 10px;\">{{event_location}}</td>\n            </tr>\n            </tbody></table><p></p>",
  "is_assignment_rule_with_workflow": 1,
  "assign_condition": "workflow_state == \"Pending Project Manager\"",
- "close_condition": "workflow_state != \"Pending Project Manager\"",
  "rule": "Based on Field",
  "field": "project_manager_user",
  "doctype": "Assignment Rule",
@@ -33,5 +32,7 @@
   {
    "day": "Sunday"
   }
- ]
+ ],
+ "unassign_condition": "workflow_state != \"Pending Project Manager\"",
+ "close_condition": ""
 }

--- a/one_fm/custom/assignment_rule/returning_to_operations_supervisor_of_client_event.json
+++ b/one_fm/custom/assignment_rule/returning_to_operations_supervisor_of_client_event.json
@@ -6,7 +6,7 @@
  "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.\n        <br>\n        The details of the request are as follows:\n        <br>\n        </p><table cellpadding=\"0\" cellspacing=\"0\" border=\"1\" style=\"border-collapse: collapse;\">\n            <thead>\n                <tr>\n                    <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th>\n                    <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th>\n                </tr>\n            </thead>\n        <tbody>\n        \n            <tr>\n                <td style=\"padding: 10px;\">Event Name</td>\n                <td style=\"padding: 10px;\">{{event_name}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Start Date</td>\n                <td style=\"padding: 10px;\">{{start_date}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Event Start Datetime</td>\n                <td style=\"padding: 10px;\">{{event_start_datetime}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Event Location</td>\n                <td style=\"padding: 10px;\">{{event_location}}</td>\n            </tr>\n            </tbody></table><p></p>",
  "is_assignment_rule_with_workflow": 1,
  "assign_condition": "workflow_state == \"Draft\"",
- "unassign_condition": "workflow_state == \"Pending Project Manager\"",
+ "unassign_condition": "workflow_state != \"Draft\"",
  "rule": "Based on Field",
  "field": "owner",
  "doctype": "Assignment Rule",
@@ -33,5 +33,6 @@
   {
    "day": "Sunday"
   }
- ]
+ ],
+ "close_condition": ""
 }

--- a/one_fm/one_fm/doctype/client_event/test_client_event_project_manager.py
+++ b/one_fm/one_fm/doctype/client_event/test_client_event_project_manager.py
@@ -191,10 +191,13 @@ class TestTheAssignmentRules(FrappeTestCase):
 		self.assertEqual(rule["field"], "project_manager_user")
 		self.assertIn(PM_STATE, rule["assign_condition"])
 
-	def test_the_draft_rule_releases_the_owner_at_the_new_state(self):
+	def test_the_draft_rule_releases_the_owner_on_leaving_draft(self):
+		"""Not "on reaching Pending Project Manager": an event with no project is submitted
+		to Pending Operations Manager instead, and naming one state left the owner assigned
+		on the other route."""
 		rule = self._rule("returning_to_operations_supervisor_of_client_event.json")
 
-		self.assertEqual(rule["unassign_condition"], f'workflow_state == "{PM_STATE}"')
+		self.assertEqual(rule["unassign_condition"], 'workflow_state != "Draft"')
 
 	def test_no_rule_carries_a_blank_process_task(self):
 		"""An empty custom_routine_task is written straight through and blanks the link."""

--- a/one_fm/one_fm/doctype/client_event/test_client_event_project_manager.py
+++ b/one_fm/one_fm/doctype/client_event/test_client_event_project_manager.py
@@ -266,3 +266,85 @@ class TestTheSiteHasOnlyTheAnalystsRules(FrappeTestCase):
 		for condition, names in claims.items():
 			with self.subTest(condition=condition):
 				self.assertEqual(len(names), 1, f"{names} all assign on {condition!r}")
+
+
+class TestTheDraftAssignmentSurvives(FrappeTestCase):
+	"""It was opening and closing in the same breath.
+
+	close_condition is not scoped to the rule that owns the assignment - Frappe closes
+	every ToDo on the document. With three rules on one doctype, the two whose state is
+	not the current one both satisfy it, so the Draft assignment was closed the instant
+	it was made. unassign_condition expresses the same rule and only touches the ToDos
+	its own rule created.
+	"""
+
+	CLIENT_EVENT_RULES = (
+		"Client Event - Draft",
+		"Client Event - Pending Operations Manager",
+		"Client Event - Pending Project Manager",
+	)
+
+	def test_no_rule_closes_assignments_it_does_not_own(self):
+		for name in self.CLIENT_EVENT_RULES:
+			with self.subTest(rule=name):
+				self.assertFalse(
+					frappe.db.get_value("Assignment Rule", name, "close_condition"),
+					f"{name} uses close_condition, which closes every assignment on the event",
+				)
+
+	def test_the_draft_rule_lets_go_on_either_route(self):
+		"""An event with no project goes to Pending Operations Manager, not Pending
+		Project Manager - naming one state left the Draft assignment open forever on the
+		other route."""
+		condition = frappe.db.get_value("Assignment Rule", "Client Event - Draft", "unassign_condition")
+		self.assertEqual(condition, 'workflow_state != "Draft"')
+
+	def test_the_assignment_stays_open_across_repeated_saves(self):
+		"""Driven through Frappe's own apply(), because the conditions can each look
+		right on their own and still cancel each other out when all three run."""
+		from frappe.automation.doctype.assignment_rule.assignment_rule import apply
+
+		name = frappe.db.get_value("Client Event", {"workflow_state": "Draft"}, "name")
+		if not name:
+			self.skipTest("no Draft Client Event on this site")
+		doc = frappe.get_doc("Client Event", name)
+		frappe.db.sql(
+			"DELETE FROM `tabToDo` WHERE reference_type='Client Event' AND reference_name=%s", name
+		)
+
+		def open_assignments():
+			return frappe.db.count(
+				"ToDo",
+				{"reference_type": "Client Event", "reference_name": name, "status": "Open"},
+			)
+
+		apply(doc)
+		self.assertEqual(open_assignments(), 1, "the Draft assignment was never made")
+		apply(doc)
+		self.assertEqual(open_assignments(), 1, "the Draft assignment was closed by another rule")
+
+	def test_it_hands_over_when_the_event_is_submitted(self):
+		"""The other half: scoping the unassign must not leave the Draft assignment open
+		alongside the approver's."""
+		from frappe.automation.doctype.assignment_rule.assignment_rule import apply
+
+		name = frappe.db.get_value(
+			"Client Event", {"workflow_state": "Draft", "project_manager_user": ["is", "set"]}, "name"
+		)
+		if not name:
+			self.skipTest("no Draft Client Event with a project manager on this site")
+		doc = frappe.get_doc("Client Event", name)
+		frappe.db.sql(
+			"DELETE FROM `tabToDo` WHERE reference_type='Client Event' AND reference_name=%s", name
+		)
+
+		apply(doc)
+		doc.workflow_state = "Pending Project Manager"
+		apply(doc)
+
+		still_open = frappe.get_all(
+			"ToDo",
+			filters={"reference_type": "Client Event", "reference_name": name, "status": "Open"},
+			pluck="assignment_rule",
+		)
+		self.assertEqual(still_open, ["Client Event - Pending Project Manager"])

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -603,7 +603,7 @@ one_fm.patches.v15_0.add_transportation_qoa_buffer_to_hr_settings #2026-08-26 WI
 one_fm.patches.v15_0.rekey_olm_shipments_on_shift_window #2026-08-31 WI-002151
 one_fm.patches.v15_0.repoint_pam_file_links_to_license_details #2026-08-29 WI-002233
 one_fm.patches.v15_0.route_ojt_to_project_manager #2026-09-03 WI-002186
-one_fm.patches.v15_0.route_client_event_to_project_manager #2026-09-06b WI-002184
+one_fm.patches.v15_0.route_client_event_to_project_manager #2026-09-06c WI-002184
 one_fm.patches.v15_0.update_action_paci_assignment_rule #2026-09-05d WI-002183
 one_fm.patches.v15_0.rename_renewal_expat_and_hr_costing #2026-09-02 WI-002178
 one_fm.patches.v15_0.consolidate_extension_actions #2026-09-02 WI-002179

--- a/one_fm/patches/v15_0/route_client_event_to_project_manager.py
+++ b/one_fm/patches/v15_0/route_client_event_to_project_manager.py
@@ -165,6 +165,21 @@ def verify():
 			f"Extra: {sorted(live - set(BA_RULES))or 'none'}. Missing: {sorted(set(BA_RULES) - live) or 'none'}."
 		)
 
+	# close_condition is not scoped to the rule that owns the assignment: it closes every
+	# ToDo on the document. With three rules on one doctype, the two that are not the
+	# current state both satisfy it, so a Draft assignment was closed the moment it was
+	# made. unassign_condition says the same thing and only touches its own rule's ToDos.
+	using_close = frappe.get_all(
+		"Assignment Rule",
+		filters={"document_type": "Client Event", "close_condition": ["!=", ""]},
+		pluck="name",
+	)
+	if using_close:
+		frappe.throw(
+			f"WI-002184: {using_close} use close_condition, which closes every assignment on "
+			"the event rather than their own - the Draft assignment closes as soon as it opens."
+		)
+
 	stranded = frappe.db.sql(
 		"""SELECT COUNT(*) FROM `tabToDo`
 		   WHERE status = 'Open' AND assignment_rule IS NOT NULL


### PR DESCRIPTION
Follow-up to #6852. **The fix for the bug reported during testing did not make it into that merge** — #6852 was merged at the `#2026-09-06b` patch tag, one commit before this one. On `staging` today, `Client Event - Draft` still carries `unassign_condition: workflow_state == "Pending Project Manager"` and the two pending rules still carry a `close_condition`.

## The bug

Creating a Client Event assigns the owner and closes the assignment in the same breath.

`close_condition` is not scoped to the rule that owns the assignment. Frappe evaluates it per rule, then closes **every** ToDo on the document:

```python
to_close_todos = assignment_rule.safe_eval("close_condition", doc)
if to_close_todos:
    todos_to_close = frappe.get_all("ToDo", filters={
        "reference_type": doc.doctype,
        "reference_name": str(doc.name),      # no assignment_rule filter
    })
```

With three rules on one doctype, the two whose state is not the current one **both** satisfy it — on a Draft event, `!= "Pending Operations Manager"` and `!= "Pending Project Manager"` are both true. So the assignment `Client Event - Draft` had just made was closed by rules that had nothing to do with it. The only guard is `if not new_apply`, which spares it during the run that created it; the next save closes it.

`unassign_condition` says the same thing and **is** scoped — `apply_unassign` runs only when the rule's own name appears on one of the document's assignments. Both pending rules move their condition there and hold no `close_condition` at all.

## A second bug found alongside it

`Client Event - Draft` released the owner on `workflow_state == "Pending Project Manager"`. But an event with **no project** is submitted to *Pending Operations Manager* — so on that route the Draft assignment stayed open next to the approver's, forever. It now releases on anything that is not Draft.

## Worth knowing

The fixtures spell `"close_condition": ""` rather than omitting the key. `create_assignment_rule` does `doc.update(fixture)`, which only writes the keys it is given — a key left out keeps whatever the record already had, which is how the first attempt at this left both conditions in place. The patch's own verify caught it.

## Verified against live data, through Frappe's own `apply()`

| step | result |
|---|---|
| Draft | owner assigned, **Open** |
| save again ×2 | still **Open** |
| → Pending Project Manager | Draft cancelled, PM's **Open** |
| → back to Draft | PM cancelled, owner's **Open** again |

The patch now refuses to finish if any Client Event rule still carries a `close_condition`. Tag bumped to `#2026-09-06c` so it runs again where `b` is already recorded.

29 tests pass, including two driven through `apply()` rather than reading conditions — the conditions each look right alone and still cancel each other out when all three run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
