### PR TITLE
WI-002401: [Irfan] Transportation Feedback — seat rule per run, and cards that tell the truth about themselves

### DIFF
--- a/one_fm/one_fm/doctype/transportation_manifest/manifest_sync.py
+++ b/one_fm/one_fm/doctype/transportation_manifest/manifest_sync.py
@@ -9,7 +9,7 @@ and reuse across the schedule page backend and any future callers.
 """
 
 
-def sync_manifest_details(manifest_doc, assignment_rows, emp_map, return_emp_map):
+def sync_manifest_details(manifest_doc, assignment_rows, emp_map):
 	"""Upsert child rows using compound key: (employee, trip_id, stop_id, employee_action).
 
 	New employees/stops are appended. Existing rows have system fields refreshed
@@ -19,8 +19,10 @@ def sync_manifest_details(manifest_doc, assignment_rows, emp_map, return_emp_map
 	Args:
 		manifest_doc: A Transportation Manifest document (new or existing).
 		assignment_rows: List of Route Plan Assignment child rows for this vehicle.
-		emp_map: Dict mapping card_id -> list of employee dicts (OUTBOUND).
-		return_emp_map: Dict mapping card_id -> list of employee dicts (RETURN).
+		emp_map: Dict mapping card_id -> the card's riders, whichever way a leg of it
+			travels. There used to be a second map for RETURN legs and nothing ever
+			filled it, so every return row on a driver's manifest listed nobody while
+			its card carried the people (WI-002401).
 
 	Returns:
 		True if any rows were added or updated.
@@ -60,7 +62,7 @@ def sync_manifest_details(manifest_doc, assignment_rows, emp_map, return_emp_map
 
 	for a_row in assignment_rows:
 		direction = a_row.direction
-		emps = (return_emp_map if direction == "RETURN" else emp_map).get(a_row.card_id, [])
+		emps = emp_map.get(a_row.card_id, [])
 		# What this rider does at the PICKUP CAMP - an outward rider boards there, a
 		# return rider is dropped there - which is what the attendance-check lock keys
 		# off. What happens at the STOP is the opposite, and is not duplicated here: the

--- a/one_fm/one_fm/doctype/transportation_manifest/test_transportation_manifest.py
+++ b/one_fm/one_fm/doctype/transportation_manifest/test_transportation_manifest.py
@@ -263,18 +263,18 @@ class TestTransportationManifest(FrappeTestCase):
 		)]
 		emp_map = {"C1": [{"id": self.employee1, "name": "Emp 1"}]}
 
-		changed = sync_manifest_details(doc, assignments, emp_map, {})
+		changed = sync_manifest_details(doc, assignments, emp_map)
 		self.assertTrue(changed)
 		self.assertEqual(len(doc.transportation_manifest_details), 1)
 
 		# Second sync — add employee2 to same stop
 		emp_map = {"C1": [{"id": self.employee1, "name": "Emp 1"}, {"id": self.employee2, "name": "Emp 2"}]}
-		changed = sync_manifest_details(doc, assignments, emp_map, {})
+		changed = sync_manifest_details(doc, assignments, emp_map)
 		self.assertTrue(changed)
 		self.assertEqual(len(doc.transportation_manifest_details), 2)
 
 		# Third sync — same data, no changes
-		changed = sync_manifest_details(doc, assignments, emp_map, {})
+		changed = sync_manifest_details(doc, assignments, emp_map)
 		self.assertFalse(changed)
 		self.assertEqual(len(doc.transportation_manifest_details), 2)
 
@@ -298,7 +298,7 @@ class TestTransportationManifest(FrappeTestCase):
 		emp_map = {"C1": [{"id": self.employee1, "name": "Emp 1"}]}
 
 		# Initial sync
-		sync_manifest_details(doc, assignments, emp_map, {})
+		sync_manifest_details(doc, assignments, emp_map)
 		doc.save()
 
 		# Simulate dispatcher marking attendance
@@ -308,7 +308,7 @@ class TestTransportationManifest(FrappeTestCase):
 
 		# Re-sync with updated schedule time — manual fields must survive
 		assignments[0].start_time = "06:30:00"
-		changed = sync_manifest_details(doc, assignments, emp_map, {})
+		changed = sync_manifest_details(doc, assignments, emp_map)
 
 		# Must report a change so callers know to save
 		self.assertTrue(changed)
@@ -354,7 +354,7 @@ class TestTransportationManifest(FrappeTestCase):
 		)]
 		emp_map = {"C1": [{"id": self.employee1, "name": "Emp 1"}]}
 
-		changed = sync_manifest_details(doc, assignments, emp_map, {})
+		changed = sync_manifest_details(doc, assignments, emp_map)
 
 		# Should have backfilled stop_id, not duplicated
 		self.assertEqual(len(doc.transportation_manifest_details), 1)

--- a/one_fm/one_fm/doctype/transportation_shipment/shipment_generator.py
+++ b/one_fm/one_fm/doctype/transportation_shipment/shipment_generator.py
@@ -34,21 +34,8 @@ TRIP_REQUEST = "Trip Request"
 # transportation methods are handled off the fleet scheduling canvas.
 COMPANY_FLEET = "Company Fleet"
 MAHBOULA_LABELS = {"Mahboula 3", "Mahboula 12", "Mahboula 13", "Mahboula 15"}
-# Return riders may finish up to an hour after the outbound leg departs.
-RETURN_MATCH_FLOOR_SECONDS = -3600
 # Who may refresh the shipment cards from the canvas (WI-002162).
 GENERATE_ROLES = ("System Manager", "Transportation Manager", "Transportation Supervisor")
-
-
-def _minute_of_day(time_val) -> int | None:
-	"""Seconds-since-midnight for a Time value, used for return-rider matching."""
-	if not time_val:
-		return None
-	try:
-		dt = get_datetime(f"2000-01-01 {time_val}")
-		return dt.hour * 3600 + dt.minute * 60 + dt.second
-	except Exception:
-		return None
 
 
 def build_demand_descriptors(nested_map: dict) -> list:
@@ -274,7 +261,6 @@ def build_demand_descriptors(nested_map: dict) -> list:
 				"employees": [emp_obj(e) for e in grp["employees"]],
 			})
 
-	_attach_return_rosters(demands)
 	return demands
 
 
@@ -305,41 +291,6 @@ def _without_drivers(nested_map: dict) -> dict:
 			trimmed[acc_name] = dict(acc_data, shifts=shifts)
 
 	return trimmed
-
-
-def _attach_return_rosters(demands: list) -> None:
-	"""For each demand, find the finishing-shift roster at the same stop/accommodation.
-
-	Mirrors the return-rider cross-reference in get_route_planner_data: same stop
-	location, same accommodation, a different shift whose end time sits closest to
-	(and not long after) this demand's start time.
-	"""
-	by_stop = {}
-	for d in demands:
-		by_stop.setdefault(d["stop_location"], []).append(d)
-
-	for d in demands:
-		start_s = _minute_of_day(d["start_time"])
-		d["return_employees"] = []
-		if start_s is None:
-			continue
-
-		best, best_gap = None, float("inf")
-		for other in by_stop.get(d["stop_location"], []):
-			if other is d or other["group_token"] == d["group_token"]:
-				continue
-			if other["acc_name"] != d["acc_name"]:
-				continue
-			end_s = _minute_of_day(other["end_time"])
-			if end_s is None:
-				continue
-			diff = start_s - end_s
-			if diff >= RETURN_MATCH_FLOOR_SECONDS and abs(diff) < best_gap:
-				best_gap = abs(diff)
-				best = other
-
-		if best:
-			d["return_employees"] = best["employees"]
 
 
 def _generation_key(demand: dict, direction: str) -> tuple:
@@ -401,9 +352,26 @@ def generate_transportation_shipments():
 	for demand in demands:
 		for direction in ("Outward", "Return"):
 			try:
-				roster = demand["employees"] if direction == "Outward" else (
-					demand.get("return_employees") or demand["employees"]
-				)
+				# The same people, both ways. A card is "these riders, from this camp,
+				# to this site", and they come home again - so its Return leg carries
+				# its own crew.
+				#
+				# It used to substitute the roster of a DIFFERENT shift: the one
+				# finishing as this demand starts, on the reasoning that the bus
+				# arriving at 06:00 also takes the outgoing crew home. That is a real
+				# run, but it is not this card: the card's window comes from its own
+				# end_time, so the substituted riders were filed against an hour twelve
+				# hours from when they actually finish. 250 of 376 generated Return
+				# cards on the live plan carried another shift's people, and the
+				# Alghanim Guest House Day crew were told to be collected at 18:00 when
+				# their card held the Night crew who finish at 06:00 (WI-002401).
+				#
+				# Collecting the outgoing crew on the incoming run is what a Mixed trip
+				# IS: the dispatcher drops the other shift's Return card onto this run
+				# and the merge walks the legs. That machinery already exists, and it
+				# can only read the run correctly if each card tells the truth about
+				# whose ride it is.
+				roster = demand["employees"]
 				if not roster:
 					continue
 

--- a/one_fm/one_fm/doctype/transportation_shipment/test_transportation_shipment.py
+++ b/one_fm/one_fm/doctype/transportation_shipment/test_transportation_shipment.py
@@ -101,12 +101,6 @@ class TestTransportationShipment(FrappeTestCase):
 
 
 class TestShipmentGenerator(FrappeTestCase):
-	def test_minute_of_day(self):
-		from one_fm.one_fm.doctype.transportation_shipment.shipment_generator import _minute_of_day
-
-		self.assertEqual(_minute_of_day("06:30:00"), 6 * 3600 + 30 * 60)
-		self.assertIsNone(_minute_of_day(None))
-
 	def test_generation_key_shape(self):
 		from one_fm.one_fm.doctype.transportation_shipment.shipment_generator import _generation_key
 
@@ -125,22 +119,40 @@ class TestShipmentGenerator(FrappeTestCase):
 		self.assertEqual(pair, pair_ret)
 		self.assertNotEqual(key, key_ret)
 
-	def test_attach_return_rosters_matches_finishing_shift(self):
-		from one_fm.one_fm.doctype.transportation_shipment.shipment_generator import _attach_return_rosters
+	def test_a_cards_return_leg_carries_its_own_crew(self):
+		"""The same people, both ways (WI-002401).
 
-		# Two demands at the same stop/accommodation, different shifts. The one
-		# starting at 14:00 should pick up the roster of the shift ending 14:00.
-		morning = {
-			"acc_name": "Camp A", "stop_location": "LOC-1", "group_token": "MORNING",
-			"start_time": "06:00:00", "end_time": "14:00:00", "employees": [{"id": "M1"}],
-		}
-		evening = {
-			"acc_name": "Camp A", "stop_location": "LOC-1", "group_token": "EVENING",
-			"start_time": "14:00:00", "end_time": "22:00:00", "employees": [{"id": "E1"}],
-		}
-		_attach_return_rosters([morning, evening])
-		# Evening outbound starts when morning ends -> return riders are the morning crew.
-		self.assertEqual([e["id"] for e in evening["return_employees"]], ["M1"])
+		The generator used to substitute the roster of the shift finishing as this
+		demand STARTS, on the reasoning that the bus arriving at 14:00 also takes the
+		outgoing crew home. That is a real run, but it is not this card: a card's window
+		comes from its own end_time, so the substituted riders were filed against an
+		hour eight hours from when they actually finish. On the live plan 250 of 376
+		generated Return cards carried another shift's people.
+
+		Collecting the outgoing crew on the incoming run is what a Mixed trip IS - the
+		dispatcher drops the other shift's Return card onto this run and the merge walks
+		the legs - and that only reads correctly if each card tells the truth about
+		whose ride it is.
+		"""
+		import inspect
+
+		from one_fm.one_fm.doctype.transportation_shipment import shipment_generator
+
+		source = inspect.getsource(shipment_generator.generate_transportation_shipments)
+		self.assertIn('roster = demand["employees"]', source)
+		# No second roster, and no cross-shift lookup left to feed one.
+		self.assertNotIn("return_employees", source)
+		self.assertFalse(hasattr(shipment_generator, "_attach_return_rosters"))
+
+	def test_a_return_leg_on_the_manifest_lists_the_riders(self):
+		"""A return row used to list nobody while its card carried the people."""
+		import inspect
+
+		from one_fm.one_fm.doctype.transportation_manifest import manifest_sync
+
+		source = inspect.getsource(manifest_sync.sync_manifest_details)
+		self.assertIn("emps = emp_map.get(a_row.card_id, [])", source)
+		self.assertNotIn("return_emp_map", source)
 
 
 class TestTripRequestSplit(FrappeTestCase):

--- a/one_fm/one_fm/doctype/transportation_shipment/transportation_shipment.py
+++ b/one_fm/one_fm/doctype/transportation_shipment/transportation_shipment.py
@@ -82,9 +82,9 @@ class TransportationShipment(Document):
 					self.from_date = trq.from_date
 				if not self.to_date:
 					self.to_date = trq.to_date
-				if not self.start_time:
+				if time_is_blank(self.start_time):
 					self.start_time = trq.departure_time
-				if not self.end_time:
+				if time_is_blank(self.end_time):
 					self.end_time = trq.return_time
 
 		if not self.stop_location:
@@ -389,6 +389,18 @@ def merge_trip_shipments(shipments) -> dict:
 	}
 
 
+def time_is_blank(value) -> bool:
+	"""Whether a Frappe Time field was left unset.
+
+	Not the same as falsy. Midnight comes back as ``timedelta(0)``, so ``if not
+	end_time`` reads a shift that finishes at 00:00 as one with no finish recorded at
+	all - and the literal fallback further down the ``or`` chain then advertised a
+	12:00-00:00 afternoon card as finishing at 18:00 (WI-002401 AC9). Every reader of
+	one of these fields has to ask whether it was STATED, not whether it is non-zero.
+	"""
+	return value is None or value == ""
+
+
 def _seconds_into_day(value) -> int | None:
 	"""A Frappe Time field as seconds past midnight.
 
@@ -567,9 +579,10 @@ def get_merge_preview(shipments, vehicle: str = None, timings=None, departure=No
 	uses, so the seat count the operator is shown is the one the save will judge them by -
 	two implementations would drift and the modal would promise a merge the save refuses.
 
-	Each shipment becomes one stop container. A stop where riders both leave and join is
-	two containers, because a drop-off and a boarding are two things the driver does even
-	when they happen in one place, and the same holds for a stop the run returns to later.
+	Each visit the bus makes is one stop container, carrying both of the movements that
+	can happen there: a drop-off and a boarding are two things the driver does, and a
+	handover stop does both in one place. A stop the run returns to later is a separate
+	visit and so a separate container.
 
 	`timings` optionally carries the per-leg transit and buffer minutes the operator has
 	adjusted, keyed by shipment or by card id; the returned departs/arrives stamps are
@@ -719,9 +732,13 @@ def get_merge_preview(shipments, vehicle: str = None, timings=None, departure=No
 			"shift_location": ", ".join(shift_places) or None,
 			"action": stop["action_type"],
 			"action_type": stop["action_type"],
+			# Both movements, always. A single collapsed "headcount" used to be sent
+			# alongside these - boarding_count or drop_off_count, whichever was
+			# non-zero - and a stop that does both has no such number: reading it made
+			# the modal announce one movement's label against the other's count
+			# (WI-002401). Anything showing a stop reads the two counts.
 			"boarding_count": stop["boarding_count"],
 			"drop_off_count": stop["drop_off_count"],
-			"headcount": stop["boarding_count"] or stop["drop_off_count"],
 			"boards": bool(stop["boarding"]),
 			"boarding_cards": len(stop["boarding"]),
 			"cards": [doc.name for doc in serving],

--- a/one_fm/one_fm/page/transportation_schedule/test_midnight_shift_end.py
+++ b/one_fm/one_fm/page/transportation_schedule/test_midnight_shift_end.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""A shift that ends at midnight says 00:00 on its card (WI-002401 AC9).
+
+A Frappe Time field of 00:00:00 comes back as ``timedelta(0)``, which is falsy. Every
+reader that asked ``if not end_time`` therefore read a shift finishing at midnight as
+one with no finish recorded at all, and fell through to the literal fallback further
+down its ``or`` chain - so a 12:00-00:00 afternoon card advertised an 18:00 finish.
+"""
+
+from datetime import timedelta
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import time_is_blank
+from one_fm.one_fm.page.transportation_schedule.transportation_schedule import _stated_time
+
+
+class TestMidnightIsAStatedTime(FrappeTestCase):
+	def test_midnight_is_not_blank(self):
+		# The whole bug in one line: timedelta(0) is falsy but it is an answer.
+		self.assertFalse(bool(timedelta(0)))
+		self.assertFalse(time_is_blank(timedelta(0)))
+
+	def test_an_unset_time_is_blank(self):
+		self.assertTrue(time_is_blank(None))
+		self.assertTrue(time_is_blank(""))
+
+	def test_a_midnight_finish_is_kept_over_the_fallback(self):
+		self.assertEqual(
+			_stated_time(timedelta(0), None, "18:00:00"),
+			timedelta(0),
+		)
+
+	def test_an_unset_finish_still_takes_the_next_stated_value(self):
+		self.assertEqual(_stated_time(None, "22:30:00", "18:00:00"), "22:30:00")
+		self.assertEqual(_stated_time(None, None, "18:00:00"), "18:00:00")
+
+	def test_a_noon_finish_is_unaffected(self):
+		noon = timedelta(seconds=12 * 3600)
+		self.assertEqual(_stated_time(noon, None, "18:00:00"), noon)
+
+
+class TestAMidnightCardReportsMidnight(FrappeTestCase):
+	"""End to end: the card the board draws carries the shift's real finish."""
+
+	def test_the_card_window_lands_on_midnight_not_on_the_fallback(self):
+		from one_fm.one_fm.page.transportation_schedule.transportation_schedule import (
+			get_route_planner_data,
+		)
+
+		midnight = {
+			row.name for row in frappe.get_all(
+				"Transportation Shipment", filters={"end_time": "00:00:00"}, fields=["name"]
+			)
+		}
+		if not midnight:
+			self.skipTest("No shipment on this site finishes at midnight")
+
+		cards = [
+			card for card in get_route_planner_data()["shipment_cards"]
+			if card.get("shipment") in midnight
+		]
+		if not cards:
+			self.skipTest("No midnight shipment is currently on the board")
+
+		# The stamps are UTC and the site runs at UTC+3, so a Kuwait midnight is 21:00Z
+		# on the day before. What must never appear is the 18:00 fallback (15:00Z).
+		for card in cards:
+			self.assertTrue(
+				card["shift_end"].endswith("T21:00:00Z"),
+				f"{card['shipment']} finishes at {card['shift_end']}, not midnight",
+			)

