### PR TITLE
WI-002184: settle a retired rule's assignments whether or not the rule survived

### DIFF
--- a/one_fm/patches/v15_0/route_client_event_to_project_manager.py
+++ b/one_fm/patches/v15_0/route_client_event_to_project_manager.py
@@ -73,11 +73,14 @@ def retire_superseded_rules():
 	Deleting a rule does not close what it assigned, and a surviving rule will not do it
 	either: apply_unassign only closes the ToDos its own rule created. So an open one is
 	dealt with here or never - it sits on somebody's to-do list for good.
+
+	The settling is not conditional on the rule surviving. Both of these were already
+	deleted, bare, by add_assignment_rule_returning_to_operations_supervisor_of_client_event
+	and add_assignment_rule_assigning_operations_manager_for_approval_client_event - which
+	is why there are open assignments to settle at all. A rule that is gone is the reason
+	to settle its ToDos, not a reason to skip them.
 	"""
 	for rule_name in SUPERSEDED_RULES:
-		if not frappe.db.exists("Assignment Rule", rule_name):
-			continue
-
 		for todo in frappe.get_all(
 			"ToDo",
 			filters={"assignment_rule": rule_name, "status": "Open"},
@@ -96,7 +99,8 @@ def retire_superseded_rules():
 				# was not, because the state it was waiting for never existed.
 				frappe.db.set_value("ToDo", todo.name, "status", "Cancelled", update_modified=False)
 
-		frappe.delete_doc("Assignment Rule", rule_name, ignore_permissions=True, force=True)
+		if frappe.db.exists("Assignment Rule", rule_name):
+			frappe.delete_doc("Assignment Rule", rule_name, ignore_permissions=True, force=True)
 
 
 def ensure_workflow_state():
@@ -180,15 +184,22 @@ def verify():
 			"the event rather than their own - the Draft assignment closes as soon as it opens."
 		)
 
-	stranded = frappe.db.sql(
-		"""SELECT COUNT(*) FROM `tabToDo`
-		   WHERE status = 'Open' AND assignment_rule IS NOT NULL
-		     AND assignment_rule NOT IN (SELECT name FROM `tabAssignment Rule`)
-		     AND reference_type = 'Client Event'""")[0][0]
+	# Scoped to the rules this patch retires. Asked of every dead rule name on Client Event
+	# instead, one orphan from some unrelated history blocks bench migrate for the whole
+	# site on a check the patch holds no repair for.
+	stranded = frappe.get_all(
+		"ToDo",
+		filters={
+			"reference_type": "Client Event",
+			"status": "Open",
+			"assignment_rule": ["in", SUPERSEDED_RULES],
+		},
+		pluck="name",
+	)
 	if stranded:
 		frappe.throw(
-			f"WI-002184: {stranded} open Client Event assignment(s) point at a rule that no "
-			"longer exists, so nothing will ever release them."
+			f"WI-002184: {len(stranded)} open Client Event assignment(s) still point at a "
+			"retired rule, so nothing will ever release them."
 		)
 
 	print(f"WI-002184: Client Event routes to {NEW_STATE} when the event has a project")


### PR DESCRIPTION
Follow-up to #6852. That patch cannot satisfy its own closing assertion on any site that has already migrated, so `bench migrate` on staging dies on it — and on every patch queued behind it:

```
ValidationError: WI-002184: 7 open Client Event assignment(s) point at a rule
that no longer exists, so nothing will ever release them.
```

## The mismatch

`retire_superseded_rules` was gated on the Assignment Rule record still existing, and `continue`d past the entire body when it wasn't — the settling included:

```python
for rule_name in SUPERSEDED_RULES:
    if not frappe.db.exists("Assignment Rule", rule_name):
        continue          # skips the settle, not just the delete
```

`verify` then asserted on the **ToDos**. So once the rule was gone, the loop skipped exactly the rows the check refused to accept, and the only repair path sat behind a guard that could never be true again. Re-running could not help, which is why bumping the marker `b` → `c` changed nothing.

## It was already never true

Both rules were deleted bare, with nothing to close what they had assigned:

- [`add_assignment_rule_returning_to_operations_supervisor_of_client_event.py:5-6`](https://github.com/ONE-F-M/one_fm/blob/staging/one_fm/patches/v15_0/add_assignment_rule_returning_to_operations_supervisor_of_client_event.py#L5)
- [`add_assignment_rule_assigning_operations_manager_for_approval_client_event.py:5-6`](https://github.com/ONE-F-M/one_fm/blob/staging/one_fm/patches/v15_0/add_assignment_rule_assigning_operations_manager_for_approval_client_event.py#L5)

Both are logged **2026-04-13 07:24**, months before this patch was written. That is where the stranded assignments come from. `retire_superseded_rules` has therefore never once run its body on any site — mine included; the run that "passed" here passed only because nothing happened to be `Open` on this copy at the time.

A rule that is gone is the reason to settle its ToDos, not a reason to skip them. The settling now runs unconditionally; only the delete is guarded.

## The check

Scoped to the two rules this patch retires. Asked of every dead rule name on Client Event, one orphan from unrelated history blocks migrate for the whole site on a hygiene assertion this patch holds no repair for. Now `frappe.get_all` rather than raw SQL.

## Rehearsed against live data

In a transaction, both branches, rolled back:

| | |
|---|---|
| both rules absent on this site | confirms the old guard was skipping, not deleting |
| 7 open orphans on events past `Draft` (`Approved`, `Pending Approval`) | → `Cancelled` |
| 1 open orphan on an event still in `Draft` | → handed to `Client Event - Draft`, stays `Open`, released on submit |
| `execute()` | runs to the end |

## No new patch marker

Frappe records a failed patch with `skipped=1`, and `run_all` builds its executed set from `skipped=0` rows only — so staging retries this same entry on the next migrate without a bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)