### PR TITLE
WI-002179: take the row out of the document, not out of the list

### DIFF
--- a/one_fm/grd/doctype/preparation/test_hr_costing_numbering.py
+++ b/one_fm/grd/doctype/preparation/test_hr_costing_numbering.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002179: collapsing the three master fee rows must not leave a hole in the numbering.
+
+Add Row numbers a new row by the table's length, not by its highest idx - create_new.js
+client side, _init_child server side. So a gap in the middle is not cosmetic: the next row
+HR adds carries an idx a row already has, and the table's order stops being decidable.
+
+The whole thing is one test method on purpose. FrappeTestCase rolls back on
+addClassCleanup, so anything a method changes is still there for the next one.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.patches.v15_0.consolidate_extension_actions import COSTING_PARENT, execute
+
+# total_amount is derived from the components on save, so the fee goes in as a component.
+MASTER_ROWS = (
+	(3, "Extend 1 month", 30),
+	(4, "Extend 2 months", 60),
+	(5, "Extend 3 months", 90),
+)
+
+
+def costing_rows():
+	return frappe.get_all(
+		"GRD Renewal Extension Cost",
+		filters=COSTING_PARENT,
+		fields=["name", "idx", "renewal_or_extend", "total_amount"],
+		order_by="idx asc, creation asc",
+	)
+
+
+class TestHrCostingNumbering(FrappeTestCase):
+	def test_the_collapse_leaves_the_table_numbered_one_to_n(self):
+		# A site that has not run the patch: the three master rows still sit at 3, 4, 5.
+		frappe.db.delete(
+			"GRD Renewal Extension Cost", dict(COSTING_PARENT, renewal_or_extend="Extension")
+		)
+		frappe.db.bulk_insert(
+			"GRD Renewal Extension Cost",
+			fields=[
+				"name", "parent", "parenttype", "parentfield",
+				"idx", "renewal_or_extend", "work_permit_amount",
+			],
+			values=[
+				[
+					f"wi2179test{position}", "HR Settings", "HR Settings",
+					"renewal_extension_cost", idx, action, amount,
+				]
+				for position, (idx, action, amount) in enumerate(MASTER_ROWS)
+			],
+		)
+		frappe.clear_cache(doctype="HR Settings")
+
+		execute()
+
+		rows = costing_rows()
+		self.assertEqual(
+			[row.idx for row in rows], list(range(1, len(rows) + 1)),
+			"the collapse left a hole - list.remove was used where Document.remove renumbers",
+		)
+
+		extension_rows = [row for row in rows if row.renewal_or_extend == "Extension"]
+		self.assertEqual(len(extension_rows), 1, "the three master rows did not become one")
+		self.assertEqual(
+			extension_rows[0].total_amount, 30,
+			"the kept row must be the one that states the monthly rate",
+		)
+
+		# And a site that already ran the old version, carrying the hole it left: the patch
+		# has to close it on the way through, not only avoid making a new one.
+		frappe.db.set_value(
+			"GRD Renewal Extension Cost", rows[-1].name, "idx", 9, update_modified=False
+		)
+		frappe.clear_cache(doctype="HR Settings")
+
+		execute()
+
+		rows = costing_rows()
+		self.assertEqual(
+			[row.idx for row in rows], list(range(1, len(rows) + 1)),
+			"a hole left by an earlier run was not repaired",
+		)

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -607,7 +607,7 @@ one_fm.patches.v15_0.add_dsot_approval_workflow #2026-09-04 WI-002283
 one_fm.patches.v15_0.route_client_event_to_project_manager #2026-09-06c WI-002184
 one_fm.patches.v15_0.update_action_paci_assignment_rule #2026-09-05d WI-002183
 one_fm.patches.v15_0.rename_renewal_expat_and_hr_costing #2026-09-02 WI-002178
-one_fm.patches.v15_0.consolidate_extension_actions #2026-09-02 WI-002179
+one_fm.patches.v15_0.consolidate_extension_actions #2026-09-08 WI-002179
 one_fm.patches.v15_0.update_work_permit_assignment_rules #2026-09-02 WI-002182
 one_fm.patches.v15_0.drop_erf_field_order_property_setter #2026-09-06b WI-002316
 one_fm.patches.v15_0.retire_unplanned_erf_reason #2026-09-06 WI-002316

--- a/one_fm/patches/v15_0/consolidate_extension_actions.py
+++ b/one_fm/patches/v15_0/consolidate_extension_actions.py
@@ -32,6 +32,7 @@ def execute():
 
 	moved = move_preparation_rows()
 	kept = collapse_master_rows()
+	renumber_costing_rows()
 
 	verify(moved, kept)
 
@@ -75,7 +76,10 @@ def collapse_master_rows():
 
 	keeper.renewal_or_extend = EXTENSION
 	for row in extend_rows[1:]:
-		settings.renewal_extension_cost.remove(row)
+		# Document.remove, not the list's: the list's takes the row out and leaves every
+		# survivor's idx where it was. Nothing else renumbers - a save keeps the idx each
+		# row already carries, and _init_child only numbers a row that has none.
+		settings.remove(row)
 
 	settings.flags.ignore_mandatory = True
 	settings.flags.ignore_permissions = True
@@ -83,6 +87,36 @@ def collapse_master_rows():
 	frappe.clear_cache(doctype="HR Settings")
 
 	return keeper.total_amount
+
+
+def costing_rows():
+	return frappe.get_all(
+		"GRD Renewal Extension Cost",
+		filters=COSTING_PARENT,
+		fields=["name", "idx"],
+		order_by="idx asc, creation asc",
+	)
+
+
+def renumber_costing_rows():
+	"""Close the gap this patch left on the sites it has already run on.
+
+	It cannot live in collapse_master_rows: that returns early once the extend rows are
+	gone, so on a re-run it would never be reached. Add Row numbers a new row by the
+	table's length rather than by its highest idx (create_new.js, and _init_child server
+	side), so a gap in the middle means the next row HR adds collides with an existing one
+	and the table's order stops being decidable.
+	"""
+	renumbered = False
+	for position, row in enumerate(costing_rows(), start=1):
+		if row.idx != position:
+			frappe.db.set_value(
+				"GRD Renewal Extension Cost", row.name, "idx", position, update_modified=False
+			)
+			renumbered = True
+
+	if renumbered:
+		frappe.clear_cache(doctype="HR Settings")
 
 
 def verify(moved, kept):
@@ -100,4 +134,15 @@ def verify(moved, kept):
 					"next save."
 				)
 
-	print(f"WI-002179: moved {moved} Preparation rows to {EXTENSION!r}; master row total {kept}")
+	numbering = [row.idx for row in costing_rows()]
+	if numbering != list(range(1, len(numbering) + 1)):
+		frappe.throw(
+			f"WI-002179: HR Costing is numbered {numbering}, not 1 to {len(numbering)} - "
+			"Add Row numbers a new row by count, so a gap makes it collide with a row that "
+			"is already there."
+		)
+
+	print(
+		f"WI-002179: moved {moved} Preparation rows to {EXTENSION!r}; master row total "
+		f"{kept if kept is not None else 'already collapsed'}"
+	)


### PR DESCRIPTION
HR Costing is numbered **1, 2, 3, 6, 7**, and Add Row then offers a second **6**. Reported from the form; traced to WI-002179 (#6835's `consolidate_extension_actions`), whose save is stamped on those rows to the millisecond.

## Cause

[`consolidate_extension_actions.py:78`](https://github.com/ONE-F-M/one_fm/blob/staging/one_fm/patches/v15_0/consolidate_extension_actions.py#L78) dropped the two surplus master fee rows with the **list's** `remove`, not the **document's**:

```python
settings.renewal_extension_cost.remove(row)
```

`Document.remove` is the one that renumbers what is left:

```python
def remove(self, doc):
    if doc.get("parentfield"):
        self.get(doc.parentfield).remove(doc)
        for i, _d in enumerate(self.get(doc.parentfield)):
            _d.idx = i + 1          # skipped entirely by list.remove
```

Nothing else does it: a save writes back whatever idx each row already carries, and `_init_child` only numbers a row that has none. The rows at 4 and 5 went; 6 and 7 stayed where they were.

## Why it matters

Add Row numbers a new row by the table's **length**, not by its highest idx — `create_new.js` client side, `_init_child` server side. With five rows the next one is 6, which Cancellation already holds, so two rows share an idx and the table's order stops being decidable. Every row HR adds from here collides.

## Fix, both ways round

| | |
|---|---|
| `settings.remove(row)` | stops the collapse creating the hole on sites that have not run it yet |
| `renumber_costing_rows()` | closes the hole on sites that already have |
| `verify()` | refuses to finish on a gap |
| marker `#2026-09-02` → `#2026-09-08` | so staging and production run it again |

The renumber step cannot live inside `collapse_master_rows`: that returns early once the extend rows are gone, so on a re-run it would never be reached.

## Test

`test_hr_costing_numbering.py` replays both situations — a site with the three master rows still at 3, 4, 5, and a site carrying the hole an earlier run left. **Checked against the unfixed patch**, where it reports the live numbering exactly:

```
- [1, 2, 3, 6, 7]
+ [1, 2, 3, 4, 5]
 : the collapse left a hole - list.remove was used where Document.remove renumbers
```

Green with the fix; `test_action_fee_master` (12 tests) still green; the live table is untouched by the run.

One test method by design — `FrappeTestCase` rolls back on `addClassCleanup`, so what one method changes is still there for the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)