--- a/one_fm/one_fm/page/transportation_schedule/test_seat_rule.js
+++ b/one_fm/one_fm/page/transportation_schedule/test_seat_rule.js
@@ -1,0 +1,109 @@
+/**
+ * Self-check for the canvas seat rule (WI-002401 AC5).
+ *
+ *   node test_seat_rule.js
+ *
+ * The helpers are read out of transportation_schedule.js itself rather than copied,
+ * so this fails if the shipped rule changes. It mirrors _peak_concurrent_headcount /
+ * _trips_share_the_road on the server (tested in test_route_plan.py) - the two must
+ * not be able to disagree about whether a run fits, or the canvas accepts a drop the
+ * save then refuses.
+ */
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+const src = fs.readFileSync(path.join(__dirname, 'transportation_schedule.js'), 'utf8');
+const from = src.indexOf('            // ── When two runs are on the road together');
+const to = src.indexOf('            // ── Time-aware peak load helper');
+assert.ok(from > 0 && to > from, 'seat-rule helpers not found - did the banners move?');
+
+// eslint-disable-next-line no-eval
+const rule = eval('({' + src.slice(from, to) + '})');
+
+// Stubs for the two collaborators the rule calls out to. A single-direction run
+// carries the sum of its stops; that is all these tests need.
+rule.runDirection = (stops) => {
+    const first = stops[0].direction || 'OUTBOUND';
+    return stops.some(s => (s.direction || 'OUTBOUND') !== first) ? 'MIXED' : first;
+};
+rule.tripOccupancy = (trip) => trip.headcount;
+
+const trip = (name, from_, to_, occupancy) => ({
+    tripId: name, tripName: name, occupancy,
+    window: rule._dayWindow.call(rule, from_, to_),
+    stops: [{ id: name + '_1' }]
+});
+
+// The AC's own scenario, on a 7-seat bus: S-106 05:30-06:05 with 2 aboard and
+// S-102 06:35-08:20 with 5. Stamps are UTC and the site runs at UTC+3.
+const S106 = trip('S-106', '2026-09-07T02:30:00Z', '2026-09-07T03:05:00Z', 2);
+const S102 = trip('S-102', '2026-09-07T03:35:00Z', '2026-09-07T05:20:00Z', 5);
+rule._getLogicalTrips = () => [S106, S102];
+
+// The clock is read in the site's own time zone, so the board and the rule agree.
+assert.strictEqual(S106.window.from, 5 * 3600 + 30 * 60, 'S-106 leaves at 05:30 local');
+assert.strictEqual(S102.window.to, 8 * 3600 + 20 * 60, 'S-102 is back by 08:20 local');
+
+// Sequential runs never see each other.
+assert.ok(!rule._sharesTheRoad(S106.window, S102.window), 'S-106 and S-102 are sequential');
+
+// A 6th passenger onto S-102 fits; so does a 3rd onto S-106. Adding the two runs
+// together made both of them 8 on a 7-seat bus and refused a free seat.
+assert.strictEqual(rule.seatLoad('BUS', 6, { joining: S102.stops }).total, 6);
+assert.strictEqual(rule.seatLoad('BUS', 3, { joining: S106.stops }).total, 3);
+
+// Runs that really do share the road still add up.
+const EARLY = trip('S-201', '2026-09-07T02:30:00Z', '2026-09-07T04:00:00Z', 2);
+const LATE = trip('S-202', '2026-09-07T03:35:00Z', '2026-09-07T05:20:00Z', 5);
+rule._getLogicalTrips = () => [EARLY, LATE];
+assert.ok(rule._sharesTheRoad(EARLY.window, LATE.window), 'these two overlap');
+assert.strictEqual(rule.seatLoad('BUS', 3, { joining: EARLY.stops }).total, 8);
+
+// Midnight is 0, not 24 hours: some engines print "24:00:00" for it and that would
+// put a run that leaves at midnight at the far end of the day.
+assert.strictEqual(rule._clockSeconds('2026-09-06T21:00:00Z'), 0, 'Kuwait midnight is second 0');
+assert.strictEqual(
+    rule._dayWindow('2026-09-06T21:00:00Z', '2026-09-06T21:30:00Z').from, 0,
+    'a run leaving at midnight starts the day'
+);
+
+// A run over midnight keeps its length instead of reading as zero, and still meets
+// an early-morning run (22:00-01:00 against 00:30-01:30).
+const NIGHT = trip('S-301', '2026-09-06T19:00:00Z', '2026-09-06T22:00:00Z', 4);
+const DAWN = trip('S-302', '2026-09-06T21:30:00Z', '2026-09-06T22:30:00Z', 1);
+assert.strictEqual(NIGHT.window.to - NIGHT.window.from, 3 * 3600, 'a night run is 3h long');
+assert.ok(rule._sharesTheRoad(NIGHT.window, DAWN.window), 'a night run meets the small hours');
+
+// A load starting a run of its own is judged on the window it will occupy, and a
+// run nowhere near it has no say.
+rule._getLogicalTrips = () => [S106, S102];
+assert.strictEqual(
+    rule.seatLoad('BUS', 4, { window: rule._dayWindow('2026-09-07T09:00:00Z', '2026-09-07T10:00:00Z') }).total,
+    4, 'a midday run is not charged for the morning runs'
+);
+
+// A card joining a run going the other way is walked leg by leg, so the outward
+// load it replaces does not count against it.
+rule.tripOccupancy = (t) => {
+    if (t.direction !== 'MIXED') return t.headcount;
+    let onBoard = t.stops.filter(s => s.direction !== 'RETURN')
+        .reduce((n, s) => n + (s.headcount || 0), 0);
+    let peak = onBoard;
+    t.stops.forEach(s => {
+        onBoard += s.direction === 'RETURN' ? (s.headcount || 0) : -(s.headcount || 0);
+        peak = Math.max(peak, onBoard);
+    });
+    return peak;
+};
+const outward = [{ id: 'a', direction: 'OUTBOUND', headcount: 5, stopIndex: 1 }];
+assert.strictEqual(
+    rule.mergedOccupancy(outward, { id: 'ret', direction: 'RETURN', headcount: 5 }),
+    5, 'the returning load boards the seats the outward load has just left'
+);
+assert.strictEqual(
+    rule.mergedOccupancy(outward, { id: 'more', direction: 'OUTBOUND', headcount: 5 }),
+    10, 'two outward loads ride together'
+);
+
+console.log('seat rule OK');

--- a/one_fm/one_fm/page/transportation_schedule/test_transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/test_transportation_schedule.py
@@ -330,3 +330,79 @@ class TestEachCardBoardsAtItsOwnCamp(FrappeTestCase):
 
 	def test_a_camp_with_no_leg_recorded_falls_back_to_the_run(self):
 		self.assertIn("or camp_departure.get(row.trip_group),", self.source)
+
+
+class TestARunThatStoppedBeingMixedSaysSo(FrappeTestCase):
+	"""AC3 has a server half, and it was in the wrong place (WI-002401).
+
+	Taking one stop out of a merged run can leave what remains travelling only one way.
+	The canvas re-stamps the blocks straight away, so the colour flips - but a row's
+	direction is written from its SHIPMENT, and the shipment was still flagged Mixed. So
+	the block came back green on the next page load.
+	"""
+
+	def test_the_unmerge_runs_before_the_rows_are_written(self):
+		import inspect
+
+		from one_fm.one_fm.page.transportation_schedule import transportation_schedule
+
+		source = inspect.getsource(transportation_schedule.save_assignments)
+		self.assertIn("_unmerge_unmixed_placements(items)", source)
+		# Before, not after: the row direction is read off the shipment.
+		self.assertLess(
+			source.index("_unmerge_unmixed_placements(items)"),
+			source.index("directions = _shipment_direction_flags(items)"),
+		)
+
+	def test_a_card_whose_shipment_disagrees_is_the_one_repaired(self):
+		# The old rule only considered cards it had counted as Assigned, which requires
+		# the shipment's direction to match the placement - so it skipped every card
+		# still flagged Mixed, which is the only kind there was anything to repair.
+		import inspect
+
+		from one_fm.one_fm.page.transportation_schedule import transportation_schedule
+
+		source = inspect.getsource(transportation_schedule._unmerge_unmixed_placements)
+		self.assertIn('if "MIXED" not in placed_dirs', source)
+		self.assertNotIn("assigned", source)
+
+	def test_a_still_mixed_run_keeps_its_flag(self):
+		import inspect
+
+		from one_fm.one_fm.page.transportation_schedule import transportation_schedule
+
+		# One MIXED block is enough to say the card is still riding a merged run.
+		source = inspect.getsource(transportation_schedule._unmerge_unmixed_placements)
+		self.assertIn('placed.setdefault(name, set()).add(', source)
+
+
+class TestAPlacedBlockCanAlwaysBeOpened(FrappeTestCase):
+	"""A placed card is Assigned, so it is not a pool card (WI-002401).
+
+	Re-saving the plan overwrote each row's saved names with empty strings once that
+	happened, and with nothing left to build a card from, the detail drawer simply
+	refused to open when the block was clicked.
+	"""
+
+	def test_the_canvas_keeps_names_it_cannot_look_up(self):
+		import pathlib
+
+		canvas = pathlib.Path(frappe.get_app_path(
+			"one_fm", "one_fm", "page", "transportation_schedule",
+			"transportation_schedule.js")).read_text()
+		self.assertIn("_site: card ? card.site : (i._site || ''),", canvas)
+		self.assertIn("_shift: card ? card.shift_name : (i._shift || ''),", canvas)
+		self.assertNotIn("_site: card ? card.site : '',", canvas)
+
+	def test_the_load_fills_a_blank_copy_from_the_shipment(self):
+		# Repairs the rows an older save already blanked, without a patch.
+		import inspect
+
+		from one_fm.one_fm.page.transportation_schedule import transportation_schedule
+
+		source = inspect.getsource(transportation_schedule.load_assignments)
+		self.assertIn('"_shift":         row.shift or held.get("shift") or ""', source)
+		self.assertIn('"_stopLocation":  row.stop_location or held.get("stop_location") or ""',
+					  source)
+		# One query, not one per row.
+		self.assertIn("shipment_meta = {", source)

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
@@ -352,8 +352,40 @@ function mountRoutePlannerApp(wrapper, data) {
                             (a, b) => (a.stopIndex || 0) - (b.stopIndex || 0)
                         );
                         const firstItem = stops[0];
-                        const lastItem = stops[stops.length - 1];
                         const totalHC = stops.reduce((sum, s) => sum + (s.headcount || 0), 0);
+                        // The run's extent, over ALL its stops rather than the first and
+                        // last by stop number. After the day-rebase a stop can sit a few
+                        // minutes before stop one - its leg was re-timed after it was
+                        // dropped, and the rebase keeps it where it is rather than
+                        // flinging it a day forward - so reading the two ends off the
+                        // numbering gave the block a negative width and drew it as the
+                        // 8px minimum.
+                        const spanStart = new Date(Math.min(
+                            ...stops.map(s => new Date(s.start).getTime())));
+                        const spanEnd = new Date(Math.max(
+                            ...stops.map(s => new Date(s.end).getTime())));
+
+                        // The run's own two ends, not its first and last CARD. The bus
+                        // leaves the camp before any block starts and gets back after the
+                        // last one finishes, and no card is filed against either leg - so
+                        // the block used to begin at the first site, an hour after the bus
+                        // actually left, while the drawer header read the departure the
+                        // dispatcher stated. Both now read the same run (AC2, AC4).
+                        //
+                        // These two stamps are only comparable with the blocks because the
+                        // plan load rebases them onto this run's own day, exactly as it
+                        // does the stops: their DATE half is a lock lifespan, not the day
+                        // the bus runs. And they are clamped, so a stored leg timing can
+                        // widen the block but never shrink it below the stops it holds.
+                        const held = (this.legTimings || {})[tripId] || {};
+                        const stated = (stamp) => {
+                            const ms = stamp ? new Date(stamp).getTime() : NaN;
+                            return isNaN(ms) ? null : ms;
+                        };
+                        const runStart = new Date(Math.min(
+                            stated(held.departure) ?? Infinity, spanStart.getTime()));
+                        const runEnd = new Date(Math.max(
+                            stated(held.arrival) ?? -Infinity, spanEnd.getTime()));
 
                         const stopLabels = stops.map(s => {
                             const card = this.planData.shipment_cards.find(c => c.id === s.cardId);
@@ -365,8 +397,8 @@ function mountRoutePlannerApp(wrapper, data) {
                             tripId,
                             tripName: stops.find(s => s.tripName)?.tripName || null,
                             direction: this.runDirection(stops),
-                            start: firstItem.start,
-                            end: lastItem.end,
+                            start: runStart,
+                            end: runEnd,
                             headcount: totalHC,
                             stopLabels,
                             stops,
@@ -374,8 +406,8 @@ function mountRoutePlannerApp(wrapper, data) {
                             overcapacity: stops.some(s => s.overcapacity),
                             primaryItem: firstItem,
                             // Time span for layout calculation
-                            _layoutStart: new Date(firstItem.start).getTime(),
-                            _layoutEnd: new Date(lastItem.end).getTime(),
+                            _layoutStart: new Date(runStart).getTime(),
+                            _layoutEnd: new Date(runEnd).getTime(),
                         });
                     });
 
