### PR TITLE
Align staging's canvas load with production: read a placed card's headcount from its shipment

### DIFF
--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -4,7 +4,12 @@ from frappe import _
 from frappe.utils import cint
 from one_fm.one_fm.doctype.transportation_manifest.manifest_sync import sync_manifest_details
 from one_fm.one_fm.doctype.vehicle_handover_log.vehicle_handover_log import get_handover_windows
-from one_fm.operations.doctype.route_plan.route_plan import _card_direction, card_rows
+from one_fm.operations.doctype.route_plan.route_plan import (
+    _card_direction,
+    card_rows,
+    live_headcounts,
+    row_headcount,
+)
 from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
     driver_employees,
     qoa_buffer_minutes,
@@ -960,8 +965,6 @@ def _build_transportation_shipment_cards(fmt, to_utc, get_coords_cached, timedel
     # nobody on it is travelling as a passenger. Generation stops making these, but
     # records made before that still exist, and an Assigned one cannot be pruned, so the
     # canvas has to refuse them itself rather than wait for a Generate run.
-    inactive_shifts = _inactive_shifts(shipments)
-
     drivers = driver_employees([row.employee_id for row in emp_rows])
     driver_only = {
         ship
@@ -983,6 +986,7 @@ def _build_transportation_shipment_cards(fmt, to_utc, get_coords_cached, timedel
     # going to plan. Generation already stops making them and prunes the Unassigned
     # ones, but that only runs daily or on the button - the dispatcher opening the board
     # in between would still be looking at them, and an Assigned card is never pruned.
+    inactive_shifts = _inactive_shifts(shipments)
     shipments = [s for s in shipments if not _serves_only_inactive_shifts(s, inactive_shifts)]
 
     # Fallback times for shipments without an Operations Shift (ad-hoc journeys).
@@ -1354,6 +1358,13 @@ def load_assignments(plan_name: str = ""):
     doc = frappe.get_doc("Route Plan", plan_name)
     doc.check_permission("read")
 
+    # A saved row's ``headcount`` is a snapshot of the moment the card was dropped and
+    # is never refreshed, so a shipment that has since gained or lost an employee left
+    # the timeline block and the client-side seat guard reading a number the sidebar
+    # (which loads the shipment) already disagreed with. The shipment is the authority
+    # here for the same reason it is on the Route Plan save.
+    live = live_headcounts(doc.assignments)
+
     swim_items = []
     assigned_card_ids = set()
     # The minutes of the legs no card is filed against, keyed by the run and the camp
@@ -1395,7 +1406,7 @@ def load_assignments(plan_name: str = ""):
             "direction": row.direction,
             "start":     row.start_time,
             "end":       row.end_time,
-            "headcount": row.headcount or 0,
+            "headcount": row_headcount(row, live),
             "conflict":  False,
             "tripId":    row.trip_group or None,
             "tripName":  row.trip_name or None,


### PR DESCRIPTION
`version-15` (and therefore production) reads a placed card's headcount from the shipment it points at. `staging` still reads the snapshot stored on the Route Plan Assignment row.

That snapshot is taken when the card is dropped and never refreshed. So a shipment that has since gained or lost an employee left the timeline block — and the client-side seat guard reading it — showing a number the sidebar had already moved on from, because the sidebar loads the shipment. The Route Plan **save** has read the shipment since #6818; this is the same rule on the way **in**.

### Why this PR exists

The two branches had diverged. This change is live on `version-15` but never reached `staging`, so the board disagreed with itself depending on which branch served it. Raising it here so the two align.

### What is in it

| Change | Why |
|---|---|
| `load_assignments` calls `live_headcounts(doc.assignments)` and each swim item takes `row_headcount(row, live)` | the shipment is the authority for how many people a card carries |
| `inactive_shifts = _inactive_shifts(shipments)` moved next to the filter that uses it | where `version-15` has it — see note below |

The `inactive_shifts` move is behaviour-neutral. It was sitting under the WI-002306 *driver* comment, 20 lines above its only use, and was computed from the pre-driver-filter list. The extra shift names it collected belong only to cards the driver filter had already removed, so `_serves_only_inactive_shifts` never asks about them. Included purely so the two branches do not differ at all in this file.

### Verification

Comments stripped from both files and diffed — `staging`'s `transportation_schedule.py` is now **code-identical** to `version-15`'s.

Test modules run green on this branch:

- `page.transportation_schedule.test_transportation_schedule` — 22 passed
- `page.transportation_schedule.test_inactive_shipment_cards` — 13 passed
- `doctype.transportation_shipment.test_driver_exclusion` — 13 passed
- `operations.doctype.route_plan.test_route_plan` — 71 passed

No schema change, no patch. `bench build --app one_fm` is not needed either — Python only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)