### PR TITLE
WI-002316: interview rounds are the recruiter's to fill, not the requester's

### DIFF
--- a/one_fm/one_fm/doctype/erf/erf.json
+++ b/one_fm/one_fm/doctype/erf/erf.json
@@ -678,7 +678,6 @@
    "fieldname": "interview_rounds",
    "fieldtype": "Table",
    "label": "Interview Rounds",
-   "mandatory_depends_on": "number_of_interview_rounds",
    "options": "ERF Interview Round"
   },
   {

--- a/one_fm/one_fm/doctype/erf/erf.py
+++ b/one_fm/one_fm/doctype/erf/erf.py
@@ -46,9 +46,6 @@ class ERF(Document):
 		self.validate_interview_rounds()
 
 	def validate_interview_rounds(self):
-		if self.number_of_interview_rounds and self.number_of_interview_rounds != len(self.interview_rounds):
-			frappe.throw(_("Number of rows of the 'Intreview Rounds' must be equal to 'Number of Interview Rounds'!"))
-
 		if self.hiring_method == 'Bulk Recruitment' and not self.number_of_interview_rounds:
 			frappe.throw(_("Minimum one intreview rounds must be added for bulk recruitment!"))
 


### PR DESCRIPTION
Follow-up to #6869. Raising a new ERF was impossible: **Interview Rounds is required** blocked the save, on a field the requester cannot fill.

## Why it blocked

`interview_rounds` lives in the **HR section**, filled by the recruiter after the ERF is open — not by the person raising it. But it carried `mandatory_depends_on: number_of_interview_rounds`, and picking `Bulk Recruitment` sets that count to `1` on the client ([erf.js:277](https://github.com/ONE-F-M/one_fm/blob/staging/one_fm/one_fm/doctype/erf/erf.js#L277)). So the mere choice of hiring method made an out-of-reach table mandatory.

Removing the `mandatory_depends_on` alone just moved the wall: the save then reached `validate_interview_rounds` and threw *"Number of rows of the 'Intreview Rounds' must be equal to 'Number of Interview Rounds'!"* — 1 declared round against 0 rows, the same auto-set count, one step later in the save. Both are gone.

| | |
|---|---|
| `erf.json` | `interview_rounds` loses `mandatory_depends_on` |
| `erf.py` | `validate_interview_rounds` loses the row-count check |

## Left alone

The auto-set in `erf.js` and the `Minimum one intreview rounds must be added for bulk recruitment!` throw stay. That throw cannot fire from the form — the client sets the count to 1 before the save — and it still catches an ERF built server-side or by import with `Bulk Recruitment` and no rounds. Removing the count check is what makes the pair harmless: the count is a target for the recruiter, no longer a gate on the requester.

## Migration

`bench migrate` — doctype change only, no data touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)