### PR TITLE
WI-002400: Send a Proof of Work PDF to Drive from the record itself

### DIFF
--- a/one_fm/one_fm/doctype/proof_of_work/proof_of_work.js
+++ b/one_fm/one_fm/doctype/proof_of_work/proof_of_work.js
@@ -1,18 +1,61 @@
 // Copyright (c) 2026, ONEFM and contributors
 // For license information, please see license.txt
 
+// WI-002400: the record offers exactly one of two buttons, decided by whether its PDF
+// has reached Google Drive. Nothing is downloaded locally any more - the point of the
+// story is that the file lives in the shared folder rather than on somebody's machine.
+const POW_DRIVE_EVENT = "pow_drive_pdf";
+
 frappe.ui.form.on("Proof of Work", {
-	refresh(frm) {
-		// WI-001808: the POW Letter and the Attendance Report are one PDF per contract -
-		// Letter (summary + signature) first, Attendance Report (detail grid) after it.
-		if (!frm.is_new()) {
-			frm.add_custom_button(__("Download PDF"), () => {
-				const method = "one_fm.one_fm.doctype.proof_of_work.proof_of_work.export_pdf";
-				window.open(
-					`/api/method/${method}?name=${encodeURIComponent(frm.doc.name)}`,
-					"_blank"
-				);
+	onload(frm) {
+		// The upload happens in a background job, so the button has to change when the
+		// job says so rather than when the click returns.
+		if (!frm.__pow_drive_listener) {
+			frm.__pow_drive_listener = true;
+			frappe.realtime.on(POW_DRIVE_EVENT, (data) => {
+				if (!data || data.name !== frm.doc.name) {
+					return;
+				}
+				frm.doc.drive_file_id = data.drive_file_id;
+				frm.refresh();
 			});
 		}
 	},
+
+	refresh(frm) {
+		if (frm.is_new()) {
+			return;
+		}
+
+		if (frm.doc.drive_file_id) {
+			frm.add_custom_button(__("Open in Google Drive"), () => {
+				window.open(pow_drive_file_link(frm.doc.drive_file_id), "_blank");
+			});
+			return;
+		}
+
+		frm.add_custom_button(__("Generate PDF"), () => generate_drive_pdf(frm));
+	},
 });
+
+function pow_drive_file_link(file_id) {
+	return `https://drive.google.com/file/d/${encodeURIComponent(file_id)}/view`;
+}
+
+function generate_drive_pdf(frm) {
+	frappe.call({
+		method: "one_fm.one_fm.doctype.proof_of_work.proof_of_work.generate_drive_pdf",
+		args: { name: frm.doc.name },
+		freeze: true,
+		freeze_message: __("Sending this Proof of Work to Google Drive..."),
+		callback: () => {
+			// Queued, not done. The button stays as it is until the job reports back -
+			// swapping it here would show "Open in Google Drive" for a file that may
+			// never arrive.
+			frappe.show_alert({
+				message: __("Generating the PDF and uploading it to Google Drive."),
+				indicator: "blue",
+			});
+		},
+	});
+}

--- a/one_fm/one_fm/doctype/proof_of_work/proof_of_work.json
+++ b/one_fm/one_fm/doctype/proof_of_work/proof_of_work.json
@@ -17,6 +17,7 @@
   "start_date",
   "end_date",
   "generation_basis",
+  "drive_file_id",
   "section_break_hyox",
   "proof_of_work_item",
   "proof_of_work_items_nonmanpower"
@@ -86,6 +87,14 @@
    "options": "\nShift Hours\nAttendance Day\nBoth"
   },
   {
+   "description": "Set when the merged PDF reaches Google Drive. Its presence is what decides whether the record offers Generate PDF or Open in Google Drive.",
+   "fieldname": "drive_file_id",
+   "fieldtype": "Data",
+   "label": "Google Drive File ID",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
    "fieldname": "section_break_hyox",
    "fieldtype": "Section Break"
   },
@@ -105,7 +114,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-07-29 21:40:00.000000",
+ "modified": "2026-09-07 02:00:00.000000",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Proof of Work",

--- a/one_fm/one_fm/doctype/proof_of_work/proof_of_work.py
+++ b/one_fm/one_fm/doctype/proof_of_work/proof_of_work.py
@@ -1144,6 +1144,10 @@ def export_pdf(name: str):
 # Document Register uses - so the configured folder has to be shared with it.
 # ---------------------------------------------------------------------------
 
+# Pushed to whoever has the record open when its PDF reaches Drive (WI-002400), so the
+# button becomes "Open in Google Drive" without a reload.
+POW_DRIVE_EVENT = "pow_drive_pdf"
+
 # On Google Settings, per the work item. Note the upload still authenticates with the
 # service account JSON on ONEFM General Setting - that is the identity the folder has to
 # be shared with, not the OAuth client Google Settings configures.
@@ -1231,6 +1235,33 @@ def _folder_link(folder_id: str) -> str:
 	return f"https://drive.google.com/drive/folders/{folder_id}"
 
 
+def drive_file_link(file_id: str) -> str:
+	"""The Drive viewer for one uploaded PDF (WI-002400).
+
+	/view rather than the folder: the reader wants the document they were looking at,
+	and Drive renders a PDF in the browser from this address.
+	"""
+	return f"https://drive.google.com/file/d/{file_id}/view"
+
+
+def _remember_upload(pow_name: str, file_id: str):
+	"""Record that this document reached Drive, and tell an open form about it.
+
+	Written straight to the row: a Proof of Work is submitted by the time it is
+	uploaded, and re-saving one from a background job would fight that. The realtime
+	event is what turns "Generate PDF" into "Open in Google Drive" without a reload,
+	which is what the criteria ask for.
+	"""
+	frappe.db.set_value("Proof of Work", pow_name, "drive_file_id", file_id, update_modified=False)
+	frappe.publish_realtime(
+		event=POW_DRIVE_EVENT,
+		message={"name": pow_name, "drive_file_id": file_id},
+		doctype="Proof of Work",
+		docname=pow_name,
+		after_commit=True,
+	)
+
+
 def _check_drive_folder(service, folder_id: str):
 	"""Fail before the batch, saying what to do about it (WI-001981).
 
@@ -1310,7 +1341,8 @@ def _upload_pow_pdfs(pow_names, user: str):
 				folders[period] = _period_folder(service, parent_id, period)
 
 			filename, content = _pow_pdf_entry(doc)
-			_upload_pdf(service, folders[period], filename, content)
+			file_id = _upload_pdf(service, folders[period], filename, content)
+			_remember_upload(pow_name, file_id)
 			uploaded.append(filename)
 		except Exception:
 			failed.append(pow_name)
@@ -1410,6 +1442,82 @@ def _notify_zip(user: str, message: str, file_url: str = None, link_label: str =
 		body += f'<br><br><a href="{file_url}" target="_blank">{escape_html(label)}</a>'
 
 	frappe.publish_realtime(event="msgprint", message=body, user=user)
+
+
+@frappe.whitelist(methods=["POST"])
+def generate_drive_pdf(name: str):
+	"""Render one Proof of Work and put it in Drive (WI-002400).
+
+	The retry for a record the bulk run could not upload, and the way a record gets its
+	PDF at all when it was submitted without one. Queued rather than done here: two print
+	formats and a Drive round trip outlive an HTTP request, which is what made the bulk
+	export a background job in the first place.
+	"""
+	_guard_permission()
+
+	doc = frappe.get_doc("Proof of Work", name)
+	doc.check_permission("read")
+
+	if not _configured_drive_folder():
+		frappe.throw(
+			_(
+				"No Proof of Work Drive folder is set on Google Settings, so there is nowhere "
+				"to upload to."
+			),
+			title=_("Drive Folder Not Configured"),
+		)
+
+	frappe.enqueue(
+		_generate_one_drive_pdf,
+		queue="long",
+		timeout=600,
+		pow_name=name,
+		user=frappe.session.user,
+	)
+
+	return {"queued": name}
+
+
+def _generate_one_drive_pdf(pow_name: str, user: str):
+	"""Upload one record's PDF, and say either way (WI-002400).
+
+	Reuses the batch's own upload so a PDF made here is the one the batch would have
+	made, filed in the same period folder.
+
+	A failure is reported to the user rather than only logged: they pressed a button and
+	are waiting for it, and the criteria ask for a message they can act on. The button
+	stays where it is, because nothing about the record changed.
+	"""
+	try:
+		doc = frappe.get_doc("Proof of Work", pow_name)
+		service = google_credentials.get_drive_service()
+		parent_id = _configured_drive_folder()
+		_check_drive_folder(service, parent_id)
+
+		period = _period_folder_name(doc.start_date)
+		folder_id = _period_folder(service, parent_id, period)
+
+		filename, content = _pow_pdf_entry(doc)
+		file_id = _upload_pdf(service, folder_id, filename, content)
+		_remember_upload(pow_name, file_id)
+		frappe.db.commit()
+	except Exception:
+		frappe.log_error(
+			title="Proof of Work Drive upload failed",
+			message=f"{pow_name}\n\n{frappe.get_traceback()}",
+		)
+		_notify_zip(
+			user,
+			_("Failed to upload {0} to Google Drive. Please try again.").format(pow_name),
+		)
+		return
+
+	_notify_zip(
+		user,
+		_("{0} uploaded to Google Drive.").format(filename),
+		file_url=drive_file_link(file_id),
+		link_label=_("Open in Google Drive"),
+	)
 
 
 @frappe.whitelist(methods=["POST"])

--- a/one_fm/one_fm/doctype/proof_of_work/proof_of_work_list.js
+++ b/one_fm/one_fm/doctype/proof_of_work/proof_of_work_list.js
@@ -57,11 +57,12 @@ function open_pow_generator() {
 				fieldtype: "HTML",
 			},
 		],
-		// WI-001808: generation submits the records. "Submit and Download Zip File"
-		// does the same and then queues one merged PDF per contract into a ZIP.
+		// WI-001808: generation submits the records. The second action does the same and
+		// then queues one merged PDF per contract - to Google Drive (WI-002400), or into
+		// a ZIP on a site with no Drive folder configured.
 		primary_action_label: __("Submit"),
 		primary_action: () => generate_pow(dialog, false),
-		secondary_action_label: __("Submit and Download Zip File"),
+		secondary_action_label: __("Generate Google Drive PDF"),
 		secondary_action: () => generate_pow(dialog, true),
 	});
 
@@ -178,7 +179,7 @@ function generate_pow(dialog, download_zip) {
 	}
 
 	const confirm_message = download_zip
-		? __("Generate and submit {0} Proof of Work record(s), then build the ZIP?", [
+		? __("Generate and submit {0} Proof of Work record(s), then upload the PDFs?", [
 				selected.length,
 		  ])
 		: __("Generate and submit {0} Proof of Work record(s)?", [selected.length]);

--- a/one_fm/one_fm/doctype/proof_of_work/test_proof_of_work.py
+++ b/one_fm/one_fm/doctype/proof_of_work/test_proof_of_work.py
@@ -1222,3 +1222,153 @@ class TestTheExportGoesToDrive(FrappeTestCase):
 
 		self.assertEqual(result["destination"], "zip")
 		self.assertEqual(enqueue.call_args.args[0].__name__, "_build_pow_zip")
+
+
+class TestTheRecordRemembersItsDrivePdf(FrappeTestCase):
+	"""WI-002400: a record offers exactly one of two buttons, and drive_file_id decides.
+
+	Drive is mocked throughout - what is under test is what the record is left holding
+	and which link it points at, not Google.
+	"""
+
+	MODULE = "one_fm.one_fm.doctype.proof_of_work.proof_of_work"
+
+	def test_the_link_opens_the_file_not_the_folder(self):
+		"""The reader wants the document they were looking at, and Drive renders a PDF
+		in the browser from /view."""
+		from one_fm.one_fm.doctype.proof_of_work.proof_of_work import drive_file_link
+
+		self.assertEqual(
+			drive_file_link("ABC123"), "https://drive.google.com/file/d/ABC123/view"
+		)
+
+	def test_the_form_and_the_server_build_the_same_link(self):
+		"""The button is drawn in JavaScript and the notification link in Python; a
+		record opening two different places is the sort of thing nobody notices."""
+		script = frappe.read_file(
+			frappe.get_app_path(
+				"one_fm", "one_fm", "doctype", "proof_of_work", "proof_of_work.js"
+			)
+		)
+
+		self.assertIn("https://drive.google.com/file/d/", script)
+		self.assertIn("/view", script)
+
+	def test_a_successful_upload_is_written_to_the_record(self):
+		from unittest.mock import patch
+
+		from one_fm.one_fm.doctype.proof_of_work.proof_of_work import _remember_upload
+
+		doc = frappe.new_doc("Proof of Work")
+		doc.contract = "_TEST-CONTRACT-DRIVE"
+		doc.start_date = get_first_day(getdate())
+		doc.end_date = get_last_day(getdate())
+		doc.flags.ignore_mandatory = True
+		doc.insert(ignore_permissions=True, ignore_links=True)
+
+		with patch("frappe.publish_realtime") as published:
+			_remember_upload(doc.name, "FILEID-1")
+
+		self.assertEqual(
+			frappe.db.get_value("Proof of Work", doc.name, "drive_file_id"), "FILEID-1"
+		)
+		# Without the push, the button only changes on a reload.
+		self.assertTrue(published.called)
+		self.assertEqual(published.call_args.kwargs["message"]["drive_file_id"], "FILEID-1")
+
+	def test_the_field_is_read_only_and_not_copied_onto_an_amendment(self):
+		"""It says where a particular PDF went. An amendment has not been uploaded, and
+		inheriting the link would offer the reader the wrong document."""
+		field = frappe.get_meta("Proof of Work").get_field("drive_file_id")
+
+		self.assertTrue(field, "drive_file_id is missing from Proof of Work")
+		self.assertTrue(field.read_only)
+		self.assertTrue(field.no_copy)
+
+	def test_a_failed_upload_leaves_the_record_without_a_link(self):
+		"""Scenario 3: the record still stands, and still offers Generate PDF."""
+		from unittest.mock import MagicMock, patch
+
+		from one_fm.one_fm.doctype.proof_of_work.proof_of_work import _generate_one_drive_pdf
+
+		with patch(f"{self.MODULE}.google_credentials.get_drive_service", MagicMock()), patch(
+			f"{self.MODULE}._configured_drive_folder", return_value="PARENT"
+		), patch(f"{self.MODULE}._check_drive_folder"), patch(
+			f"{self.MODULE}._period_folder", return_value="FOLDER"
+		), patch(
+			f"{self.MODULE}._pow_pdf_entry", side_effect=Exception("render blew up")
+		), patch(
+			f"{self.MODULE}._remember_upload"
+		) as remembered, patch(
+			f"{self.MODULE}._notify_zip"
+		) as notified, patch(
+			"frappe.log_error"
+		):
+			_generate_one_drive_pdf("POW-DOES-NOT-MATTER", "Administrator")
+
+		remembered.assert_not_called()
+		self.assertTrue(notified.called)
+		# Scenario 7 asks for a message the user can act on, naming the retry.
+		self.assertIn("try again", notified.call_args.args[1].lower())
+
+	def test_a_successful_generation_reports_the_file(self):
+		from unittest.mock import MagicMock, patch
+
+		from one_fm.one_fm.doctype.proof_of_work.proof_of_work import _generate_one_drive_pdf
+
+		# A document is loaded before anything else happens, so it has to exist.
+		doc = frappe.new_doc("Proof of Work")
+		doc.contract = "_TEST-CONTRACT-DRIVE-OK"
+		doc.start_date = get_first_day(getdate())
+		doc.end_date = get_last_day(getdate())
+		doc.flags.ignore_mandatory = True
+		doc.insert(ignore_permissions=True, ignore_links=True)
+
+		with patch(f"{self.MODULE}.google_credentials.get_drive_service", MagicMock()), patch(
+			f"{self.MODULE}._configured_drive_folder", return_value="PARENT"
+		), patch(f"{self.MODULE}._check_drive_folder"), patch(
+			f"{self.MODULE}._period_folder", return_value="FOLDER"
+		), patch(
+			f"{self.MODULE}._pow_pdf_entry", return_value=("POW.pdf", b"%PDF-")
+		), patch(
+			f"{self.MODULE}._upload_pdf", return_value="FILEID-OK"
+		), patch(
+			f"{self.MODULE}._notify_zip"
+		) as notified, patch(
+			"frappe.publish_realtime"
+		):
+			_generate_one_drive_pdf(doc.name, "Administrator")
+
+		self.assertEqual(
+			frappe.db.get_value("Proof of Work", doc.name, "drive_file_id"), "FILEID-OK"
+		)
+		self.assertEqual(
+			notified.call_args.kwargs.get("file_url"),
+			"https://drive.google.com/file/d/FILEID-OK/view",
+		)
+
+	def test_the_bulk_button_says_where_the_pdfs_go(self):
+		"""Scenario 1: the label names Drive, not a ZIP download."""
+		script = frappe.read_file(
+			frappe.get_app_path(
+				"one_fm", "one_fm", "doctype", "proof_of_work", "proof_of_work_list.js"
+			)
+		)
+
+		self.assertIn('__("Generate Google Drive PDF")', script)
+		self.assertNotIn("Submit and Download Zip File", script)
+
+	def test_the_form_offers_one_button_or_the_other(self):
+		"""Scenarios 2 and 4: the two are mutually exclusive, decided by drive_file_id."""
+		script = frappe.read_file(
+			frappe.get_app_path(
+				"one_fm", "one_fm", "doctype", "proof_of_work", "proof_of_work.js"
+			)
+		)
+
+		self.assertIn('if (frm.doc.drive_file_id)', script)
+		self.assertIn('__("Open in Google Drive")', script)
+		self.assertIn('__("Generate PDF")', script)
+		# The early return after the Drive button is what keeps Generate PDF hidden.
+		drive_branch = script.split("if (frm.doc.drive_file_id)")[1].split("frm.add_custom_button(__(\"Generate PDF\")")[0]
+		self.assertIn("return;", drive_branch)


### PR DESCRIPTION
Closes WI-002400.

The bulk export already uploaded to Google Drive (WI-001981), but nothing came back to the record: `_upload_pdf` returned a file id and the caller threw it away. So a document could not say whether its PDF existed, and the only thing the form offered was **Download PDF** — a local download, which is the thing the story is trying to stop.

## What the record now knows

One new field, `drive_file_id` (Data, read-only, `no_copy`), written when an upload succeeds. It alone decides what the form offers:

| `drive_file_id` | button |
|---|---|
| set | **Open in Google Drive** — the file's own `/view` address, new tab |
| unset | **Generate PDF** |

Never both — the Drive branch returns before the other button is added. That covers scenarios 2, 4 and 6. The link is the file rather than the folder, so the reader lands on the document they were looking at.

## Scenario by scenario

1. **Label** — the bulk action is now `Generate Google Drive PDF`.
2. **Bulk success** — `_upload_pow_pdfs` keeps the file id and writes it to each record, so every uploaded one opens in Drive and hides Generate PDF.
3. **Individual failure** — the batch already saves and submits before it tries to upload, and a failed record simply gets no link, so it keeps its Generate PDF button and offers no Drive link. No new code was needed for the "still submit" half; a test pins it.
4. **Not yet generated** — no link, so Generate PDF.
5. **Generate** — `generate_drive_pdf` queues the same upload the batch uses, so a retry produces the PDF the batch would have, in the same period folder. The button changes when the **job** reports, over a realtime event on the document — not when the click returns, which would show "Open in Google Drive" for a file that may never arrive.
6. **Open** — new tab, Drive's own PDF viewer.
7. **Failure** — reported to the user, not only to the Error Log: they pressed a button and are waiting. The message names the retry, and the button stays put because nothing about the record changed.

## Judgement calls, flagged

- **`export_pdf` is left in place.** Nothing calls it now, but it is a whitelisted API and removing one is not what this story asks for. Say the word and it goes.
- **The ZIP fallback survives.** WI-001981 kept a ZIP for a site with no Drive folder configured. Scenario 1 names the button unconditionally, so a site without a folder now has a button that says Drive and produces a ZIP. The single-record path refuses outright with a message naming the setting. If you would rather the fallback go, that is a one-line change.
- **A missed realtime event costs a reload, not a wrong button** — the form reads `drive_file_id` on every refresh either way.

## ⚠️ Not verified yet

The database is mid-restore, so **nothing here has been run**. The tests are written but unexecuted, and the realtime refresh in particular wants a live check that the desk form receives a document-room event. I will run the suite and confirm as soon as the site is back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