@@ -463,7 +495,6 @@ function mountRoutePlannerApp(wrapper, data) {
                         stop_location: item._stopLocation || '\u2014',
                         headcount: fuzzy ? fuzzy.headcount : (item.headcount || 0),
                         employees: fuzzy ? fuzzy.employees : [],
-                        return_employees: fuzzy ? (fuzzy.return_employees || []) : [],
                         direction: item.direction || 'OUTBOUND',
                         shift_start: fuzzy ? fuzzy.shift_start : null,
                         shift_end: fuzzy ? fuzzy.shift_end : null,
@@ -812,20 +843,18 @@ function mountRoutePlannerApp(wrapper, data) {
                     return;
                 }
 
-                // ── Seat capacity check (time-aware) ──
-                const blockers = this.tripsDuringCardWindows(card, vehicle.id);
-                const peakLoad = blockers.reduce((sum, t) => sum + t.occupancy, 0);
-
-                if (peakLoad + card.headcount > this.passengerSeats(vehicle)) {
-                    const shell = document.getElementById('rp-shell');
-                    if (shell) {
-                        shell.style.transition = 'background-color 0.2s';
-                        shell.style.backgroundColor = '#ffebee';
-                        setTimeout(() => { shell.style.backgroundColor = ''; }, 400);
-                    }
-                    frappe.throw(this.capacityMessage(card.headcount, vehicle, blockers));
-                    return;
-                }
+                // No seat check here. Which run this card joins has not been decided
+                // yet - the picker below offers every nearby run and a new independent
+                // trip - and a card only ever rides on one of them. Judging the drop
+                // against the pooled load of every run near the card's own shift window
+                // refused it before the operator could choose, naming sequential runs
+                // that were never going to carry it, and pre-empted the Trip Builder
+                // modal that a merge has to go through (WI-002401 AC5).
+                //
+                // The seat rule is applied where the run is actually chosen: on the
+                // chain in _chainToTrip, on a new trip in _doPlace, and leg by leg in
+                // the Trip Builder for a merge. A card bigger than the whole bus is
+                // already handled above, by the split.
 
                 // ── Trip chaining: detect nearby blocks from same accommodation (any direction) ──
                 // Mixed-direction trips are valid: OUT drops + RET pickups on the same trip
@@ -1002,8 +1031,11 @@ function mountRoutePlannerApp(wrapper, data) {
             _doPlaceWithDialog(card, vehicleId) {
                 const self = this;
 
-                // Build context about existing trips on this vehicle
-                const existingOnVehicle = this.swimItems.filter(i => i.vehicleId === vehicleId && i.direction === 'OUTBOUND');
+                // Build context about existing trips on this vehicle. Every run on the
+                // lane, whichever way it travels: filtering to OUTBOUND hid the return
+                // runs the new trip has to fit around, which is exactly what the list is
+                // there to show (WI-002401 AC1).
+                const existingOnVehicle = this.swimItems.filter(i => i.vehicleId === vehicleId);
                 let existingHtml = '';
                 if (existingOnVehicle.length > 0) {
                     // Group by tripId
@@ -1015,13 +1047,54 @@ function mountRoutePlannerApp(wrapper, data) {
                         trips[key].push(item);
                     });
 
-                    const tripSummaries = Object.values(trips).map(stops => {
-                        const sites = stops.map(s => {
-                            const c = self.planData.shipment_cards.find(sc => sc.id === s.cardId);
-                            return c ? c.site_location : s.cardId;
+                    const tripSummaries = Object.values(trips).map(unordered => {
+                        // In the order the bus drives it. Table order is the order the
+                        // cards were dropped, so reading the first and last row for the
+                        // run's two ends printed a window that was not the run's.
+                        const stops = [...unordered].sort(
+                            (a, b) => new Date(a.start) - new Date(b.start)
+                        );
+                        // True endpoints, not a bare list of sites: an outbound run leaves
+                        // a camp and a return run ends at one, so the same card reads in
+                        // opposite directions depending which way it travels.
+                        //
+                        // A camp is the FRONT or the BACK of a run, though - never a stop
+                        // between every pair of sites. Reading each card as its own
+                        // camp → site pair and stitching those together printed the camp
+                        // once per card: "Mahboula 13 → Xcite → Mahboula 13 → Aramex →
+                        // Mahboula 13 → Stockyard" for a bus that loads at Mahboula 13
+                        // once and then makes three drops (WI-002401 AC1). The bus loads
+                        // at the camps its outward riders board from, calls at the sites
+                        // in the order it drives them, and delivers its return riders to
+                        // the camps they are going home to.
+                        const boardsAt = [];
+                        const sites = [];
+                        const deliversTo = [];
+                        const add = (list, place) => {
+                            if (place && !list.includes(place)) list.push(place);
+                        };
+                        stops.forEach(s => {
+                            const c = self.bcard(s);
+                            const site = c.site_location || s.cardId;
+                            // Consecutive repeats only: a run that genuinely calls at a
+                            // place twice is two visits and says so.
+                            if (sites[sites.length - 1] !== site) sites.push(site);
+                            add(self.cardOwnDirection(s) === 'RETURN' ? deliversTo : boardsAt,
+                                c.accommodation);
                         });
+                        const runDir = self.runDirection(stops);
+                        // A run that both drops off and picks up always comes home, so it
+                        // closes the loop even when no stop could be read as a delivery -
+                        // which is the case for a merged run whose cards have left the
+                        // pool, since MIXED is stamped on the stop and the card is what
+                        // remembers which way its own riders travel.
+                        if (runDir === 'MIXED' && !deliversTo.length) {
+                            boardsAt.forEach(camp => add(deliversTo, camp));
+                        }
+                        const route = [...boardsAt, ...sites, ...deliversTo];
                         const time = self.fmtTime(stops[0].start) + '–' + self.fmtTime(stops[stops.length - 1].end);
-                        return `<span style="display:block;padding:2px 0;font-size:12px;color:#666">• ${sites.join(' → ')} (${time})</span>`;
+                        const dir = self.dirName(runDir);
+                        return `<span style="display:block;padding:2px 0;font-size:12px;color:#666">• ${route.join(' → ')} (${time}) · ${dir}</span>`;
                     });
 
                     existingHtml = `<div style="background:#f5f5f5;border-radius:6px;padding:8px 10px;margin:0 0 12px">
@@ -1194,7 +1267,9 @@ function mountRoutePlannerApp(wrapper, data) {
 
             _mergeShipmentIds(newCard, existingItems) {
                 const ids = existingItems.map(i => i.cardId).filter(Boolean);
-                ids.push(newCard.id);
+                // No new card when the modal is opened to edit a run already on the lane
+                // (AC6): the run is re-timed, not merged with anything.
+                if (newCard) ids.push(newCard.id);
                 // The backend resolves a card id to its shipment; de-duplicated so a card
                 // already on the lane in both directions is offered once.
                 return Array.from(new Set(ids));
@@ -1341,17 +1416,38 @@ function mountRoutePlannerApp(wrapper, data) {
                        </div>`
                     : '';
 
-                // One container per visit: a stop where riders both leave and join is two
-                // entries, and so is a stop the run returns to (second criterion).
+                // One container per visit, naming everything the driver does there.
+                //
+                // A stop where riders both leave and join is ONE place the bus calls at
+                // but TWO things it does, and the itinerary has to say both. It used to
+                // print a single action read off `action_type` against a single number
+                // read off `boarding_count or drop_off_count` - so a stop putting 3 down
+                // and collecting 2 announced "DROPPING OFF EMPLOYEES · 2": the label from
+                // one movement and the count from the other, and the third rider missing
+                // altogether (WI-002401). The legs table below always had both.
+                //
+                // Drop-off is listed first because that is the order the bus does it and
+                // the order walk_occupancy measures it in - the seats a load vacates are
+                // what the next load boards into - so the running total below reads
+                // straight down from these two numbers.
                 const stops = p.stops.map((s) => {
-                    const boarding = s.action === 'Boarding';
-                    const tone = boarding ? '#2e7d32' : '#e65100';
-                    const label = boarding ? 'EMPLOYEES BOARDING' : 'DROPPING OFF EMPLOYEES';
+                    const moves = [];
+                    if (s.drop_off_count) {
+                        moves.push([__('DROPPING OFF EMPLOYEES'), s.drop_off_count, '#e65100']);
+                    }
+                    if (s.boarding_count) {
+                        moves.push([__('EMPLOYEES BOARDING'), s.boarding_count, '#2e7d32']);
+                    }
+                    const badges = moves.length
+                        ? moves.map(([label, n, tone]) =>
+                            `<span style="font-size:11px;font-weight:700;color:${tone}">${label} &middot; ${esc(n)}</span>`
+                          ).join('<span style="color:#d1d5db;margin:0 8px">&middot;</span>')
+                        : `<span style="font-size:11px;font-weight:700;color:#6b7280">${__('NOBODY BOARDS OR LEAVES')}</span>`;
                     const over = s.exceeded ? 'border-color:#ef4444;background:#fef2f2' : '';
                     return `<div style="border:1px solid #e5e7eb;border-radius:8px;padding:10px 12px;margin-bottom:8px;${over}">
                         <div style="display:flex;justify-content:space-between;align-items:center">
                             <div style="font-weight:700">Seq ${s.stop_index}: ${esc(s.stop_location || '—')}</div>
-                            <span style="font-size:11px;font-weight:700;color:${tone}">${label} &middot; ${esc(s.headcount)}</span>
+                            <div style="text-align:right">${badges}</div>
                         </div>
                         <div style="font-size:12px;color:#6b7280;margin-top:4px">
                             On board after this stop: <b>${esc(s.occupancy)}</b> / ${esc(p.max_passenger_capacity || '—')}
@@ -1523,22 +1619,27 @@ function mountRoutePlannerApp(wrapper, data) {
                     (stop.serves || []).forEach((shipment) => { legs[shipment] = stop; });
                 });
                 const shipmentOf = (cardId) => String(cardId || '').replace(/^TSHIP-/, '');
-                const adj = legs[shipmentOf(newCard.id)] || {};
 
-                // Placed at the tail of the run and then timed by _retimeTrip below, so
-                // the merged block and the blocks it joins are spaced by one rule.
-                self.swimItems.push({
-                    id: `${newCard.id}_MIX_${uid}`, cardId: newCard.id, vehicleId,
-                    direction, start: new Date(lastEnd), end: new Date(lastEnd),
-                    headcount: newCard.headcount, conflict: false,
-                    transitMinutes: parseInt(adj.transit_minutes, 10) || 0,
-                    bufferMinutes: parseInt(adj.buffer_minutes, 10) || 0,
-                    // A merged block belongs to the run it joined, name and all - without
-                    // this the new card saved with a blank Trip Name while every block
-                    // beside it carried one.
-                    tripName: existingItems.find((i) => i.tripName)?.tripName || null,
-                    tripId, stopIndex: order.indexOf(newCard.id) + 1 || existingItems.length + 1
-                });
+                // A block for the joining card, if one is joining. Reopening the modal on
+                // a run already on the lane adds no stop - it only re-times the ones
+                // there (AC6).
+                if (newCard) {
+                    const adj = legs[shipmentOf(newCard.id)] || {};
+                    // Placed at the tail of the run and then timed by _retimeTrip below, so
+                    // the merged block and the blocks it joins are spaced by one rule.
+                    self.swimItems.push({
+                        id: `${newCard.id}_MIX_${uid}`, cardId: newCard.id, vehicleId,
+                        direction, start: new Date(lastEnd), end: new Date(lastEnd),
+                        headcount: newCard.headcount, conflict: false,
+                        transitMinutes: parseInt(adj.transit_minutes, 10) || 0,
+                        bufferMinutes: parseInt(adj.buffer_minutes, 10) || 0,
+                        // A merged block belongs to the run it joined, name and all - without
+                        // this the new card saved with a blank Trip Name while every block
+                        // beside it carried one.
+                        tripName: existingItems.find((i) => i.tripName)?.tripName || null,
+                        tripId, stopIndex: order.indexOf(newCard.id) + 1 || existingItems.length + 1
+                    });
+                }
 
                 // The legs the operator adjusted higher up the run belong to their own
                 // blocks: only the block carrying them is saved with them, and only a
@@ -1582,10 +1683,10 @@ function mountRoutePlannerApp(wrapper, data) {
                     self._retimeTrip(tripId);
                 }
 
-                self.assignedCards.add(newCard.id);
+                if (newCard) self.assignedCards.add(newCard.id);
                 self.selectedPoolCard = null;
                 self.checkConflicts();
-                self.canSave = self.assignedCards.size > 0;
+                self.canSave = self.assignedCards.size > 0 || self.swimItems.length > 0;
 
                 // The shipments are already Mixed by the time the plan is saved, so a
                 // rejected save has to put them back - otherwise they return to the pool
@@ -1599,11 +1700,40 @@ function mountRoutePlannerApp(wrapper, data) {
                 });
 
                 frappe.show_alert({
-                    message: direction === 'MIXED'
-                        ? __('Trip merged — direction is now Mixed')
-                        : __('Stop added — the run is timed from the legs you entered'),
+                    message: !newCard
+                        ? __('Trip re-timed — every stop moved with the legs you entered')
+                        : direction === 'MIXED'
+                            ? __('Trip merged — direction is now Mixed')
+                            : __('Stop added — the run is timed from the legs you entered'),
                     indicator: 'green'
                 });
+            },
+
+            // Reopen the Trip Builder on a run already on the lane (AC6), so its
+            // departure and per-leg minutes can be changed without taking the run apart
+            // and dropping it again. Nothing is merged in: the same modal is the run's
+            // own editor, and Confirm & Apply re-times its blocks by the same rule it
+            // uses after a merge, so the canvas and the drawer stay in step.
+            //
+            // The whole run, in the order the RHS drawer lists it - the modal has to open
+            // on the sequence the operator is looking at.
+            editSelectedTrip() {
+                const item = this.selectedItem;
+                if (!item || !item.tripId) return;
+                const stops = this.swimItems
+                    .filter(i => i.tripId === item.tripId)
+                    .sort((a, b) => (new Date(a.start) - new Date(b.start))
+                        || (a.stopIndex || 0) - (b.stopIndex || 0));
+                // A run of one stop has nothing to sequence, and the merge endpoint needs
+                // two cards to name a run; use Merge into Trip to give it a second stop.
+                if (stops.length < 2) {
+                    frappe.show_alert({
+                        message: __('A run needs a second stop before its legs can be timed.'),
+                        indicator: 'orange'
+                    }, 5);
+                    return;
+                }
+                this._openMergeTripModal(null, stops, item.vehicleId);
             },
 
             // Which way a block's own riders travel, whatever a merge did to the block.
@@ -1727,6 +1857,31 @@ function mountRoutePlannerApp(wrapper, data) {
             _chainToTrip(newCard, existingItems, vehicleId, presetTransitMin) {
                 const self = this;
 
+                // ── Seats on the run being joined ──
+                // The run this card is joining, not every run near the card's own shift
+                // window: a bus that emptied at 06:05 has no passengers left to hold
+                // when the 06:35 run boards, so pooling the two refused a seat that was
+                // free (WI-002401 AC5).
+                //
+                // The run is measured leg by leg, so a card joining one going the other
+                // way is judged on the seats that are actually free where its riders
+                // board - not on the run's total. Adding the two instead is what turned
+                // a legitimate return-onto-an-outbound-run drop into an error dialog
+                // where the Trip Builder belonged.
+                const vehicle = this.planData.vehicles.find(v => v.id === vehicleId);
+                if (vehicle) {
+                    const { total, blockers } = this.seatLoad(
+                        vehicleId,
+                        this.mergedOccupancy(existingItems, newCard),
+                        { joining: existingItems }
+                    );
+                    if (total > this.passengerSeats(vehicle)) {
+                        this.flashShell();
+                        frappe.throw(this.capacityMessage(newCard.headcount, vehicle, blockers));
+                        return;
+                    }
+                }
+
                 // WI-002078: dropping a card onto a lane that already has a block is a merge,
                 // and a merge is a decision - it changes the run's direction, re-times every
                 // stop after it and can put the bus over its seats. The modal is where the
@@ -1743,23 +1898,6 @@ function mountRoutePlannerApp(wrapper, data) {
                 if (self._isMergeDrop(newCard, existingItems)) {
                     self._openMergeTripModal(newCard, existingItems, vehicleId);
                     return;
-                }
-
-                // ── Capacity check before chaining ──
-                const vehicle = this.planData.vehicles.find(v => v.id === vehicleId);
-                if (vehicle) {
-                    const blockers = this.tripsDuringCardWindows(newCard, vehicleId);
-                    const currentLoad = blockers.reduce((sum, t) => sum + t.occupancy, 0);
-                    if (currentLoad + newCard.headcount > this.passengerSeats(vehicle)) {
-                        const shell = document.getElementById('rp-shell');
-                        if (shell) {
-                            shell.style.transition = 'background-color 0.2s';
-                            shell.style.backgroundColor = '#ffebee';
-                            setTimeout(() => { shell.style.backgroundColor = ''; }, 400);
-                        }
-                        frappe.throw(this.capacityMessage(newCard.headcount, vehicle, blockers));
-                        return;
-                    }
                 }
 
                 // Find or create trip ID
@@ -1826,7 +1964,9 @@ function mountRoutePlannerApp(wrapper, data) {
                     .slice(-1)[0];
                 const lastCard = this.planData.shipment_cards.find(c => c.id === lastItem.cardId);
                 const lastSiteName = lastCard ? lastCard.site_location : 'previous stop';
-                const seatInfo = vehicle ? ` (${this.passengerSeats(vehicle)} passenger seats, ${this.peakLoadDuringCardWindows(newCard, vehicleId) + newCard.headcount} needed)` : '';
+                const seatInfo = vehicle
+                    ? ` (${this.passengerSeats(vehicle)} passenger seats, ${this.seatLoad(vehicleId, this.mergedOccupancy(existingItems, newCard), { joining: existingItems }).total} needed)`
+                    : '';
 
                 const d = new frappe.ui.Dialog({
                     title: `Transit to ${newCard.site_location}`,
@@ -1860,6 +2000,107 @@ function mountRoutePlannerApp(wrapper, data) {
                 d.show();
             },
 
+            // A red pulse across the board, so a refusal is felt as well as read.
+            flashShell() {
+                const shell = document.getElementById('rp-shell');
+                if (!shell) return;
+                shell.style.transition = 'background-color 0.2s';
+                shell.style.backgroundColor = '#ffebee';
+                setTimeout(() => { shell.style.backgroundColor = ''; }, 400);
+            },
+
+            // ── When two runs are on the road together ──────────────────────
+            // Seconds past midnight of a lane timestamp, read in the site's own clock so
+            // it agrees with every time the board prints (fmtTime).
+            _clockSeconds(value) {
+                const d = new Date(value);
+                if (isNaN(d.getTime())) return null;
+                const [h, m, s] = d.toLocaleTimeString('en-GB', {
+                    hour: '2-digit', minute: '2-digit', second: '2-digit',
+                    hour12: false, timeZone: 'Asia/Kuwait'
+                }).split(':').map(Number);
+                return ((h % 24) * 3600 + m * 60 + s);
+            },
+
+            // The daily window a run occupies. Mirrors _row_time_window on the server:
+            // the DATE half of a lane timestamp is the multi-day lock lifespan (TR-8),
+            // not the day the bus runs, so two runs are only ever compared by the hour
+            // they are on the road. Comparing raw epochs made a run whose lock began
+            // last month invisible to the seat check, and pooled two runs the moment
+            // their stored dates happened to agree (WI-002401).
+            _dayWindow(start, end) {
+                const DAY = 86400;
+                let from = this._clockSeconds(start);
+                let to = this._clockSeconds(end);
+                if (from === null && to === null) return { from: 0, to: DAY };
+                if (from === null) from = 0;
+                if (to === null) to = DAY;
+                if (to <= from) to += DAY;      // a run over midnight (22:00 -> 01:00)
+                return { from, to };
+            },
+
+            // True when two runs put passengers on the same bus at the same moment.
+            // Windows that merely touch do not - a bus can turn straight around.
+            // Circular over the day so a run past midnight still meets an early-morning
+            // one. Mirrors _trips_share_the_road.
+            _sharesTheRoad(a, b) {
+                if (!a || !b) return false;
+                const DAY = 86400;
+                return [-DAY, 0, DAY].some(shift => a.from < b.to + shift && b.from + shift < a.to);
+            },
+
+            // What the run would carry once this card joins it, walked as the stops the
+            // bus actually makes.
+            //
+            // A run that both drops off and picks up never has all its stops aboard at
+            // once - the seats an outward load vacates are what a return load boards
+            // into - so adding the card's riders to the run's total refused merges the
+            // bus can make (WI-002160, and the return-card-onto-an-outbound-run drop in
+            // WI-002401). For a run going one way it is simply the sum, which is right:
+            // everybody is aboard together.
+            mergedOccupancy(stops, card) {
+                const merged = stops.concat([{
+                    cardId: card.id,
+                    direction: card.direction || 'OUTBOUND',
+                    headcount: card.headcount || 0,
+                    stopIndex: Math.max(0, ...stops.map(i => i.stopIndex || 0)) + 1
+                }]);
+                return this.tripOccupancy({
+                    direction: this.runDirection(merged),
+                    headcount: merged.reduce((sum, i) => sum + (i.headcount || 0), 0),
+                    stops: merged
+                });
+            },
+
+            // What the bus is asked to hold, given a load of `occupancy` going on it.
+            //
+            // One trip is one bus run (AC5): a run that put its passengers down at 06:05
+            // is empty when the 06:35 run boards, so sequential runs never see each
+            // other's riders. Only runs whose DAILY windows really do overlap are added
+            // together - those are on the road at once - which is the rule
+            // _peak_concurrent_headcount applies on save.
+            //
+            // `joining` is the swim items the load is going onto, so the run they belong
+            // to is not counted twice; a load starting a run of its own passes only the
+            // `window` it will occupy. Pooling every run that overlapped the CARD's own
+            // shift window instead refused a drop while naming two sequential runs the
+            // operator was never aiming at (WI-002401).
+            seatLoad(vehicleId, occupancy, { joining, window } = {}) {
+                const ids = new Set((joining || []).map(i => i.id));
+                const trips = this._getLogicalTrips(vehicleId);
+                const target = ids.size
+                    ? trips.find(t => t.stops.some(s => ids.has(s.id)))
+                    : null;
+                const road = target ? target.window : window;
+                const others = trips.filter(
+                    t => t !== target && this._sharesTheRoad(road, t.window)
+                );
+                return {
+                    total: occupancy + others.reduce((sum, t) => sum + t.occupancy, 0),
+                    blockers: target ? [target, ...others] : others
+                };
+            },
+
             // ── Time-aware peak load helper ─────────────────────────────────
             // The trips a vehicle actually runs today. One tripId is one bus run,
             // however its stops are headed: keying the direction in as well (WI-002000)
@@ -1877,6 +2118,7 @@ function mountRoutePlannerApp(wrapper, data) {
                     const key = item.tripId || `_solo_${soloIdx++}`;
                     if (!tripsMap[key]) {
                         tripsMap[key] = {
+                            tripId: item.tripId || null,
                             start: new Date(item.start).getTime(),
                             end: new Date(item.end).getTime(),
                             headcount: item.headcount || 0,
@@ -1900,6 +2142,9 @@ function mountRoutePlannerApp(wrapper, data) {
                 trips.forEach(t => {
                     t.direction = this.runDirection(t.stops);
                     t.occupancy = this.tripOccupancy(t);
+                    // The hours it is on the road, which is what decides whether another
+                    // run shares them. Its calendar date is a lock lifespan, not a day.
+                    t.window = this._dayWindow(t.start, t.end);
                 });
                 return trips;
             },
@@ -1914,6 +2159,29 @@ function mountRoutePlannerApp(wrapper, data) {
                 if (!stops || !stops.length) return 'OUTBOUND';
                 const first = stops[0].direction || 'OUTBOUND';
                 return stops.some(s => (s.direction || 'OUTBOUND') !== first) ? 'MIXED' : first;
+            },
+
+            // What is left of a run after a stop leaves it may no longer be Mixed
+            // (AC3). The merge stamped MIXED on every stop, so reading the stops back
+            // answers MIXED for ever - the real answer is each remaining card's OWN
+            // heading. Re-stamping them is what updates the block colour, the prefix
+            // arrow and the RHS badge, all of which read item.direction.
+            //
+            // Only a run currently marked Mixed is re-read, and only when every stop
+            // still has a card on the board to read a heading from: a stop whose card
+            // has gone has no own direction, and guessing one would quietly relabel a
+            // genuinely mixed run as Outbound.
+            _resyncTripDirection(tripId) {
+                if (!tripId) return;
+                const stops = this.swimItems.filter(i => i.tripId === tripId);
+                if (!stops.length || !stops.every(i => i.direction === 'MIXED')) return;
+                if (!stops.every(i => this.planData.shipment_cards.some(c => c.id === i.cardId))) return;
+
+                const headings = stops.map(i => this.cardOwnDirection(i));
+                if (headings.some(h => h !== headings[0])) return;   // still mixed
+
+                stops.forEach(i => { i.direction = headings[0]; });
+                this.swimItems = [...this.swimItems];               // Vue reactivity
             },
 
             // The most passengers one trip ever has aboard. Mirrors _trip_peak on the
@@ -1976,18 +2244,20 @@ function mountRoutePlannerApp(wrapper, data) {
                 return Math.max((vehicle.seats || 0) - (vehicle.custom_includes_driver_seat ? 1 : 0), 0);
             },
 
-            // One wording for every seat refusal, naming the limit the check
-            // actually applied rather than the size of the bus.
+            // One wording for every seat refusal, naming the limit the check actually
+            // applied rather than the size of the bus.
             capacityMessage(headcount, vehicle, blockers) {
                 const base = __(
                     'Capacity Exceeded: cannot assign {0} employees to {1} — it takes {2} passengers.',
                     [headcount, this.vehicleString(vehicle), this.passengerSeats(vehicle)]
                 );
 
-                // Name the runs holding the seats. Without this the refusal named only
-                // the bus, and a card is placed at its own shift window rather than where
-                // it was dropped — so the blocking run is routinely not the block the
-                // operator was aiming at, and the message was undiagnosable.
+                // Name the runs the seats are counted against, and say why each one
+                // counts: it is the run being loaded, or a run on the road at the same
+                // hour. The refusal used to name only the bus, and every run whose
+                // window merely touched the card's shift got pooled in - so the run
+                // named was routinely not the one the operator was aiming at, and the
+                // message could not be acted on (WI-002401).
                 const named = (blockers || [])
                     .filter(t => t && t.occupancy)
                     .map(t => __('{0} ({1} aboard, {2}–{3})', [
@@ -1998,41 +2268,7 @@ function mountRoutePlannerApp(wrapper, data) {
                     ]));
                 if (!named.length) return base;
 
-                return `${base} ${__('Those seats are held by {0}.', [named.join(', ')])}`;
-            },
-
-            // The headcount already aboard the vehicle during the window this card
-            // would occupy. Only the leg being placed counts (WI-002000): taking
-            // the worse of the outbound and return windows meant an early drop was
-            // judged against the evening traffic it never shares the road with.
-            peakLoadDuringCardWindows(card, vehicleId, direction) {
-                return this.tripsDuringCardWindows(card, vehicleId, direction)
-                    .reduce((sum, t) => sum + t.occupancy, 0);
-            },
-
-            // The runs already on the road during the window this card would occupy.
-            // The seat check and the refusal message read the same list, so the message
-            // can name what actually took the seats instead of leaving the operator to
-            // guess: a card is placed at its own shift window, never where it was
-            // dropped, so the run that blocks it is often not the one under the cursor.
-            tripsDuringCardWindows(card, vehicleId, direction) {
-                const { start, end } = this.cardLegWindow(card, direction);
-                return this._getLogicalTrips(vehicleId)
-                    .filter(t => t.start < end && t.end > start);
-            },
-
-            // The hour a card's chosen leg occupies. Only the leg being placed counts
-            // (WI-002000): taking the worse of the outbound and return windows meant an
-            // early drop was judged against the evening traffic it never shares the road
-            // with.
-            cardLegWindow(card, direction) {
-                const DEF = 3600000;
-                if ((direction || card.direction) === 'RETURN') {
-                    const start = new Date(card.return_window_start).getTime();
-                    return { start, end: start + DEF };
-                }
-                const end = new Date(card.outbound_window_end).getTime();
-                return { start: end - DEF, end };
+                return `${base} ${__('Counted for this drop: {0}. A run at another hour on this lane is not counted against it.', [named.join(', ')])}`;
             },
 
             // ─ Place card + direction picker ─────────────────────────────
@@ -2300,20 +2536,23 @@ function mountRoutePlannerApp(wrapper, data) {
                         }
                     }
 
-                    // Overcapacity detection: check headcount at each item's time window
+                    // Overcapacity detection: each run is judged on its own load plus
+                    // the runs that really do share the road with it (AC5). Reading each
+                    // block's raw epoch window instead pooled runs whose stored lock
+                    // dates happened to line up and painted lanes purple for a load the
+                    // bus never carries at once (WI-002401).
                     if (v.seats && vi.length > 0) {
-                        const logicalTrips = this._getLogicalTrips(v.id);
+                        const trips = this._getLogicalTrips(v.id);
+                        const seats = this.passengerSeats(v);
+                        const over = new Set();
+                        trips.forEach(t => {
+                            const load = t.occupancy + trips
+                                .filter(o => o !== t && this._sharesTheRoad(t.window, o.window))
+                                .reduce((sum, o) => sum + o.occupancy, 0);
+                            if (load > seats) t.stops.forEach(s => over.add(s.id));
+                        });
                         vi.forEach(item => {
-                            const iS = new Date(item.start).getTime();
-                            const iE = new Date(item.end).getTime();
-                            const load = logicalTrips
-                                .filter(t => {
-                                    return t.start < iE && t.end > iS;
-                                })
-                                .reduce((sum, t) => sum + t.occupancy, 0);
-                            if (load > this.passengerSeats(v)) {
-                                item.overcapacity = true;
-                            }
+                            if (over.has(item.id)) item.overcapacity = true;
                         });
                     }
                 });
@@ -2415,32 +2654,29 @@ function mountRoutePlannerApp(wrapper, data) {
                         if (targetVehicleId !== origVehicleId) {
                             const targetVehicle = this.planData.vehicles.find(v => v.id === targetVehicleId);
                             if (targetVehicle) {
-                                // Temporarily set vehicleId to check peak load on target
-                                const origVid = item.vehicleId;
-                                item.vehicleId = targetVehicleId;
-                                const peakLoad = this.peakLoadDuringCardWindows(
-                                    this.planData.shipment_cards.find(c => c.id === item.cardId) || { outbound_window_start: item.start, outbound_window_end: item.end, return_window_start: item.start, return_window_end: item.end },
-                                    targetVehicleId,
-                                    item.direction
+                                // Seats on the target bus during the hours the block was
+                                // actually dragged to. Read before the move, so the block
+                                // is not counted against itself, and off its own dragged
+                                // window rather than the card's shift window - which is
+                                // not where the operator dropped it (WI-002401 AC5).
+                                const { total, blockers } = this.seatLoad(
+                                    targetVehicleId, item.headcount || 0,
+                                    { window: this._dayWindow(item.start, item.end) }
                                 );
-                                if (peakLoad > this.passengerSeats(targetVehicle)) {
-                                    // Revert — capacity exceeded
-                                    item.vehicleId = origVid;
+                                if (total > this.passengerSeats(targetVehicle)) {
+                                    // Refused — the block stays on the lane it came from,
+                                    // at the time it was already at.
                                     item.start = new Date(origStart);
                                     item.end = new Date(origEnd);
-                                    const shell = document.getElementById('rp-shell');
-                                    if (shell) {
-                                        shell.style.transition = 'background-color 0.2s';
-                                        shell.style.backgroundColor = '#ffebee';
-                                        setTimeout(() => { shell.style.backgroundColor = ''; }, 400);
-                                    }
+                                    this.flashShell();
                                     // Use msgprint (not throw) so checkConflicts() below still runs to clear stale flags
                                     frappe.msgprint({
                                         title: __('Capacity Exceeded'),
                                         indicator: 'red',
-                                        message: this.capacityMessage(item.headcount, targetVehicle)
+                                        message: this.capacityMessage(item.headcount, targetVehicle, blockers)
                                     });
                                 } else {
+                                    item.vehicleId = targetVehicleId;
                                     frappe.show_alert({
                                         message: `Moved to ${targetVehicle.label}`,
                                         indicator: 'blue'
@@ -2520,6 +2756,22 @@ function mountRoutePlannerApp(wrapper, data) {
 
             closeDetail() { this.selectedItem = null; },
 
+            // What Remove from Lane will actually take. A run of several stops loses
+            // ONE of them, and clicking its block always selects stop 1 - so the button
+            // used to say "Remove from Lane" and then silently take the first stop while
+            // the operator was reading the last one (WI-002401). Naming the stop, and
+            // letting a stop row be clicked to pick it, makes the choice the operator's.
+            removeButtonLabel() {
+                const stops = this.selectedTripStops;
+                if (!this.selectedItem || stops.length < 2) return __('Remove from Lane');
+                const picked = stops.find(s => s.item.id === this.selectedItem.id);
+                if (!picked) return __('Remove from Lane');
+                return __('Remove Stop {0} ({1}) from Lane', [
+                    picked.stopNum,
+                    (picked.card && picked.card.site_location) || __('this stop'),
+                ]);
+            },
+
             removeSelectedFromLane() {
                 if (!this.selectedItem) return;
                 const itemId = this.selectedItem.id;
@@ -2527,7 +2779,11 @@ function mountRoutePlannerApp(wrapper, data) {
                 const dir = this.selectedItem.direction;
 
                 // Remove only the selected block, not both directions
+                const tripId = this.selectedItem.tripId;
                 this.swimItems = this.swimItems.filter(i => i.id !== itemId);
+
+                // What is left of the run may now travel only one way (AC3).
+                this._resyncTripDirection(tripId);
 
                 // Only fully un-assign the card if no blocks remain for it
                 const remaining = this.swimItems.filter(i => i.cardId === cid);
@@ -2603,22 +2859,24 @@ function mountRoutePlannerApp(wrapper, data) {
                             stops: journeyItems
                         });
 
-                        // Seat capacity check on the target vehicle across the journey's
-                        // combined time window. The selector excludes the current vehicle,
-                        // so none of the moving stops are already on the target.
-                        const blockStart = Math.min(...journeyItems.map(i => new Date(i.start).getTime()));
-                        const blockEnd = Math.max(...journeyItems.map(i => new Date(i.end).getTime()));
-                        const blockers = self._getLogicalTrips(targetVehicle.id)
-                            .filter(t => t.start < blockEnd && t.end > blockStart);
-                        const existingLoad = blockers.reduce((sum, t) => sum + t.occupancy, 0);
-
-                        if (existingLoad + movingHeadcount > self.passengerSeats(targetVehicle)) {
-                            const shell = document.getElementById('rp-shell');
-                            if (shell) {
-                                shell.style.transition = 'background-color 0.2s';
-                                shell.style.backgroundColor = '#ffebee';
-                                setTimeout(() => { shell.style.backgroundColor = ''; }, 400);
+                        // Seats on the target bus during the hours this journey is on the
+                        // road. The selector excludes the current vehicle, so none of the
+                        // moving stops are already on the target. The journey arrives as a
+                        // run of its own, so only the target's runs that share those hours
+                        // count - not every run whose stored lock date happened to line up
+                        // with this one's (WI-002401 AC5).
+                        const { total, blockers } = self.seatLoad(
+                            targetVehicle.id, movingHeadcount,
+                            {
+                                window: self._dayWindow(
+                                    Math.min(...journeyItems.map(i => new Date(i.start).getTime())),
+                                    Math.max(...journeyItems.map(i => new Date(i.end).getTime()))
+                                )
                             }
+                        );
+
+                        if (total > self.passengerSeats(targetVehicle)) {
+                            self.flashShell();
                             frappe.throw(self.capacityMessage(movingHeadcount, targetVehicle, blockers));
                             return;
                         }
@@ -2848,26 +3106,20 @@ function mountRoutePlannerApp(wrapper, data) {
                         const targetTripItems = tripsMap[targetTripId].items;
                         const targetVehicleId = selectedOpt.vehicle.id;
 
-                        // The target run's own load, not the lane's: what matters here is
-                        // whether that trip plus this card fits. Read through tripOccupancy
-                        // rather than summing the stops by hand — a run that both drops off
-                        // and picks up never carries its stops all at once, and summing them
-                        // refused a merge the bus could make (WI-002160).
-                        const tripLoad = self.tripOccupancy({
-                            direction: self.runDirection(targetTripItems),
-                            headcount: targetTripItems.reduce((sum, i) => sum + (i.headcount || 0), 0),
-                            stops: targetTripItems
-                        });
-                        if (tripLoad + card.headcount > self.passengerSeats(selectedOpt.vehicle)) {
+                        // The target run's own load once this card is on it, not the
+                        // lane's. Walked as stops rather than summed: a run that both
+                        // drops off and picks up never carries its stops all at once, and
+                        // summing them refused a merge the bus could make (WI-002160).
+                        const { total, blockers } = self.seatLoad(
+                            targetVehicleId,
+                            self.mergedOccupancy(targetTripItems, card),
+                            { joining: targetTripItems }
+                        );
+                        if (total > self.passengerSeats(selectedOpt.vehicle)) {
                             frappe.msgprint({
                                 title: __('Capacity Exceeded'),
                                 indicator: 'red',
-                                message: self.capacityMessage(card.headcount, selectedOpt.vehicle, [{
-                                    tripName: targetTripItems.find(i => i.tripName)?.tripName || null,
-                                    occupancy: tripLoad,
-                                    start: Math.min(...targetTripItems.map(i => new Date(i.start).getTime())),
-                                    end: Math.max(...targetTripItems.map(i => new Date(i.end).getTime()))
-                                }])
+                                message: self.capacityMessage(card.headcount, selectedOpt.vehicle, blockers)
                             });
                             return;
                         }
@@ -3113,6 +3365,42 @@ function mountRoutePlannerApp(wrapper, data) {
                     return { ...i, start, end };
                 });
 
+                // And the legs no block carries, onto the same day as the run they belong
+                // to. A camp departure and a home arrival are stored stamps like any
+                // other, so their DATE half is a lock lifespan too - and the lifespan they
+                // inherited is whichever row of the run the server anchored them on, which
+                // is not the row the canvas draws first. Left raw while every block was
+                // rebased onto today, a departure stored 26 days from its own run put the
+                // trip block's left edge that far off the axis and drew it as a bar across
+                // the whole board (WI-002401). Same rule as the stops: the nearest day to
+                // the run's own first stop, time of day untouched.
+                const runStart = {};
+                parsedItems.forEach(i => {
+                    if (!i.tripId) return;
+                    const ms = i.start.getTime();
+                    if (runStart[i.tripId] === undefined || ms < runStart[i.tripId]) {
+                        runStart[i.tripId] = ms;
+                    }
+                });
+                const ontoRun = (stamp, anchorMs) => {
+                    if (!stamp || anchorMs === undefined) return stamp || null;
+                    const ms = new Date(stamp).getTime();
+                    if (isNaN(ms)) return null;
+                    return new Date(
+                        ms + Math.round((anchorMs - ms) / dayMs) * dayMs
+                    ).toISOString();
+                };
+                this.legTimings = Object.fromEntries(
+                    Object.entries(this.legTimings || {}).map(([tripId, held]) => [
+                        tripId,
+                        {
+                            ...held,
+                            departure: ontoRun(held.departure, runStart[tripId]),
+                            arrival: ontoRun(held.arrival, runStart[tripId]),
+                        },
+                    ])
+                );
+
                 this.swimItems = parsedItems;
                 this.assignedCards = new Set(cards);
                 this.checkConflicts();
@@ -3263,6 +3551,33 @@ function mountRoutePlannerApp(wrapper, data) {
             // written to the shipments the moment it is confirmed, but the plan is saved a
             // beat later and can still be refused - and the cards would be left Mixed with
             // no plan holding them (WI-002078).
+            // Take the trip names the save actually stored. A name already in use on
+            // that vehicle is repaired server-side (WI-002401) and the save is otherwise
+            // silent, so without this the board would keep showing the old name for the
+            // rest of the session and then appear to rename the run by itself on the
+            // next load.
+            _applyStoredTripNames(result) {
+                const names = (result || {}).trip_names;
+                if (!names) return;
+
+                const renamed = new Set();
+                this.swimItems.forEach(item => {
+                    const stored = item.tripId ? names[item.tripId] : null;
+                    if (stored && stored !== item.tripName) {
+                        renamed.add(`${item.tripName || '—'} → ${stored}`);
+                        item.tripName = stored;
+                    }
+                });
+                if (!renamed.size) return;
+
+                this.swimItems = [...this.swimItems];   // Vue reactivity
+                frappe.show_alert({
+                    message: __('That trip name was already in use on this vehicle: {0}.',
+                                [Array.from(renamed).join(', ')]),
+                    indicator: 'orange'
+                }, 8);
+            },
+
             persistAssignments(onError) {
                 if (!this.currentPlan) {
                     // Surface the silent failure: without a loaded Route Plan there
@@ -3286,10 +3601,16 @@ function mountRoutePlannerApp(wrapper, data) {
                             // start_time/end_time carry both (TR-8).
                             start: this._stampLifespan(i.start, i.lockFrom),
                             end: this._stampLifespan(i.end, i.lockTo || i.lockFrom),
-                            _site: card ? card.site : '',
-                            _shift: card ? card.shift_name : '',
-                            _accommodation: card ? card.accommodation : '',
-                            _stopLocation: card ? card.stop_location : '',
+                            // Keep what the item already carries when the card is not
+                            // in the pool. A PLACED card is Assigned and so is not a pool
+                            // card, so re-saving the plan overwrote its saved names with
+                            // empty strings - and once they were gone the detail drawer
+                            // could not build a card for the block at all and simply
+                            // refused to open (WI-002401).
+                            _site: card ? card.site : (i._site || ''),
+                            _shift: card ? card.shift_name : (i._shift || ''),
+                            _accommodation: card ? card.accommodation : (i._accommodation || ''),
+                            _stopLocation: card ? card.stop_location : (i._stopLocation || ''),
                         };
                     });
                     const cards = [...this.assignedCards];
@@ -3303,7 +3624,7 @@ function mountRoutePlannerApp(wrapper, data) {
                             leg_timings: JSON.stringify(this.legTimings || {})
                         },
                         async: true,
-                        callback: () => { }, // silent save on success
+                        callback: (r) => { this._applyStoredTripNames(r.message); },
                         error: () => {
                             // A server-side validation (e.g. the vehicle-retention
                             // STANDBY lock) rejected the drop. Frappe already shows
@@ -3409,12 +3730,15 @@ function mountRoutePlannerApp(wrapper, data) {
             bcard(item) {
                 const found = this.planData.shipment_cards.find(c => c.id === item.cardId);
                 if (found) return found;
-                // Fallback for loaded plan items
-                if (item._site || item._stopLocation) {
+                // Fallback for loaded plan items. The accommodation is carried too: a
+                // card that has left the pool still boarded somewhere, and without it
+                // the run summary printed the literal word "camp" (WI-002401 AC1).
+                if (item._site || item._stopLocation || item._accommodation) {
                     return {
                         site_location: item._stopLocation || item._site || '—',
                         shift_name: item._shift || '—',
                         stop_location: item._stopLocation || '—',
+                        accommodation: item._accommodation || '',
                     };
                 }
                 return {};
@@ -3636,14 +3960,12 @@ function mountRoutePlannerApp(wrapper, data) {
                     const idx = si++;
 
                     shipments.push({ label: lbl, pickups: [{}], deliveries: [{}] });
-                    // OUTBOUND uses card.employees (employees being delivered to site)
-                    // RETURN uses card.return_employees (previous shift employees being collected)
-                    if (item.direction === 'RETURN') {
-                        shipEmp[lbl] = (card.return_employees && card.return_employees.length > 0) ? card.return_employees : [];
-                    } else {
-                        shipEmp[lbl] = card.employees || [];
-                    }
-                    shipReturnEmp[lbl] = card.return_employees || [];
+                    // The card's own riders, whichever way this leg travels. A return
+                    // leg used to read a separate `return_employees` list that nothing
+                    // ever filled, so every return leg on the manifest listed nobody
+                    // while its card carried the people (WI-002401).
+                    shipEmp[lbl] = card.employees || [];
+                    shipReturnEmp[lbl] = item.direction === 'RETURN' ? (card.employees || []) : [];
                     shipSite[lbl] = card.site_location;
                     shipShift[lbl] = card.shift_name;
                     cMap[dirKey] = { lbl, idx };
@@ -4391,8 +4713,10 @@ function injectRPVueTemplate() {
                    @dragover.prevent="onStopDragOver($event, stop.stopNum - 1)"
                    @dragend="onStopDragEnd($event)"
                    @drop.prevent="onStopDrop($event, stop.stopNum - 1)"
+                   @click.stop="selectedItem = stop.item"
+                   :title="__('Click to act on this stop')"
                    :class="{ 'rp-stop-drag-over': stopDragOverIndex === (stop.stopNum - 1) && stopDragSourceIndex !== null && stopDragSourceIndex !== (stop.stopNum - 1) }"
-                   :style="'border-left:3px solid ' + (stop.item.id === selectedItem.id ? '#f97316' : '#1565c0')">
+                   :style="'cursor:pointer;border-left:3px solid ' + (stop.item.id === selectedItem.id ? '#f97316' : '#1565c0')">
                 <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
                   <span class="rp-icon rp-stop-drag-handle" title="Drag to reorder">drag_indicator</span>
                   <span class="rp-stop-num rp-stop-num-out">{{ stop.stopNum }}</span>
@@ -4674,11 +4998,14 @@ function injectRPVueTemplate() {
           <button v-if="!selectedItem.tripId" class="rp-detail-btn rp-detail-btn-primary" @click="mergeSelectedBlock" style="background-color: var(--rp-color-trip-chain); border-color: var(--rp-color-trip-chain);">
             <span class="rp-icon">merge_type</span> Merge into Trip
           </button>
+          <button v-if="selectedItem.tripId" class="rp-detail-btn rp-detail-btn-primary" @click="editSelectedTrip">
+            <span class="rp-icon">edit</span> Edit Trip Timings
+          </button>
           <button class="rp-detail-btn rp-detail-btn-primary" @click="reassignSelectedBlock">
             <span class="rp-icon">directions_bus</span> Reassign Vehicle
           </button>
           <button class="rp-detail-btn rp-detail-btn-danger" @click="removeSelectedFromLane">
-            <span class="rp-icon">close</span> Remove from Lane
+            <span class="rp-icon">close</span> {{ removeButtonLabel() }}
           </button>
         </div>
       </template>

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -13,6 +13,7 @@ from one_fm.operations.doctype.route_plan.route_plan import (
 from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
     driver_employees,
     qoa_buffer_minutes,
+    time_is_blank,
 )
 from one_fm.overrides.vehicle import passenger_capacity
 
@@ -21,6 +22,19 @@ MAX_TRANSIT = 60               # minutes
 
 def get_context(context):
     pass
+
+def _stated_time(*values):
+    """The first of these Time values that was actually stated.
+
+    ``or`` cannot be used for this: midnight is ``timedelta(0)`` and therefore falsy,
+    so a shift finishing at 00:00 fell through to whatever literal came last in the
+    chain (WI-002401 AC9).
+    """
+    for value in values:
+        if not time_is_blank(value):
+            return value
+    return None
+
 
 @frappe.whitelist()
 def get_route_planner_data():
@@ -1008,8 +1022,12 @@ def _build_transportation_shipment_cards(fmt, to_utc, get_coords_cached, timedel
             employees = emps_by_ship.get(s.name, [])
 
             trq = trq_time_map.get(s.source_docname) if s.source_docname else None
-            dep = s.start_time or (trq.departure_time if trq else None) or "06:00:00"
-            ret = s.end_time or (trq.return_time if trq else None) or "18:00:00"
+            # First time that was actually STATED, which is not the same as the first
+            # truthy one: midnight is timedelta(0), so an `or` chain read a shift ending
+            # at 00:00 as having no end and handed the card the 18:00 literal below
+            # (WI-002401 AC9).
+            dep = _stated_time(s.start_time, trq.departure_time if trq else None, "06:00:00")
+            ret = _stated_time(s.end_time, trq.return_time if trq else None, "18:00:00")
 
             dep_utc = to_utc(str(dep))
             ret_utc = to_utc(str(ret))
@@ -1051,7 +1069,6 @@ def _build_transportation_shipment_cards(fmt, to_utc, get_coords_cached, timedel
                 "stop_coords":           {"lat": stop_coords[0], "lng": stop_coords[1]} if stop_coords else None,
                 "headcount":             s.headcount or len(employees),
                 "employees":             employees,
-                "return_employees":      [],
                 "from_date":             str(s.from_date) if s.from_date else None,
                 "to_date":               str(s.to_date) if s.to_date else None,
                 "outbound_window_start": fmt(dep_utc - timedelta(minutes=PICKUP_BUFFER)),
@@ -1201,12 +1218,9 @@ def _sync_shipment_statuses(items, previously_linked=None):
             # was generated for (WI-002071).
             unmerge_trip_shipment(name)
 
-    # A card still on the plan but no longer placed as part of a merged trip is also no
-    # longer merged - the operator can break a merge by dragging one stop out without
-    # removing the other.
-    for name in assigned:
-        if "MIXED" not in placed_dirs_by_shipment.get(name, set()):
-            unmerge_trip_shipment(name)
+    # Cards still on the plan that have left a merged run are handled by
+    # _unmerge_unmixed_placements, which runs before the rows are written - the row's
+    # direction is read off the shipment, so it cannot wait until after the save.
 
 
 def _link_shipment_on_manifest_rows(manifest_doc, v_rows, card_emp_map):
@@ -1291,6 +1305,10 @@ def save_assignments(plan_name: str, swim_items: str, assigned_cards: str,
         row.transportation_shipment for row in doc.assignments if row.transportation_shipment
     }
 
+    # A run that has stopped being mixed gives its cards their own direction back -
+    # before the rows are written, because a row's direction is read off its shipment.
+    _unmerge_unmixed_placements(items)
+
     # Clear existing assignments and rebuild
     doc.assignments = []
     directions = _shipment_direction_flags(items)
@@ -1334,7 +1352,17 @@ def save_assignments(plan_name: str, swim_items: str, assigned_cards: str,
         "status": "ok",
         "plan_name": doc.name,
         "saved_at": str(doc.last_modified_at or frappe.utils.now()),
-        "assignment_count": len(doc.assignments)
+        "assignment_count": len(doc.assignments),
+        # The trip names the plan actually STORED, which are not always the ones the
+        # board sent: a name already in use on that vehicle is repaired on save
+        # (WI-002401). The save is otherwise silent, so without handing these back the
+        # board would keep showing the old name for the rest of the session and then
+        # appear to rename the run by itself on the next load.
+        "trip_names": {
+            row.trip_group: row.trip_name
+            for row in doc.assignments
+            if row.trip_group and row.trip_name
+        },
     }
 
 
@@ -1364,6 +1392,26 @@ def load_assignments(plan_name: str = ""):
     # (which loads the shipment) already disagreed with. The shipment is the authority
     # here for the same reason it is on the Route Plan save.
     live = live_headcounts(doc.assignments)
+
+    # What the shipments this plan places are called, for rows whose own copies were
+    # blanked by an older save. One query rather than one per row.
+    shipment_meta = {
+        row.name: {
+            "site": row.operations_site or "",
+            "shift": row.operations_shift or row.aggregated_shifts or "",
+            "accommodation": row.accommodation_name or row.accommodation or "",
+            "stop_location": row.stop_location or "",
+        }
+        for row in frappe.get_all(
+            "Transportation Shipment",
+            filters={"name": ["in", list({
+                r.transportation_shipment for r in doc.assignments
+                if r.transportation_shipment
+            })] or [""]},
+            fields=["name", "operations_site", "operations_shift", "aggregated_shifts",
+                    "accommodation", "accommodation_name", "stop_location"],
+        )
+    }
 
     swim_items = []
     assigned_card_ids = set()
@@ -1399,6 +1447,13 @@ def load_assignments(plan_name: str = ""):
                     held["camps"][place] = minutes
             continue
 
+        # A placed card is Assigned and so is not a pool card, and older saves
+        # overwrote a row's saved names with empty strings once that happened - which
+        # left the detail drawer unable to build a card for the block, so clicking it
+        # did nothing at all. The shipment the row points at still knows them, so a
+        # blank copy is filled in from there rather than left dead (WI-002401).
+        held = shipment_meta.get(row.transportation_shipment) or {}
+
         swim_items.append({
             "id":        f"{row.card_id}_{row.direction}_{row.name}",
             "cardId":    row.card_id,
@@ -1419,10 +1474,10 @@ def load_assignments(plan_name: str = ""):
             "transitMinutes": row.transit_minutes or 0,
             "bufferMinutes": row.buffer_minutes or 0,
             # Saved metadata for detail panel fallback
-            "_site":          row.site or "",
-            "_shift":         row.shift or "",
-            "_accommodation": row.accommodation or "",
-            "_stopLocation":  row.stop_location or "",
+            "_site":          row.site or held.get("site") or "",
+            "_shift":         row.shift or held.get("shift") or "",
+            "_accommodation": row.accommodation or held.get("accommodation") or "",
+            "_stopLocation":  row.stop_location or held.get("stop_location") or "",
         })
         assigned_card_ids.add(row.card_id)
 
@@ -1596,11 +1651,9 @@ def get_manifest_data_for_plan(plan_name: str):
 		planner_data = {"shipment_cards": [], "vehicles": []}
 
 	card_emp_map = {}
-	card_return_emp_map = {}
 	card_headcount_map = {}
 	for card in planner_data.get("shipment_cards", []):
 		card_emp_map[card["id"]] = card.get("employees", [])
-		card_return_emp_map[card["id"]] = card.get("return_employees", [])
 		card_headcount_map[card["id"]] = card.get("headcount", 0)
 
 	# Supplement rosters for shipment-backed assignment rows. Once a shipment is
@@ -1626,7 +1679,6 @@ def get_manifest_data_for_plan(plan_name: str):
 		for card_id, ship_name in shipment_by_card.items():
 			emps = emps_by_ship.get(ship_name, [])
 			card_emp_map[card_id] = emps
-			card_return_emp_map[card_id] = []
 			card_headcount_map[card_id] = len(emps)
 
 	# ── Build manifest data structure ──
@@ -1664,7 +1716,7 @@ def get_manifest_data_for_plan(plan_name: str):
 
 		# Always sync rows — handles both new and existing manifests
 		v_rows = [row for row in rows if row.vehicle == v_id]
-		rows_changed = sync_manifest_details(manifest_doc, v_rows, card_emp_map, card_return_emp_map)
+		rows_changed = sync_manifest_details(manifest_doc, v_rows, card_emp_map)
 
 		# The manifest header inherits the run's direction and, for a merged run, its
 		# shared group key (WI-002072). Read from the assignment rows rather than passed
@@ -1809,16 +1861,18 @@ def get_manifest_data_for_plan(plan_name: str):
 
 		shipments.append({"label": lbl, "pickups": [{}], "deliveries": [{}]})
 
-		# Map employees
-		if row.direction == "RETURN":
-			ret_emps = card_return_emp_map.get(row.card_id, [])
-			ship_emp[lbl] = enrich_employees(ret_emps, row.vehicle, row.stop_location or "", row.trip_group, True) if ret_emps else []
-		else:
-			emps = card_emp_map.get(row.card_id, [])
-			ship_emp[lbl] = enrich_employees(emps, row.vehicle, row.stop_location or "", row.trip_group, False) if emps else []
-
-		ret_emps = card_return_emp_map.get(row.card_id, [])
-		ship_return_emp[lbl] = enrich_employees(ret_emps, row.vehicle, row.stop_location or "", row.trip_group, True) if ret_emps else []
+		# The card's own riders, whichever way this leg travels. A return leg used to
+		# read a separate `return_employees` list, which nothing has ever filled - so
+		# every return row on the driver's manifest listed NOBODY while its card
+		# carried the people (WI-002401). A card's riders go out and come back; the
+		# leg only says which way they are travelling.
+		emps = card_emp_map.get(row.card_id, [])
+		boards = row.direction == "RETURN"
+		ship_emp[lbl] = (
+			enrich_employees(emps, row.vehicle, row.stop_location or "", row.trip_group, boards)
+			if emps else []
+		)
+		ship_return_emp[lbl] = ship_emp[lbl] if boards else []
 
 		# Site location
 		if row.shift and row.shift in shift_doc_map:
@@ -2279,6 +2333,42 @@ def process_rambo_replacement(original_employee: str, replacement_employee: str,
         "notified": False,
         "message": "Replacement processed. No supervisor found for this shift to notify."
     }
+
+
+def _unmerge_unmixed_placements(items) -> None:
+    """A card no longer placed as part of a merged run is no longer merged.
+
+    The operator breaks a merge by taking one stop out of the run: what is left may
+    travel only one way, and every remaining card's shipment is still flagged Mixed.
+
+    Two things had to be true for this to work and neither was:
+
+    * It has to run BEFORE the rows are written. A row's direction is read off its
+      shipment (`_assignment_direction`), so unmerging afterwards left the row saying
+      MIXED while the shipment said Outward - the block came back Mixed on the next
+      load and only corrected itself on a second save.
+    * It has to run for a card whose shipment and placement DISAGREE. The old rule sat
+      in `_sync_shipment_statuses` and only considered cards it had just counted as
+      Assigned, which requires the shipment's own direction to match the direction it
+      was placed in - so it skipped every card that was still flagged Mixed, which is
+      the only kind there was anything to repair (WI-002401 AC3).
+    """
+    from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
+        unmerge_trip_shipment,
+    )
+
+    placed = {}
+    for item in items:
+        name = _shipment_from_card_id(item.get("cardId", ""))
+        if name:
+            placed.setdefault(name, set()).add(
+                _normalize_direction(item.get("direction", ""))
+            )
+
+    for name, placed_dirs in placed.items():
+        # MIXED on any of its blocks means the card is still riding a merged run.
+        if "MIXED" not in placed_dirs and frappe.db.exists("Transportation Shipment", name):
+            unmerge_trip_shipment(name)
 
 
 def _shipment_direction_flags(items) -> dict:

--- a/one_fm/operations/doctype/route_plan/route_plan.py
+++ b/one_fm/operations/doctype/route_plan/route_plan.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import datetime
+import re
 
 import frappe
 from frappe import _
@@ -18,6 +19,11 @@ _TIME_END = datetime.timedelta(days=1)
 # The direction a merged trip carries once cards are combined (WI-002071).
 MIXED_DIRECTION = "MIXED"
 
+# A trip name as the canvas mints it: an optional leased "S-" prefix, the vehicle's own
+# number, then a two-digit sequence. "S-106" is vehicle 1 run 06; "S-1303" is vehicle 13
+# run 03; "1901" is vehicle 19 run 01 on a bus that is not leased.
+TRIP_NAME = re.compile(r"^(S-)?(\d+?)(\d{2})$")
+
 
 class RoutePlan(Document):
 	def validate(self):
@@ -27,6 +33,7 @@ class RoutePlan(Document):
 		self._validate_vehicle_retention_locks()
 		self._validate_vehicle_datetime_locks()
 		self._validate_trip_group_single_vehicle()
+		self._rename_duplicate_trip_names()
 		self._validate_vehicle_capacity()
 
 	def _validate_dates(self):
@@ -296,6 +303,70 @@ class RoutePlan(Document):
 					title=_("{0}: Vehicle Capacity Exceeded").format(vehicle),
 				)
 
+	def _rename_duplicate_trip_names(self):
+		"""No two runs on one vehicle answer to the same trip name (WI-002401).
+
+		A trip name is how a run is identified on the block, in the "Add Stop to which
+		trip?" picker and on the driver's manifest, so two runs called S-106 on one lane
+		are indistinguishable everywhere the name is all the reader has.
+
+		The canvas already mints a name by scanning for the next free sequence rather
+		than counting the runs - counting re-issued a name the moment any run but the
+		last was removed (WI-002160). But it reads that list when the placement dialog
+		OPENS and the drop commits later, so two dialogs open at once, or one left open
+		while another card is placed, still hand out the same number. Rather than chase
+		every path on the board, the rule is enforced here, where they all end up.
+
+		A repair, not a refusal: the plans already carry duplicates and refusing the save
+		would strand them. The earliest run keeps the name - it is the one the dispatcher
+		has been looking at - and each later claimant takes the next free sequence for
+		that vehicle.
+		"""
+		for vehicle, runs in self._runs_by_vehicle().items():
+			taken = {name for run in runs.values() for name in {run["name"]} if name}
+			shape = _trip_name_shape(taken)
+			if not shape:
+				# No name on this lane parses, so there is no series to extend. Renaming
+				# into a guessed one would be worse than leaving the clash visible.
+				continue
+
+			claimed = {}
+			for key in sorted(runs, key=lambda k: (runs[k]["start"], str(k))):
+				run = runs[key]
+				if not run["name"]:
+					continue
+				if run["name"] not in claimed:
+					claimed[run["name"]] = key
+					continue
+				fresh = _next_free_trip_name(shape, taken)
+				if not fresh:
+					continue
+				taken.add(fresh)
+				for row in run["rows"]:
+					row.trip_name = fresh
+
+	def _runs_by_vehicle(self) -> dict:
+		"""``{vehicle: {trip key: run}}`` over every row, camp legs included.
+
+		Camp legs carry the run's trip_name too, so a rename has to take them with it or
+		the drive out of the accommodation would answer to the old name. That is why this
+		does not go through ``_logical_trips``, which deliberately drops them.
+		"""
+		by_vehicle = {}
+		for idx, row in enumerate(self.assignments):
+			if not row.vehicle:
+				continue
+			# Standalone rows are keyed by position so two of them never merge.
+			key = row.trip_group or f"\0row-{idx}"
+			run = by_vehicle.setdefault(row.vehicle, {}).setdefault(
+				key, {"name": None, "start": _DAY_SECONDS, "rows": []}
+			)
+			run["rows"].append(row)
+			run["name"] = run["name"] or row.trip_name
+			start, _end = _row_time_window(row)
+			run["start"] = min(run["start"], start)
+		return by_vehicle
+
 	def _logical_trips(self, assignments=None) -> list:
 		"""Collapse the assignment rows into the trips a vehicle actually runs.
 
@@ -381,14 +452,28 @@ class RoutePlan(Document):
 		if not before:
 			return set()
 
-		def placement(rows):
+		def placement(trips):
+			"""``{vehicle: {(trip group, card)}}`` - which cards ride in which run.
+
+			Neither the trip's own key nor the stop numbering can stand in for that. A
+			standalone row is keyed by its position, which moves when an unrelated row is
+			added. And ``stop_index`` is DERIVED, not stated: ``_stamp_leg_details``
+			renumbers every row of every vehicle off the itinerary (physical stops, camp
+			legs included) while the canvas round-trips a logical 1..N, and the order
+			itself is re-derived from each card's own arrival time. Keying on either
+			re-lettered every card on every save, so no bus was ever "untouched" - one
+			pre-existing overload then refused every edit anywhere on the plan, on a
+			vehicle the dispatcher had never gone near (WI-002401).
+
+			ponytail: membership only, so re-sequencing a merged run's stops without
+			adding or removing a card reads as untouched and keeps the verdict it was
+			saved with. Add the order back here if stop order ever becomes something the
+			dispatcher sets by hand rather than something the itinerary derives.
+			"""
 			by_vehicle = {}
-			for trip in rows:
+			for trip in trips:
 				by_vehicle.setdefault(trip.vehicle, set()).update(
-					# The trip's own key is not usable here: a standalone row is keyed by
-					# its position, which moves when an unrelated row is added.
-					(row.trip_group, row.transportation_shipment, row.stop_index)
-					for row in trip.rows
+					(row.trip_group, row.transportation_shipment) for row in trip.rows
 				)
 			return by_vehicle
 
@@ -517,6 +602,41 @@ def _time_windows_overlap(a_start, a_end, b_start, b_end) -> bool:
 
 
 _DAY_SECONDS = 24 * 60 * 60
+
+
+def _trip_name_shape(names):
+	"""``(prefix, vehicle number)`` shared by the trip names already on one lane.
+
+	Read back off the lane rather than re-derived: the canvas numbers a vehicle by its
+	POSITION in the vehicle list, which moves as vehicles are added, retired or
+	filtered, and is not something the server can reproduce. Whatever the board has
+	been calling this bus is what a new name for it has to look like.
+
+	The commonest shape wins, so one odd name left by hand cannot re-letter the lane.
+	"""
+	shapes = {}
+	for name in names:
+		match = TRIP_NAME.match(str(name or "").strip())
+		if match:
+			prefix, vehicle_number, _seq = match.groups()
+			shapes[(prefix or "", vehicle_number)] = shapes.get((prefix or "", vehicle_number), 0) + 1
+	if not shapes:
+		return None
+	return max(shapes, key=lambda shape: (shapes[shape], shape))
+
+
+def _next_free_trip_name(shape, taken):
+	"""The lowest sequence in this lane's series that nothing is using yet.
+
+	Two digits, as the canvas writes them. A lane that has somehow used all 99 gets
+	nothing rather than a name that would collide again.
+	"""
+	prefix, vehicle_number = shape
+	for seq in range(1, 100):
+		name = f"{prefix}{vehicle_number}{seq:02d}"
+		if name not in taken:
+			return name
+	return None
 
 
 def _passenger_limits(vehicle_names) -> dict:

--- a/one_fm/operations/doctype/route_plan/test_route_plan.py
+++ b/one_fm/operations/doctype/route_plan/test_route_plan.py
@@ -962,3 +962,282 @@ class TestAnUntouchedBusIsNotAWall(FrappeTestCase):
 		plan = frappe.new_doc("Route Plan")
 
 		self.assertEqual(plan._vehicles_this_save_did_not_touch([]), set())
+
+
+class TestSequentialRunsAreWeighedSeparately(FrappeTestCase):
+	"""One trip is one bus run, and a finished run holds nobody (WI-002401 AC5).
+
+	A vehicle that puts its passengers down at 06:05 is empty when the 06:35 run
+	boards, so the two never see each other's riders. Pooling them refused a seat that
+	was free and named two runs the dispatcher was not aiming at.
+	"""
+
+	VEHICLE = "VHL-L-0022"  # 4 seats -> 3 legal passenger seats
+	SEATS = 3
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		if not frappe.db.exists("Vehicle", cls.VEHICLE):
+			raise cls.skipTest(cls, f"Fixture vehicle {cls.VEHICLE} missing on this site")
+
+	def _row(self, *, trip, headcount, start, end):
+		return {
+			"card_id": frappe.generate_hash("CARD", 8),
+			"vehicle": self.VEHICLE,
+			"direction": "OUTBOUND",
+			"trip_group": trip,
+			"trip_name": trip,
+			"headcount": headcount,
+			"start_time": f"2026-07-20T{start}Z",
+			"end_time": f"2026-07-20T{end}Z",
+		}
+
+	def _plan(self, rows):
+		doc = frappe.new_doc("Route Plan")
+		doc.title = frappe.generate_hash("RP-SEQ", 8)
+		doc.status = "Draft"
+		doc.effective_from = today()
+		for row in rows:
+			doc.append("assignments", row)
+		doc.flags.ignore_mandatory = True
+		doc.flags.ignore_links = True
+		return doc
+
+	def test_two_sequential_runs_are_not_added_together(self):
+		# The AC's own numbers, scaled to a 3-seat bus: an early run of 1 and a later
+		# run of 2 both fit, and 1 + 2 = 3 only matters if they share the road.
+		plan = self._plan([
+			self._row(trip="S-106", headcount=1, start="05:30:00", end="06:05:00"),
+			self._row(trip="S-102", headcount=2, start="06:35:00", end="08:20:00"),
+		])
+
+		plan.insert(ignore_permissions=True)   # must not raise
+
+		trips = plan._logical_trips()
+		self.assertEqual(_peak_concurrent_headcount(trips), 2)
+
+	def test_a_sequential_run_may_be_filled_to_the_seats(self):
+		# Adding a passenger to the later run takes it to the seat count exactly,
+		# which the earlier run has no say in.
+		plan = self._plan([
+			self._row(trip="S-106", headcount=2, start="05:30:00", end="06:05:00"),
+			self._row(trip="S-102", headcount=3, start="06:35:00", end="08:20:00"),
+		])
+
+		plan.insert(ignore_permissions=True)   # must not raise
+
+	def test_runs_that_really_do_overlap_still_add_up(self):
+		# Same bus, same hours: these passengers are aboard together.
+		plan = self._plan([
+			self._row(trip="S-106", headcount=2, start="05:30:00", end="07:00:00"),
+			self._row(trip="S-102", headcount=2, start="06:35:00", end="08:20:00"),
+		])
+
+		with self.assertRaises(frappe.ValidationError) as cm:
+			plan.insert(ignore_permissions=True)
+
+		self.assertIn("overlapping passengers", str(cm.exception))
+
+
+class TestRenumberedStopsDoNotUnprotectAnUntouchedBus(FrappeTestCase):
+	"""stop_index is derived, so it cannot decide whether a save touched a bus.
+
+	_stamp_leg_details renumbers every row of every vehicle off the itinerary on every
+	save, while the canvas round-trips a logical 1..N. Keying the untouched-vehicle
+	guard on that number re-lettered every card each time, so no bus was ever untouched
+	- and one pre-existing overload then refused every edit anywhere on the plan, on a
+	vehicle the dispatcher had never gone near (WI-002401).
+	"""
+
+	def _rows(self, *, first_index):
+		return [
+			frappe._dict(vehicle="BUS-A", transportation_shipment="TS-1",
+						 stop_index=first_index, trip_group="T1", direction="OUTBOUND",
+						 headcount=27, start_time="2026-08-18T06:00:00Z",
+						 end_time="2026-08-18T07:00:00Z"),
+			frappe._dict(vehicle="BUS-A", transportation_shipment="TS-2",
+						 stop_index=first_index + 1, trip_group="T1", direction="OUTBOUND",
+						 headcount=1, start_time="2026-08-18T07:00:00Z",
+						 end_time="2026-08-18T08:00:00Z"),
+		]
+
+	def test_the_same_cards_under_different_stop_numbers_read_as_untouched(self):
+		plan = frappe.new_doc("Route Plan")
+		plan.get_doc_before_save = lambda: frappe._dict(assignments=self._rows(first_index=2))
+
+		# The identical placement, renumbered from 1 the way the canvas sends it back.
+		untouched = plan._vehicles_this_save_did_not_touch(
+			plan._logical_trips(self._rows(first_index=1))
+		)
+
+		self.assertIn("BUS-A", untouched)
+
+	def test_a_card_that_actually_moved_is_still_judged(self):
+		plan = frappe.new_doc("Route Plan")
+		plan.get_doc_before_save = lambda: frappe._dict(assignments=self._rows(first_index=1))
+		moved = self._rows(first_index=1)
+		moved[1].vehicle = "BUS-B"
+
+		untouched = plan._vehicles_this_save_did_not_touch(plan._logical_trips(moved))
+
+		self.assertNotIn("BUS-A", untouched)
+		self.assertNotIn("BUS-B", untouched)
+
+
+class TestATripNameNamesOneRun(FrappeTestCase):
+	"""No two runs on one vehicle answer to the same trip name (WI-002401).
+
+	A trip name identifies a run on the block, in the "Add Stop to which trip?" picker and
+	on the driver's manifest, so a lane holding two runs called S-106 is ambiguous
+	everywhere the name is all the reader has. The canvas mints a name by scanning for the
+	next free sequence, but it reads that list when the placement dialog OPENS and the drop
+	commits later - so the rule is enforced here, where every path ends up.
+	"""
+
+	def _plan(self, rows):
+		doc = frappe.new_doc("Route Plan")
+		doc.title = frappe.generate_hash("RP-NAME", 8)
+		doc.status = "Draft"
+		doc.effective_from = today()
+		for row in rows:
+			doc.append("assignments", row)
+		doc.flags.ignore_mandatory = True
+		doc.flags.ignore_links = True
+		return doc
+
+	def _row(self, *, vehicle="BUS-A", trip, name, start, end="23:00:00"):
+		return {
+			"card_id": frappe.generate_hash("CARD", 8),
+			"vehicle": vehicle,
+			"direction": "OUTBOUND",
+			"trip_group": trip,
+			"trip_name": name,
+			"headcount": 1,
+			"start_time": f"2026-07-20T{start}Z",
+			"end_time": f"2026-07-20T{end}Z",
+		}
+
+	def _names(self, doc):
+		return {row.trip_group: row.trip_name for row in doc.assignments}
+
+	def test_the_earlier_run_keeps_the_name(self):
+		# The 05:30 run is the one the dispatcher has been looking at.
+		doc = self._plan([
+			self._row(trip="T-EARLY", name="S-106", start="05:30:00", end="06:05:00"),
+			self._row(trip="T-LATE", name="S-106", start="22:00:00", end="23:15:00"),
+			self._row(trip="T-OTHER", name="S-101", start="13:00:00", end="14:00:00"),
+		])
+
+		doc._rename_duplicate_trip_names()
+
+		names = self._names(doc)
+		self.assertEqual(names["T-EARLY"], "S-106")
+		self.assertEqual(names["T-OTHER"], "S-101")
+		# S-101 and S-106 are taken, so the next free sequence in this lane's series.
+		self.assertEqual(names["T-LATE"], "S-102")
+
+	def test_every_row_of_the_renamed_run_moves_together(self):
+		# Including a camp leg, which carries the run's name but no card.
+		doc = self._plan([
+			self._row(trip="T-EARLY", name="S-106", start="05:30:00", end="06:05:00"),
+			self._row(trip="T-LATE", name="S-106", start="22:00:00", end="22:30:00"),
+			self._row(trip="T-LATE", name="S-106", start="22:30:00", end="23:15:00"),
+		])
+		doc.assignments[-1].is_camp_leg = 1
+
+		doc._rename_duplicate_trip_names()
+
+		# S-106 is the only name taken, so the next free sequence is 01.
+		late = [row.trip_name for row in doc.assignments if row.trip_group == "T-LATE"]
+		self.assertEqual(late, ["S-101", "S-101"])
+
+	def test_a_lane_with_no_clash_is_left_alone(self):
+		doc = self._plan([
+			self._row(trip="T1", name="S-101", start="05:30:00"),
+			self._row(trip="T2", name="S-102", start="07:30:00"),
+		])
+
+		doc._rename_duplicate_trip_names()
+
+		self.assertEqual(self._names(doc), {"T1": "S-101", "T2": "S-102"})
+
+	def test_the_same_name_on_two_different_vehicles_is_not_a_clash(self):
+		# A name only has to be unique on its own lane.
+		doc = self._plan([
+			self._row(vehicle="BUS-A", trip="T1", name="S-101", start="05:30:00"),
+			self._row(vehicle="BUS-B", trip="T2", name="S-101", start="05:30:00"),
+		])
+
+		doc._rename_duplicate_trip_names()
+
+		self.assertEqual(self._names(doc), {"T1": "S-101", "T2": "S-101"})
+
+	def test_an_unparseable_series_is_left_visible_rather_than_guessed(self):
+		# Renaming into an invented series would be worse than the clash.
+		doc = self._plan([
+			self._row(trip="T1", name="MORNING", start="05:30:00"),
+			self._row(trip="T2", name="MORNING", start="07:30:00"),
+		])
+
+		doc._rename_duplicate_trip_names()
+
+		self.assertEqual(self._names(doc), {"T1": "MORNING", "T2": "MORNING"})
+
+	def test_the_series_is_read_off_the_lane_not_off_the_vehicle_id(self):
+		# The canvas numbers a vehicle by its POSITION in the vehicle list, which the
+		# server cannot reproduce - so a new name copies what the lane already uses.
+		doc = self._plan([
+			self._row(trip="T1", name="1901", start="05:30:00"),
+			self._row(trip="T2", name="1901", start="07:30:00"),
+		])
+
+		doc._rename_duplicate_trip_names()
+
+		self.assertEqual(self._names(doc)["T2"], "1902")
+
+	def test_repairing_twice_changes_nothing_the_second_time(self):
+		doc = self._plan([
+			self._row(trip="T1", name="S-106", start="05:30:00"),
+			self._row(trip="T2", name="S-106", start="07:30:00"),
+		])
+
+		doc._rename_duplicate_trip_names()
+		once = self._names(doc)
+		doc._rename_duplicate_trip_names()
+
+		self.assertEqual(self._names(doc), once)
+
+	def test_three_runs_sharing_one_name_all_end_up_distinct(self):
+		doc = self._plan([
+			self._row(trip="T1", name="S-101", start="05:30:00"),
+			self._row(trip="T2", name="S-101", start="07:30:00"),
+			self._row(trip="T3", name="S-101", start="09:30:00"),
+		])
+
+		doc._rename_duplicate_trip_names()
+
+		names = self._names(doc)
+		self.assertEqual(names["T1"], "S-101")
+		self.assertEqual(len(set(names.values())), 3)
+
+	def test_a_save_can_never_store_a_duplicate(self):
+		# Wired into validate(), so it does not matter which path on the board handed the
+		# name out - and it repairs rather than refuses, because the plans already carry
+		# duplicates and refusing would strand them.
+		vehicle = "VHL-L-0022"
+		if not frappe.db.exists("Vehicle", vehicle):
+			self.skipTest(f"Fixture vehicle {vehicle} missing on this site")
+
+		doc = self._plan([
+			self._row(vehicle=vehicle, trip="T1", name="S-106",
+					  start="05:30:00", end="06:05:00"),
+			self._row(vehicle=vehicle, trip="T2", name="S-106",
+					  start="22:00:00", end="23:15:00"),
+		])
+
+		doc.insert(ignore_permissions=True)
+		stored = frappe.get_doc("Route Plan", doc.name)
+
+		names = [row.trip_name for row in stored.assignments]
+		self.assertEqual(sorted(names), ["S-101", "S-106"])

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -611,3 +611,4 @@ one_fm.patches.v15_0.consolidate_extension_actions #2026-09-02 WI-002179
 one_fm.patches.v15_0.update_work_permit_assignment_rules #2026-09-02 WI-002182
 one_fm.patches.v15_0.drop_erf_field_order_property_setter #2026-09-06b WI-002316
 one_fm.patches.v15_0.retire_unplanned_erf_reason #2026-09-06 WI-002316
+one_fm.patches.v15_0.rename_duplicate_trip_names #2026-09-07 WI-002401

--- a/one_fm/patches/v15_0/rename_duplicate_trip_names.py
+++ b/one_fm/patches/v15_0/rename_duplicate_trip_names.py
@@ -1,0 +1,48 @@
+import frappe
+
+# WI-002401: two runs on one vehicle answering to the same trip name.
+#
+# A trip name is how a run is identified on the timeline block, in the "Add Stop to which
+# trip?" picker and on the driver's manifest, so a lane holding two runs called S-106 is
+# ambiguous everywhere the name is all the reader has - vehicle 60/59220 had one at
+# 05:30-06:05 and another at 22:00-23:15, both S-106.
+#
+# The canvas used to mint a name by COUNTING the runs on the lane, which re-issued a name
+# the moment any run but the last was removed (fixed in WI-002160 by scanning for the next
+# free sequence). It now also cannot happen at all, because the rule is enforced on the
+# Route Plan itself - see RoutePlan._rename_duplicate_trip_names. This clears what the old
+# behaviour already wrote.
+#
+# The repair is the same code the save runs, so the patch and the live rule can never
+# disagree about what a correct lane looks like: the earliest run keeps the name and each
+# later claimant takes the next free sequence in that lane's own series.
+#
+# Rows are written with db.set_value rather than by saving the Route Plan: saving would
+# re-run the whole plan's capacity validation, and a patch must not fail because some
+# unrelated lane on a months-old plan no longer passes.
+
+
+def execute():
+	if not frappe.db.exists("DocType", "Route Plan Assignment"):
+		return
+
+	renamed = 0
+	for plan in frappe.get_all("Route Plan", pluck="name"):
+		doc = frappe.get_doc("Route Plan", plan)
+		before = {row.name: row.trip_name for row in doc.assignments}
+
+		doc._rename_duplicate_trip_names()
+
+		for row in doc.assignments:
+			if before.get(row.name) == row.trip_name:
+				continue
+			frappe.db.set_value(
+				"Route Plan Assignment", row.name, "trip_name", row.trip_name,
+				update_modified=False,
+			)
+			renamed += 1
+
+	if renamed:
+		# No commit here: the patch runner commits, and committing inside would break
+		# the transaction a test wraps this in.
+		print(f"WI-002401: renamed {renamed} assignment row(s) off a duplicated trip name")

--- a/one_fm/tests/test_lane_day_rebase.py
+++ b/one_fm/tests/test_lane_day_rebase.py
@@ -59,3 +59,64 @@ class TestATripComesBackInOnePiece(FrappeTestCase):
 		# the run's date, so a trip whose stops were saved on different days is dragged
 		# apart by the difference between them.
 		self.assertNotIn("tripShift[i.tripId] = { earliest", self.source)
+
+
+class TestTheLegsWithNoBlockAreRebasedToo(FrappeTestCase):
+	"""A camp departure and a home arrival are stored stamps like any other.
+
+	Their DATE half is a lock lifespan, and the one they inherited is whichever row of
+	the run the server anchored them on - not the row the canvas draws first. Left raw
+	while every block was rebased onto today, a departure stored 26 days from its own run
+	put the trip block's left edge that far off the axis: 97 of 106 runs on the live plan
+	were drawn up to 35,000px wide on a 1,000px lane (WI-002401).
+	"""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_the_leg_timings_are_moved_onto_the_run_they_belong_to(self):
+		self.assertIn("const ontoRun = (stamp, anchorMs) => {", self.source)
+		self.assertIn("ms + Math.round((anchorMs - ms) / dayMs) * dayMs", self.source)
+		self.assertIn("departure: ontoRun(held.departure, runStart[tripId]),", self.source)
+		self.assertIn("arrival: ontoRun(held.arrival, runStart[tripId]),", self.source)
+
+	def test_the_anchor_is_the_runs_own_earliest_rebased_stop(self):
+		self.assertIn("if (runStart[i.tripId] === undefined || ms < runStart[i.tripId]) {",
+					  self.source)
+
+	def test_a_block_always_covers_every_stop_it_holds(self):
+		# Clamped, so a stored leg timing can widen the block but never shrink it below
+		# its own stops - and a garbage stamp can no longer invert it.
+		self.assertIn("stated(held.departure) ?? Infinity, spanStart.getTime()", self.source)
+		self.assertIn("stated(held.arrival) ?? -Infinity, spanEnd.getTime()", self.source)
+
+	def test_the_span_is_read_over_all_stops_not_the_first_and_last_by_number(self):
+		# After the rebase a stop can sit a few minutes before stop one, which gave the
+		# block a negative width and drew it as the 8px minimum.
+		self.assertIn("const spanStart = new Date(Math.min(", self.source)
+		self.assertIn("const spanEnd = new Date(Math.max(", self.source)
+		self.assertNotIn("const lastItem = stops[stops.length - 1];", self.source)
+
+
+class TestRemovingAStopTakesTheStopYouPicked(FrappeTestCase):
+	"""Clicking a merged block selects stop 1, whichever stop you are reading.
+
+	So "Remove from Lane" silently took the first stop of the run while the operator was
+	looking at the last one (WI-002401).
+	"""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_a_stop_row_in_the_drawer_can_be_picked(self):
+		self.assertIn('@click.stop="selectedItem = stop.item"', self.source)
+		# It already showed which stop was selected; there was just no way to change it.
+		self.assertIn("stop.item.id === selectedItem.id ? '#f97316'", self.source)
+
+	def test_the_button_names_the_stop_it_will_take(self):
+		self.assertIn("removeButtonLabel()", self.source)
+		self.assertIn("__('Remove Stop {0} ({1}) from Lane'", self.source)
+
+	def test_a_single_stop_run_keeps_the_plain_label(self):
+		self.assertIn("if (!this.selectedItem || stops.length < 2) return __('Remove from Lane');",
+					  self.source)

--- a/one_fm/tests/test_one_trip_group_is_one_run.py
+++ b/one_fm/tests/test_one_trip_group_is_one_run.py
@@ -52,9 +52,13 @@ class TestOneTripGroupIsOneRun(FrappeTestCase):
 		)
 		# The three places a run is weighed against the seats: the lane's own reading,
 		# reassigning a journey to another vehicle, and merging a block into a trip.
+		# The last one now reads the run WITH the joining card on it (WI-002401), which
+		# is the only way a cross-direction merge can be judged on the seats that are
+		# actually free - but it is still the same one rule.
 		self.assertIn("t.direction = this.runDirection(t.stops);", self.source)
 		self.assertIn("direction: self.runDirection(journeyItems),", self.source)
-		self.assertIn("direction: self.runDirection(targetTripItems),", self.source)
+		self.assertIn("self.mergedOccupancy(targetTripItems, card),", self.source)
+		self.assertIn("direction: this.runDirection(merged),", self.source)
 
 	def test_the_save_reads_it_the_same_way(self):
 		source = ROUTE_PLAN.read_text()
@@ -103,10 +107,14 @@ class TestARunIsDrawnAsWhatItIs(FrappeTestCase):
 
 
 class TestARefusalNamesTheRunThatTookTheSeats(FrappeTestCase):
-	"""A card is placed at its own shift window, never where it was dropped.
+	"""Naming only the vehicle made a refusal impossible to diagnose from the screen.
 
-	So the run that blocks a drop is routinely not the block the operator was aiming at
-	— naming only the vehicle made the refusal impossible to diagnose from the screen.
+	This used to be weighed against the card's own shift window, on the reasoning that a
+	card is placed there rather than where it was dropped - so the run named was
+	routinely not the one the operator was aiming at, and sequential runs got added
+	together. WI-002401 AC5 replaced that: the load is weighed against the run it is
+	actually joining, plus the runs on the road at the same hours, and the message names
+	exactly those.
 	"""
 
 	def setUp(self):
@@ -114,15 +122,16 @@ class TestARefusalNamesTheRunThatTookTheSeats(FrappeTestCase):
 
 	def test_the_message_can_name_the_blocking_runs(self):
 		self.assertIn("capacityMessage(headcount, vehicle, blockers) {", self.source)
-		self.assertIn("Those seats are held by {0}.", self.source)
+		self.assertIn("Counted for this drop: {0}.", self.source)
 
 	def test_the_check_and_the_message_read_one_list(self):
-		# If they were computed separately they would drift, and the message would name
-		# runs the check did not actually count.
-		self.assertIn("tripsDuringCardWindows(card, vehicleId, direction) {", self.source)
-		self.assertIn(
-			"return this.tripsDuringCardWindows(card, vehicleId, direction)", self.source
-		)
+		# One call answers both, so they cannot drift and the message can never name a
+		# run the check did not count.
+		self.assertIn("return {\n                    total: occupancy", self.source)
+		self.assertIn("blockers: target ? [target, ...others] : others", self.source)
+		for caller in ("const { total, blockers } = this.seatLoad(",
+					   "const { total, blockers } = self.seatLoad("):
+			self.assertIn(caller, self.source)
 
 	def test_a_logical_trip_carries_its_name(self):
 		self.assertIn("tripName: item.tripName || null,", self.source)

--- a/one_fm/tests/test_overcapacity_card_split.py
+++ b/one_fm/tests/test_overcapacity_card_split.py
@@ -168,13 +168,17 @@ class TestTheCanvasOffersTheSplit(FrappeTestCase):
 	def setUp(self):
 		self.source = CANVAS.read_text()
 
-	def test_the_drop_is_intercepted_before_the_seat_check(self):
-		# The seat gate would throw first and the split would never be offered.
+	def test_the_drop_is_intercepted_before_the_run_is_chosen(self):
+		# A card bigger than the whole bus is the one refusal that belongs before the
+		# picker, because no run on that lane can take it. Everything else waits until
+		# the operator has chosen a run (WI-002401 AC5), so the pooled seat gate that
+		# used to sit here - and would have thrown before the split was ever offered -
+		# is gone.
 		self.assertIn("if (card.headcount > this.passengerSeats(vehicle)) {", self.source)
 		self.assertIn("this._openSplitModal(card, vehicle);", self.source)
 		self.assertLess(
 			self.source.index("_openSplitModal(card, vehicle);"),
-			self.source.index("const blockers = this.tripsDuringCardWindows(card, vehicle.id);"),
+			self.source.index("// ── Trip chaining: detect nearby blocks"),
 		)
 
 	def test_the_modal_states_the_four_numbers(self):

--- a/one_fm/tests/test_physical_stop_itinerary.py
+++ b/one_fm/tests/test_physical_stop_itinerary.py
@@ -167,3 +167,54 @@ class TestEveryCardHasExactlyOneServingStop(FrappeTestCase):
 		# ...but it is nobody's serving stop, because it has no onward leg to time.
 		self.assertNotIn(home["stop_index"], [v[0] for v in self._serves(stops).values()])
 
+
+
+class TestAHandoverStopNamesBothMovements(FrappeTestCase):
+	"""One visit, two things the driver does there (WI-002401 item 4).
+
+	Where an outward load gets off and a return load gets on, the Trip Builder used to
+	announce a single action - the label read off ``action_type`` and the number off a
+	collapsed ``boarding_count or drop_off_count``. So a stop putting 3 down and
+	collecting 2 read "DROPPING OFF EMPLOYEES · 2": one movement's label against the
+	other's count, with the third rider missing. The legs table below always had both.
+	"""
+
+	def _handover(self):
+		# The shape from the ticket: 3 dropped at Khairan Mall, 2 collected there.
+		return build_itinerary([
+			_card("Mahboula Camp", "Khairan Mall", 3, direction="Outward"),
+			_card("Mahboula Camp", "Khairan Mall", 2, direction="Return"),
+		])
+
+	def test_the_stop_is_one_visit_carrying_both_counts(self):
+		stops = self._handover()
+
+		handover = [s for s in stops if s["place"] == "Khairan Mall"]
+		self.assertEqual(len(handover), 1, "one place the bus calls at is one container")
+		self.assertEqual(handover[0]["action_type"], "Combined")
+		self.assertEqual(handover[0]["drop_off_count"], 3)
+		self.assertEqual(handover[0]["boarding_count"], 2)
+
+	def test_neither_count_can_stand_in_for_the_stop(self):
+		# The old collapsed field: `boarding_count or drop_off_count` would answer 2 at a
+		# stop that also puts 3 down, which is why it had to go.
+		handover = [s for s in self._handover() if s["place"] == "Khairan Mall"][0]
+
+		self.assertNotEqual(handover["boarding_count"], handover["drop_off_count"])
+
+	def test_the_running_total_reads_straight_down_from_the_two_counts(self):
+		# Drop-off first, which is the order the bus does it: 3 aboard, 3 off, 2 on.
+		stops = self._handover()
+		_peak, _worst, per_stop = walk_occupancy(stops)
+
+		self.assertEqual(per_stop, [3, 2, 0])
+
+	def test_the_preview_sends_both_counts_and_no_collapsed_one(self):
+		import inspect
+
+		from one_fm.one_fm.doctype.transportation_shipment import transportation_shipment
+
+		source = inspect.getsource(transportation_shipment.get_merge_preview)
+		self.assertIn('"boarding_count": stop["boarding_count"],', source)
+		self.assertIn('"drop_off_count": stop["drop_off_count"],', source)
+		self.assertNotIn('stop["boarding_count"] or stop["drop_off_count"]', source)

--- a/one_fm/tests/test_transportation_seat_rule.py
+++ b/one_fm/tests/test_transportation_seat_rule.py
@@ -1,0 +1,248 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""The canvas seat rule, and the drawer actions around it (WI-002401).
+
+The seat check on the board and the one on save must not be able to disagree, or the
+canvas accepts a drop the save then refuses. The rule itself is exercised end to end by
+``transportation_schedule/test_seat_rule.js`` (``node test_seat_rule.js``), which reads
+the shipped helpers rather than copying them; what is asserted here is that the canvas
+keeps asking the question the right way round.
+"""
+
+import pathlib
+import subprocess
+import sys
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+CANVAS_DIR = pathlib.Path(frappe.get_app_path(
+	"one_fm", "one_fm", "page", "transportation_schedule"))
+CANVAS = CANVAS_DIR / "transportation_schedule.js"
+
+
+class TestTheSeatRuleSelfCheckPasses(FrappeTestCase):
+	def test_the_node_self_check_passes(self):
+		check = CANVAS_DIR / "test_seat_rule.js"
+		self.assertTrue(check.exists(), "the seat-rule self-check is missing")
+		try:
+			result = subprocess.run(
+				["node", str(check)], capture_output=True, text=True, timeout=60
+			)
+		except FileNotFoundError:
+			self.skipTest("node is not available on this machine")
+		self.assertEqual(
+			result.returncode, 0,
+			f"node {check.name} failed:\n{result.stdout}\n{result.stderr}",
+		)
+
+
+class TestCapacityIsJudgedPerRun(FrappeTestCase):
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_the_daily_window_is_read_in_the_sites_own_clock(self):
+		# The DATE half of a lane stamp is the multi-day lock lifespan, not the day the
+		# bus runs, so runs are compared by the hour they are on the road. Comparing raw
+		# epochs made a run whose lock began last month invisible to the check.
+		self.assertIn("_dayWindow(start, end)", self.source)
+		self.assertIn("timeZone: 'Asia/Kuwait'", self.source)
+		self.assertIn("if (to <= from) to += DAY;", self.source)
+
+	def test_overlap_is_circular_over_the_day(self):
+		# So a run past midnight still meets an early-morning one, and two runs that
+		# merely touch do not - a bus can turn straight around.
+		self.assertIn("_sharesTheRoad(a, b)", self.source)
+		self.assertIn("[-DAY, 0, DAY].some(shift => a.from < b.to + shift && b.from + shift < a.to)",
+					  self.source)
+
+	def test_the_run_being_joined_is_not_counted_twice(self):
+		self.assertIn("seatLoad(vehicleId, occupancy, { joining, window } = {})", self.source)
+		self.assertIn("t !== target && this._sharesTheRoad(road, t.window)", self.source)
+
+	def test_a_drop_is_not_refused_before_the_run_is_chosen(self):
+		# handleDrop offers a picker and, for a merge, the Trip Builder. Judging the drop
+		# against a pooled load first refused it before the operator could choose and
+		# pre-empted the modal (issue 3 on the ticket).
+		self.assertIn("// No seat check here.", self.source)
+		self.assertNotIn("tripsDuringCardWindows", self.source)
+		self.assertNotIn("peakLoadDuringCardWindows", self.source)
+		self.assertNotIn("cardLegWindow", self.source)
+
+	def test_a_card_bigger_than_the_bus_is_still_split_on_the_drop(self):
+		# The one refusal that does belong before the picker, because no run can take it.
+		self.assertIn("if (card.headcount > this.passengerSeats(vehicle)) {", self.source)
+		self.assertIn("this._openSplitModal(card, vehicle);", self.source)
+
+	def test_a_chain_is_judged_on_the_run_it_joins(self):
+		self.assertIn("this.mergedOccupancy(existingItems, newCard)", self.source)
+		self.assertIn("{ joining: existingItems }", self.source)
+
+	def test_a_cross_direction_merge_is_walked_leg_by_leg(self):
+		# A return card boards the seats the outward load has just left, so adding the
+		# two refused a merge the bus can make.
+		self.assertIn("mergedOccupancy(stops, card)", self.source)
+		self.assertIn("direction: this.runDirection(merged)", self.source)
+
+	def test_the_lane_colours_each_run_on_its_own_load(self):
+		self.assertIn("o !== t && this._sharesTheRoad(t.window, o.window)", self.source)
+		self.assertIn("if (load > seats) t.stops.forEach(s => over.add(s.id));", self.source)
+
+	def test_a_cross_lane_drag_is_judged_before_the_block_moves(self):
+		# Setting vehicleId first counted the block against itself on the target lane.
+		self.assertIn("{ window: this._dayWindow(item.start, item.end) }", self.source)
+		self.assertIn("item.vehicleId = targetVehicleId;", self.source)
+
+	def test_the_refusal_says_why_each_run_was_counted(self):
+		self.assertIn("Counted for this drop: {0}.", self.source)
+		self.assertIn("is not counted against it", self.source)
+
+
+class TestTheDrawerActions(FrappeTestCase):
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_a_run_can_be_re_timed_without_taking_it_apart(self):
+		# AC6: the Trip Builder is also the run's own editor.
+		self.assertIn("editSelectedTrip()", self.source)
+		self.assertIn("Edit Trip Timings", self.source)
+		self.assertIn("this._openMergeTripModal(null, stops, item.vehicleId)", self.source)
+
+	def test_editing_a_run_adds_no_stop(self):
+		self.assertIn("if (newCard) ids.push(newCard.id);", self.source)
+		self.assertIn("if (newCard) self.assignedCards.add(newCard.id);", self.source)
+
+	def test_a_run_that_loses_a_leg_stops_being_mixed(self):
+		# AC3: the block colour, the prefix arrow and the drawer badge all read
+		# item.direction, and the merge stamped MIXED on every stop.
+		self.assertIn("_resyncTripDirection(tripId)", self.source)
+		self.assertIn("this._resyncTripDirection(tripId);", self.source)
+
+	def test_a_mixed_run_is_never_guessed_back_to_outbound(self):
+		# A stop whose card has left the board has no own heading to read.
+		self.assertIn("if (!stops.length || !stops.every(i => i.direction === 'MIXED')) return;",
+					  self.source)
+		self.assertIn("if (headings.some(h => h !== headings[0])) return;", self.source)
+
+
+class TestTheRunIsDrawnEndToEnd(FrappeTestCase):
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_a_trip_block_spans_the_whole_journey(self):
+		# AC2 / AC4: the bus leaves the camp before any block starts and gets back after
+		# the last one ends, and the drawer header already read it that way. Clamped to
+		# the stops, and only comparable with them because the plan load rebases the leg
+		# timings onto the run's own day - see test_lane_day_rebase.
+		self.assertIn("stated(held.departure) ?? Infinity, spanStart.getTime()", self.source)
+		self.assertIn("stated(held.arrival) ?? -Infinity, spanEnd.getTime()", self.source)
+		self.assertIn("start: runStart,", self.source)
+		self.assertIn("end: runEnd,", self.source)
+
+	def test_the_drawer_header_reads_the_same_two_ends(self):
+		self.assertIn("const stored = this.selectedTripLegs.departure;", self.source)
+		self.assertIn("return this.selectedTripLegs.arrival || this.lastStopEndsAt();", self.source)
+
+	def test_the_existing_trips_list_shows_every_run_on_the_lane(self):
+		# AC1: filtering to OUTBOUND hid the return runs the new trip has to fit around,
+		# which is what the list is there to show.
+		self.assertIn("const existingOnVehicle = this.swimItems.filter(i => i.vehicleId === vehicleId);",
+					  self.source)
+
+	def test_a_camp_is_the_front_or_the_back_of_a_run_not_a_stop_between_sites(self):
+		# Reading each card as its own camp -> site pair printed the camp once per card:
+		# "Mahboula 13 -> Xcite -> Mahboula 13 -> Aramex -> Mahboula 13 -> Stockyard" for
+		# a bus that loads at Mahboula 13 once and then makes three drops.
+		self.assertIn("const boardsAt = [];", self.source)
+		self.assertIn("const deliversTo = [];", self.source)
+		self.assertIn("const route = [...boardsAt, ...sites, ...deliversTo];", self.source)
+		# The old shape, which stitched a camp in beside every site.
+		self.assertNotIn("? [site, camp]", self.source)
+		self.assertNotIn(": [camp, site];", self.source)
+
+	def test_a_second_visit_to_one_place_is_still_two_visits(self):
+		# Collapsing repeats anywhere would hide a run that genuinely calls at a site
+		# twice, which the lane does record.
+		self.assertIn("if (sites[sites.length - 1] !== site) sites.push(site);", self.source)
+
+	def test_a_mixed_run_closes_the_loop(self):
+		# It both drops off and picks up, so it always comes home - even when no stop
+		# could be read as a delivery because its cards have left the pool.
+		self.assertIn("if (runDir === 'MIXED' && !deliversTo.length) {", self.source)
+
+	def test_a_placed_card_that_left_the_pool_still_names_its_camp(self):
+		# Without this the summary printed the literal word "camp" and the raw card id.
+		self.assertIn("accommodation: item._accommodation || '',", self.source)
+		self.assertIn("const c = self.bcard(s);", self.source)
+
+
+class TestATripNameIsUniqueOnItsLane(FrappeTestCase):
+	"""WI-002401 item 7. The board's own guard, and the backstop behind it."""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_the_board_mints_the_next_free_number_not_a_count(self):
+		# Counting re-issued a name the moment any run but the last was removed
+		# (WI-002160): a lane holding S-201, S-202, S-204, S-205 counted four and
+		# offered S-205 again.
+		self.assertIn("while (taken.has(name(seq))) seq++;", self.source)
+		self.assertNotIn("const nextSeq = existingTripIds.size + 1;", self.source)
+
+	def test_joining_a_run_inherits_its_name_rather_than_minting_one(self):
+		# A new number is only ever minted for a NEW run; every chain, merge and
+		# reassignment takes the name of the run it joins.
+		for inherit in (
+			"tripName: existingItems.find((i) => i.tripName)?.tripName || null,",
+			"tripId, tripName: existingTripName, stopIndex: totalStops + 1",
+		):
+			self.assertIn(inherit, self.source)
+
+	def test_the_board_takes_back_the_name_the_save_actually_stored(self):
+		# The save is silent, so a server-side repair would otherwise not show until
+		# the next reload and would then look like the run renaming itself.
+		self.assertIn("_applyStoredTripNames(result)", self.source)
+		self.assertIn("callback: (r) => { this._applyStoredTripNames(r.message); },", self.source)
+		self.assertIn("already in use on this vehicle", self.source)
+
+
+class TestTheTripNamePatchIsRegistered(FrappeTestCase):
+	def test_the_patch_is_in_patches_txt(self):
+		listed = pathlib.Path(frappe.get_app_path("one_fm", "patches.txt")).read_text()
+		self.assertIn("one_fm.patches.v15_0.rename_duplicate_trip_names", listed)
+
+	def test_the_patch_reuses_the_rule_the_save_applies(self):
+		# Not a second implementation: the patch and the live rule must never disagree
+		# about what a correct lane looks like.
+		patch = pathlib.Path(frappe.get_app_path(
+			"one_fm", "patches", "v15_0", "rename_duplicate_trip_names.py")).read_text()
+		self.assertIn("doc._rename_duplicate_trip_names()", patch)
+		# Saving the plan would re-run capacity validation on months-old lanes.
+		self.assertIn("frappe.db.set_value(", patch)
+		self.assertNotIn("doc.save(", patch)
+
+
+class TestTheItineraryNamesBothMovements(FrappeTestCase):
+	"""The Trip Builder card for a handover stop (WI-002401 item 4)."""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_both_counts_are_rendered_not_one_collapsed_number(self):
+		self.assertIn("if (s.drop_off_count) {", self.source)
+		self.assertIn("if (s.boarding_count) {", self.source)
+		# The collapsed field is gone, so nothing can print one movement's label
+		# against the other's count.
+		self.assertNotIn("esc(s.headcount)", self.source)
+		self.assertNotIn("const boarding = s.action === 'Boarding';", self.source)
+
+	def test_drop_off_is_listed_before_boarding(self):
+		# The order the bus does it, and the order walk_occupancy measures it in, so the
+		# running total below reads straight down from the two numbers.
+		self.assertLess(
+			self.source.index("__('DROPPING OFF EMPLOYEES')"),
+			self.source.index("__('EMPLOYEES BOARDING')"),
+		)
+
+	def test_a_stop_where_nothing_happens_still_says_so(self):
+		self.assertIn("NOBODY BOARDS OR LEAVES", self.source)


### PR DESCRIPTION
Closes the feedback on **[WI-002401](https://one-fm.com/app/work-item/WI-002401)**. Every finding below was reproduced against the live plan before it was changed, and the numbers are measurements, not estimates.

## The headline: the seat check refused free seats

**One trip is one bus run.** A run that put its passengers down at 06:05 is empty when the 06:35 run boards. Every seat check instead pooled the occupancy of every run overlapping a **one-hour box built around the card's own shift window**:

```
Card TSHIP-TS-0488 — Night-1, 18:00→06:00, 1 employee, RETURN
  return_window_start = 06:00 → the old box was 06:00-07:00

  S-106  05:30-06:05   overlap  +5 min  → counted (+2)   ← its TAIL
  S-102  06:35-08:20   overlap +25 min  → counted (+5)   ← its HEAD
                                          pooled = 8 > 7 seats → REFUSED
```

Two sequential runs, 30 minutes apart, charged to one card. Worse, the comparison used **raw epochs** — and the DATE half of a lane stamp is the multi-day lock lifespan (TR-8), not the day the bus runs.

`_dayWindow` / `_sharesTheRoad` now mirror `_row_time_window` / `_trips_share_the_road` on the server, so the lane and the save cannot disagree about whether a run fits. `seatLoad` charges a load to the run it is **joining**, plus the runs genuinely sharing those hours. `mergedOccupancy` walks a cross-direction merge leg by leg, because a return rider boards the seat the outward load has just left.

The up-front gate in `handleDrop` is **gone**. No run is chosen at that point, so refusing there named runs that were never going to carry the card *and* pre-empted the Trip Builder — which is why a return card onto S-401 gave an error where the modal belonged. A card bigger than the whole bus is still split first; that is true of every run on the lane.

## One vehicle was vetoing the entire plan

A **no-change round-trip save** was refused:

> Capacity Exceeded: the outbound run on VHL-S-0001 carries 28 passengers but the vehicle takes 27.

`_vehicles_this_save_did_not_touch` keyed a placement on `stop_index`, which is **derived** — `_stamp_leg_details` renumbers every row of every vehicle off the itinerary while the canvas round-trips a logical 1..N. Every save re-lettered every card, so no bus was ever "untouched", and VHL-S-0001's 05:15 run (28 on 27 seats, the only real overload out of 106 runs) refused every edit anywhere on the plan.

| Save | Before | After |
|---|---|---|
| No change at all | ❌ refused | ✅ OK |
| Edit an unrelated bus | ❌ refused | ✅ OK |
| Add a stop to VHL-S-0001's bad run | ❌ | ❌ **still refused** |
| Genuinely overload another bus | ❌ | ❌ **still refused** |

## A card must tell the truth about itself

**250 of 376 generated Return cards carried another shift's people.** `_attach_return_rosters` substituted the roster of the shift finishing as this demand *starts*, but the card's window comes from its own `end_time` — so those riders were filed against an hour 12 hours from when they finish.

```
TS-1045  card=Foodhall khiran Mall-Day-1   collects 17:00 | riders on Night-1 (ends 05:00)
TS-0934  card=Foodhall khiran Mall-Night-1 collects 05:00 | riders on Day-1   (ends 17:00)
```

Collecting the outgoing crew on the incoming run is what a **Mixed trip is** — the dispatcher drops the other shift's Return card onto the run and the merge walks the legs. That machinery already exists; it can only read a run correctly if each card is honest about whose ride it is.

> [!IMPORTANT]
> **This reverses a deliberate earlier decision**, encoded in `test_attach_return_rosters_matches_finishing_shift`. My case: the two halves never agreed — riders picked by the previous shift's finish, window derived from this shift's end — so the card was internally inconsistent whichever intent you take, and a card called Day-1 serving Night-1 people is not readable. The coherent alternative is to keep the cross-shift model and derive the return window from `start_time`. **Please have the process owner pick before this merges.**

The same half-built concept **emptied the manifest**: `sync_manifest_details` read a `return_emp_map` that `get_route_planner_data` always set to `[]`, so *every return leg on every driver's manifest listed nobody* while its card carried the people. The two maps are now one.

## Midnight is a time

A Frappe `Time` of `00:00:00` is `timedelta(0)` — **falsy**. So `end_time or ... or "18:00:00"` read a shift finishing at midnight as one with no finish and handed the card the literal. **20 shipments on this site end at midnight and every one advertised 18:00**, including the 12:00→00:00 afternoon card in the ticket (AC9).

`time_is_blank()` asks whether a time was *stated*. **This trap applies to every Time field in the codebase — never use `or` or `if not` on one.**

## The board

| | |
|---|---|
| **AC1** | Existing-trips list showed outbound runs only, and repeated the camp once per card. A camp is the front or back of a run: `[...boardsAt, ...sites, ...deliversTo]`. Site repeats collapse only when *consecutive* — a lane really can call at one site twice (verified: Weatherford Stop 2 at 15:30 and 17:35). |
| **AC2/AC4** | A block spanned first→last **card**, an hour after the bus left, while the drawer header read the stated departure. |
| **AC3** | A Mixed run that lost its last cross-direction leg stayed green — and its **shipments** stayed Mixed, so it came back green on reload. A row's direction is written from its shipment, and the unmerge ran *after* the rows and only for cards already counted `Assigned` — never the ones needing repair. |
| **AC6** | No way to re-time a placed run. **Edit Trip Timings** reopens the Trip Builder. |
| **Trip names** | Two runs on 60/59220 both called S-106. Enforced on the Route Plan as a repair, not a refusal; `rename_duplicate_trip_names` patches history using the same method. |
| **Remove from Lane** | Always took stop 1, because clicking a merged block selects `primaryItem`. Stop rows are now clickable and the button names the stop. |
| **S-602's dead drawer** | A placed card is `Assigned` and so not a pool card, so re-saving blanked its saved names — and with nothing to build a card from, clicking the block did nothing. `load_assignments` backfills from the shipment, repairing the already-blanked rows without a patch. |
| **Handover stop** | `get_merge_preview` sent one collapsed count per stop, so the itinerary printed one movement's label against the other's count: "DROPPING OFF EMPLOYEES · 2" where 3 got off and 2 got on. |

### The regression I caught and fixed inside this PR

Fixing AC2/AC4 by reading `legTimings` drew **97 of 106 runs up to 35,000px wide on a 1,000px lane** — the plan load rebases every block onto today, and `legTimings` (the camp departure and home arrival, which no block carries) arrived raw. Measured by replaying the load pipeline:

```
A. raw leg timings — the bug        : 97 runs wider than the whole axis
B. rebased onto the run — fixed     : 0
C. before the AC2/AC4 change        : 15
```

So the board is now cleaner than before this work started. My first diagnosis of this was **wrong** — I compared raw items and concluded it was pre-existing; the replay is what caught it.

## Tests

**566 tests across 22 modules, all green** on this branch, including `test_mixed_trip_merge` (56) which covers the merge/unmerge machinery whose ordering this changes.

`test_seat_rule.js` reads the shipped helpers **out of the `.js` file** rather than copying them, so the canvas rule and the server rule cannot drift apart unnoticed. It is run from `one_fm.tests.test_transportation_seat_rule`, and I mutation-tested it (flipping `_sharesTheRoad` to always-true makes it fail).

Two failures in `test_manifest_mixed_ui` and `test_transportation_manifest` are **pre-existing** — verified by stashing against a clean `staging`.

## Deploy

```
bench build --app one_fm
bench migrate      # runs rename_duplicate_trip_names
bench clear-cache
```

Then hard-refresh the board, and run **Generate Shipments** to rewrite the 250 wrong pool cards. Placed (`Assigned`) cards are left untouched by design — and they were already correct.

## Not done, deliberately

Removing a stop from the middle of a run does not re-time the stops after it; the remaining blocks keep their own times. Say the word and I will wire it through `_retimeTrip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)