### PR TITLE
WI-002401: the order the operator puts a run in is the order everyone reads

### DIFF
--- a/one_fm/one_fm/doctype/transportation_shipment/transportation_shipment.py
+++ b/one_fm/one_fm/doctype/transportation_shipment/transportation_shipment.py
@@ -324,6 +324,28 @@ def arrival_order(shipment):
 	return (arrival is None, arrival or 0, boards, shipment.name)
 
 
+def run_order(shipment, placed=None):
+	"""Sort key placing a run's cards in the order the OPERATOR has them.
+
+	A run's order used to be re-derived from each card's own shift times
+	(`arrival_order`) by every reader. That kept the trip modal and the save in step, but
+	it made the drawer's drag-to-reorder cosmetic: the operator moved a stop, its block
+	moved with it, and then the modal, the itinerary, the leg walk and the manifest all
+	put the run back into shift order (WI-002401).
+
+	`placed` is the second of the day the block actually sits at on the lane - the time
+	the operator has the bus at that stop - and it wins when there is one. Callers pass
+	it from the plan row the card is on, using whichever ISO parser they already have; a
+	card with no placement falls back to `arrival_order`, so a run nobody has ordered by
+	hand still reads sensibly.
+
+	The tie-breaks stay `arrival_order`'s, so two stops the operator has at the same
+	minute are still served drop-off first - the seats one load vacates are what the next
+	load boards into.
+	"""
+	return (placed is None, placed or 0) + arrival_order(shipment)
+
+
 @frappe.whitelist()
 def merge_trip_shipments(shipments) -> dict:
 	"""Merge two or more cards into a single Mixed trip (WI-002071).
@@ -350,7 +372,9 @@ def merge_trip_shipments(shipments) -> dict:
 	for doc in docs:
 		doc.check_permission("write")
 
-	docs.sort(key=arrival_order)
+	# In the order the caller listed them. The canvas sends the run as the operator has
+	# it in the drawer, so re-sorting here on the cards' own shift times threw away a
+	# drag-to-reorder the moment it was confirmed (WI-002401).
 	trip_group = merge_key([doc.name for doc in docs])
 	direction = run_direction(docs)
 
@@ -608,7 +632,9 @@ def get_merge_preview(shipments, vehicle: str = None, timings=None, departure=No
 	docs = [frappe.get_doc("Transportation Shipment", name) for name in names]
 	for doc in docs:
 		doc.check_permission("read")
-	docs.sort(key=arrival_order)
+	# In the order the caller listed them - see merge_trip_shipments. The preview and the
+	# merge have to build the same run out of the same cards, so both honour the order
+	# rather than re-deriving one.
 
 	limit = (
 		frappe.db.get_value("Vehicle", vehicle, "custom_max_passenger_capacity") if vehicle else None

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
@@ -348,9 +348,7 @@ function mountRoutePlannerApp(wrapper, data) {
 
                     // Build merged blocks for each trip group
                     Object.keys(tripGroups).forEach(tripId => {
-                        const stops = tripGroups[tripId].sort(
-                            (a, b) => (a.stopIndex || 0) - (b.stopIndex || 0)
-                        );
+                        const stops = this._inRunOrder(tripGroups[tripId]);
                         const firstItem = stops[0];
                         const totalHC = stops.reduce((sum, s) => sum + (s.headcount || 0), 0);
                         // The run's extent, over ALL its stops rather than the first and
@@ -517,14 +515,10 @@ function mountRoutePlannerApp(wrapper, data) {
                 if (!this.selectedItem || !this.selectedItem.tripId) return [];
                 const tripId = this.selectedItem.tripId;
                 const self = this;
-                return this.swimItems
-                    .filter(i => i.tripId === tripId)
-                    // In the order the bus drives it. stopIndex is the order the cards
-                    // were dropped on the lane, which is not the order of the run: a card
-                    // added first can be the last stop. Sorting by it listed a 07:32 stop
-                    // above a 07:20 one and made the trip timeline read 07:32 to 07:32.
-                    .sort((a, b) => (new Date(a.start) - new Date(b.start))
-                        || (a.stopIndex || 0) - (b.stopIndex || 0))
+                // In the order the bus drives it - one definition, shared with the Trip
+                // Builder and the seat walk so the drawer cannot list a run in an order
+                // the rest of the board disagrees with.
+                return this._inRunOrder(this.swimItems.filter(i => i.tripId === tripId))
                     .map((item, idx) => {
                         let card = self.planData.shipment_cards.find(c => c.id === item.cardId);
                         if (!card && (item._site || item._shift || item._accommodation || item._stopLocation)) {
@@ -1266,7 +1260,11 @@ function mountRoutePlannerApp(wrapper, data) {
             },
 
             _mergeShipmentIds(newCard, existingItems) {
-                const ids = existingItems.map(i => i.cardId).filter(Boolean);
+                // In the order the operator has the run, which is the order the drawer
+                // lists it in and the order the server now honours rather than
+                // re-deriving from the cards' shift times (WI-002401). A card dragged to
+                // the middle of the run reaches the Trip Builder in the middle of it.
+                const ids = this._inRunOrder(existingItems).map(i => i.cardId).filter(Boolean);
                 // No new card when the modal is opened to edit a run already on the lane
                 // (AC6): the run is re-timed, not merged with anything.
                 if (newCard) ids.push(newCard.id);
@@ -1709,6 +1707,17 @@ function mountRoutePlannerApp(wrapper, data) {
                 });
             },
 
+            // The order the operator has a run in: where each block sits on the lane,
+            // which is what drag-to-reorder in the drawer rewrites. stopIndex only
+            // breaks ties - it is the PHYSICAL stop number the server stamps from the
+            // itinerary, camp stops included, so it cannot lead.
+            _inRunOrder(items) {
+                return [...(items || [])].sort(
+                    (a, b) => (new Date(a.start) - new Date(b.start))
+                        || (a.stopIndex || 0) - (b.stopIndex || 0)
+                );
+            },
+
             // Reopen the Trip Builder on a run already on the lane (AC6), so its
             // departure and per-leg minutes can be changed without taking the run apart
             // and dropping it again. Nothing is merged in: the same modal is the run's
@@ -1720,10 +1729,9 @@ function mountRoutePlannerApp(wrapper, data) {
             editSelectedTrip() {
                 const item = this.selectedItem;
                 if (!item || !item.tripId) return;
-                const stops = this.swimItems
-                    .filter(i => i.tripId === item.tripId)
-                    .sort((a, b) => (new Date(a.start) - new Date(b.start))
-                        || (a.stopIndex || 0) - (b.stopIndex || 0));
+                const stops = this._inRunOrder(
+                    this.swimItems.filter(i => i.tripId === item.tripId)
+                );
                 // A run of one stop has nothing to sequence, and the merge endpoint needs
                 // two cards to name a run; use Merge into Trip to give it a second stop.
                 if (stops.length < 2) {
@@ -1822,9 +1830,12 @@ function mountRoutePlannerApp(wrapper, data) {
             },
 
             _retimeTrip(tripId) {
-                const stops = this.swimItems
-                    .filter((i) => i.tripId === tripId)
-                    .sort((a, b) => (a.stopIndex || 0) - (b.stopIndex || 0));
+                // In the order the operator has the run: re-timing lays each stop out
+                // after the one before it, so walking it in stopIndex order would undo a
+                // drag-to-reorder the moment any leg was re-timed (WI-002401).
+                const stops = this._inRunOrder(
+                    this.swimItems.filter((i) => i.tripId === tripId)
+                );
                 if (!stops.length) return;
 
                 const MIN_BLOCK_MS = 5 * 60000;     // a block thinner than this is unclickable
@@ -2189,7 +2200,11 @@ function mountRoutePlannerApp(wrapper, data) {
             tripOccupancy(trip) {
                 if (trip.direction !== 'MIXED') return trip.headcount;
 
-                const stops = [...trip.stops].sort((a, b) => (a.stopIndex || 0) - (b.stopIndex || 0));
+                // The order the operator has the run in, the same one the server walks.
+                // Sorting on stopIndex alone read the physical stop number the save
+                // stamps from the itinerary, so a reordered run was walked in its old
+                // order and the lane and the save could reach different peaks.
+                const stops = this._inRunOrder(trip.stops);
                 const boards = (item) => this.cardOwnDirection(item) === 'RETURN';
 
                 // Everyone the trip carries out of the camp is aboard before stop 1.
@@ -2925,10 +2940,13 @@ function mountRoutePlannerApp(wrapper, data) {
                 const tripId = this.selectedItem.tripId;
                 if (!tripId) return;
 
-                // Get trip stops sorted by current stopIndex
-                const tripStops = this.swimItems
-                    .filter(i => i.tripId === tripId)
-                    .sort((a, b) => (a.stopIndex || 0) - (b.stopIndex || 0));
+                // The same order the drawer lists, because sourceIndex and targetIndex
+                // are positions in THAT list. Sorting differently here mapped the drag
+                // onto whichever stop happened to hold that stopIndex, so a reorder could
+                // move a stop the operator was not dragging (WI-002401).
+                const tripStops = this._inRunOrder(
+                    this.swimItems.filter(i => i.tripId === tripId)
+                );
 
                 if (sourceIndex >= tripStops.length || targetIndex >= tripStops.length) return;
 
@@ -3823,8 +3841,8 @@ function mountRoutePlannerApp(wrapper, data) {
                 });
 
                 const connectors = [];
-                Object.entries(trips).forEach(([tripId, stops]) => {
-                    stops.sort((a, b) => (a.stopIndex || 0) - (b.stopIndex || 0));
+                Object.entries(trips).forEach(([tripId, unordered]) => {
+                    const stops = this._inRunOrder(unordered);
                     for (let i = 0; i < stops.length - 1; i++) {
                         const a = stops[i], b = stops[i + 1];
                         const aEnd = this.bx(a) + this.bw(a);

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -2528,9 +2528,9 @@ def _stamp_leg_details(doc, leg_timings=None):
 	"""
 	from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
 		CAMP_STOP,
-		arrival_order,
 		build_itinerary,
 		own_direction,
+		run_order,
 		walk_occupancy,
 	)
 
@@ -2566,9 +2566,14 @@ def _stamp_leg_details(doc, leg_timings=None):
 		group_key = _group if not _group.startswith("\0") else run[0].card_id
 		cards = _cards_for_itinerary(run)
 		by_name = {card.name: card for card in cards}
+		# In the order the operator has the run on the lane, not the order the cards'
+		# own shift times imply. Re-deriving it here put a stop dragged in the drawer
+		# straight back where it started, on the very next save (WI-002401).
 		ordered = sorted(
 			[row for row in run if row.transportation_shipment in by_name],
-			key=lambda row: arrival_order(by_name[row.transportation_shipment]),
+			key=lambda row: run_order(
+				by_name[row.transportation_shipment], _local_seconds(row.start_time)
+			),
 		)
 		if not ordered:
 			continue

--- a/one_fm/operations/doctype/route_plan/route_plan.py
+++ b/one_fm/operations/doctype/route_plan/route_plan.py
@@ -873,7 +873,10 @@ def _cards_for_itinerary(rows) -> list:
 		fact = facts.get(row.transportation_shipment)
 		if not fact:
 			continue
-		cards.append(frappe._dict({
+		# Where the operator has this block on the lane, which is the order they have
+		# stated for the run. Carried alongside the card rather than on it: the card is
+		# the shipment's own facts and nothing downstream should read a plan detail off it.
+		cards.append((_iso_time_of_day(row.start_time), frappe._dict({
 			"name": fact.name,
 			"accommodation": fact.accommodation,
 			"accommodation_name": fact.accommodation_name,
@@ -883,18 +886,21 @@ def _cards_for_itinerary(rows) -> list:
 			"pre_merge_trip_direction": fact.pre_merge_trip_direction,
 			"start_time": fact.start_time,
 			"end_time": fact.end_time,
-		}))
+		})))
 
-	# Ordered the way the bus reaches them, which is how the trip modal orders the same
-	# cards. Sorting on the stored stop_index instead let the two build different runs
-	# out of the same cards and reach different peaks - the modal would accept a merge
-	# the save then refused.
+	# In the order the operator has the run, which is how the trip modal and the drawer
+	# order the same cards. This used to re-derive the order from each card's own shift
+	# times so that the modal and the save could not disagree; they still cannot, but
+	# both now read the stated order instead of rebuilding one, so a stop dragged in the
+	# drawer stays where it was put (WI-002401). Sorting on the stored stop_index is
+	# still wrong - that is the PHYSICAL stop number, camp stops included, rewritten
+	# from the itinerary on every save.
 	from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
-		arrival_order,
+		run_order,
 	)
 
-	cards.sort(key=arrival_order)
-	return cards
+	cards.sort(key=lambda pair: run_order(pair[1], pair[0]))
+	return [card for _placed, card in cards]
 
 
 def _iso_to_date(value):

--- a/one_fm/tests/test_mixed_trip_merge.py
+++ b/one_fm/tests/test_mixed_trip_merge.py
@@ -468,6 +468,9 @@ class TestAMergeCanBeUndone(FrappeTestCase):
 		)
 		if not name:
 			self.skipTest("No unmerged Transportation Shipment on this site")
+		before = frappe.db.get_value(
+			"Transportation Shipment", name, ["trip_direction", "trip_group"], as_dict=True
+		)
 
 		frappe.db.set_value("Transportation Shipment", name, {
 			"trip_direction": MIXED, "trip_group": "MIX-test", "pre_merge_trip_direction": "Return",
@@ -480,6 +483,16 @@ class TestAMergeCanBeUndone(FrappeTestCase):
 		self.assertEqual(
 			frappe.db.get_value("Transportation Shipment", name, "trip_direction"), "Return"
 		)
+
+		# Put the card back. This walks over a real shipment, picked arbitrarily, and the
+		# rollback here is per class - so leaving it as "Return" handed the later
+		# generation-key assertion a card whose key says "|Outward", and which card that
+		# was changed with the table. Its sibling above already restores; this one did not.
+		frappe.db.set_value("Transportation Shipment", name, {
+			"trip_direction": before.trip_direction,
+			"trip_group": before.trip_group,
+			"pre_merge_trip_direction": None,
+		}, update_modified=False)
 
 	def test_rolling_back_a_merge_that_never_happened_changes_nothing(self):
 		from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
@@ -532,3 +545,112 @@ class TestAMergeCanBeUndone(FrappeTestCase):
 					frappe.db.count("Route Plan Assignment", {"transportation_shipment": row.name}),
 					f"{row.name} is Mixed but on no Route Plan",
 				)
+
+
+class TestTheOperatorOwnsTheRunOrder(FrappeTestCase):
+	"""Drag-to-reorder in the drawer used to be cosmetic (WI-002401).
+
+	Every reader re-derived a run's order from each card's own shift times
+	(`arrival_order`): the trip modal, the merge, the itinerary the save stamps, the
+	leg walk and the manifest. That kept them in step with each other, but it meant the
+	operator could move a stop, watch its block move with it, and then find the Trip
+	Builder, the legs table and the driver's manifest all putting the run back into
+	shift order. They still cannot disagree - they now all read the STATED order.
+	"""
+
+	def test_a_placed_card_sorts_by_where_the_operator_put_it(self):
+		from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
+			arrival_order,
+			run_order,
+		)
+
+		# Two cards whose shift times say A then B ...
+		a = frappe._dict({"name": "TS-A", "start_time": "06:00:00", "end_time": "18:00:00",
+						  "trip_direction": "Outward", "pre_merge_trip_direction": None})
+		b = frappe._dict({"name": "TS-B", "start_time": "07:00:00", "end_time": "19:00:00",
+						  "trip_direction": "Outward", "pre_merge_trip_direction": None})
+		self.assertEqual([c.name for c in sorted([b, a], key=arrival_order)], ["TS-A", "TS-B"])
+
+		# ... but the operator has B's block on the lane first.
+		placed = {"TS-A": 8 * 3600, "TS-B": 6 * 3600}
+		self.assertEqual(
+			[c.name for c in sorted([a, b], key=lambda c: run_order(c, placed[c.name]))],
+			["TS-B", "TS-A"],
+		)
+
+	def test_a_card_with_no_placement_falls_back_to_the_shift_times(self):
+		from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
+			arrival_order,
+			run_order,
+		)
+
+		card = frappe._dict({"name": "TS-A", "start_time": "06:00:00", "end_time": "18:00:00",
+							 "trip_direction": "Outward", "pre_merge_trip_direction": None})
+		# The key still ends with arrival_order's, so a run nobody has ordered by hand
+		# reads exactly as it did.
+		self.assertEqual(run_order(card)[2:], arrival_order(card))
+
+	def test_a_placed_card_always_sorts_before_an_unplaced_one(self):
+		from one_fm.one_fm.doctype.transportation_shipment.transportation_shipment import (
+			run_order,
+		)
+
+		card = frappe._dict({"name": "TS-A", "start_time": "06:00:00", "end_time": "18:00:00",
+							 "trip_direction": "Outward", "pre_merge_trip_direction": None})
+		self.assertLess(run_order(card, 3600), run_order(card))
+
+	def test_the_two_endpoints_honour_the_order_they_are_given(self):
+		import inspect
+
+		from one_fm.one_fm.doctype.transportation_shipment import transportation_shipment
+
+		for fn in (transportation_shipment.get_merge_preview,
+				   transportation_shipment.merge_trip_shipments):
+			source = inspect.getsource(fn)
+			self.assertNotIn("docs.sort(key=arrival_order)", source)
+			self.assertIn("order the caller listed them", source)
+
+	def test_the_save_reads_the_stated_order_too(self):
+		# The modal and the save must build the same run out of the same cards, or the
+		# modal accepts a merge the save then refuses.
+		import inspect
+
+		from one_fm.one_fm.page.transportation_schedule import transportation_schedule
+		from one_fm.operations.doctype.route_plan import route_plan
+
+		self.assertIn("cards.sort(key=lambda pair: run_order(pair[1], pair[0]))",
+					  inspect.getsource(route_plan._cards_for_itinerary))
+		self.assertIn("_local_seconds(row.start_time)",
+					  inspect.getsource(transportation_schedule._stamp_leg_details))
+
+	def test_the_canvas_sends_and_walks_one_order(self):
+		import pathlib
+
+		canvas = pathlib.Path(frappe.get_app_path(
+			"one_fm", "one_fm", "page", "transportation_schedule",
+			"transportation_schedule.js")).read_text()
+		self.assertIn("_inRunOrder(items) {", canvas)
+		# The modal is opened with it, the drawer lists with it, and the seat walk
+		# follows it - one definition, so no reader can disagree with another.
+		self.assertIn("this._inRunOrder(existingItems).map(i => i.cardId)", canvas)
+		self.assertIn("const stops = this._inRunOrder(trip.stops);", canvas)
+		self.assertIn(
+			"return this._inRunOrder(this.swimItems.filter(i => i.tripId === tripId))",
+			canvas,
+		)
+		# Everything that reads a run's order goes through it: the block's own stop
+		# labels, the re-time walk, and the drag whose indices are positions in the
+		# drawer's list - sorting differently there moved a stop nobody was dragging.
+		for site in ("const stops = this._inRunOrder(tripGroups[tripId]);",
+					 "this.swimItems.filter((i) => i.tripId === tripId)",
+					 "const tripStops = this._inRunOrder(",
+					 "const stops = this._inRunOrder(unordered);"):
+			self.assertIn(site, canvas)
+		# Only two bare stopIndex comparators are left: the tie-break inside
+		# _inRunOrder itself, and the cross-trip lane sort, which orders unrelated runs
+		# against each other and is a different question.
+		self.assertEqual(canvas.count("(a.stopIndex || 0) - (b.stopIndex || 0)"), 2)
+		# stopIndex only ever breaks a tie: it is the physical stop number the save
+		# stamps from the itinerary, camp stops included.
+		self.assertNotIn("const stops = [...trip.stops].sort((a, b) => (a.stopIndex || 0)",
+						 canvas)

--- a/one_fm/tests/test_the_lane_lays_out_the_run.py
+++ b/one_fm/tests/test_the_lane_lays_out_the_run.py
@@ -22,10 +22,10 @@ CANVAS = pathlib.Path(frappe.get_app_path(
 MINUTE = 60000
 
 
-def _method(name):
+def _method(name, args="tripId"):
 	"""The named method's source, by counting braces from its opening one."""
 	source = CANVAS.read_text()
-	start = source.index(f"{name}(tripId) {{")
+	start = source.index(f"{name}({args}) {{")
 	depth, i = 0, source.index("{", start)
 	while True:
 		if source[i] == "{":
@@ -46,6 +46,9 @@ def retime(items, leg_timings=None, own=None):
 		swimItems: {json.dumps(items)},
 		legTimings: {json.dumps(leg_timings or {})},
 		_ownDirection: (item) => ({json.dumps(own or {})})[item.cardId] || 'OUTBOUND',
+		// The real one, not a stub: _retimeTrip lays each stop out after the one before
+		// it, so which order it walks is part of what these tests are checking.
+		_inRunOrder: function (items) {_method('_inRunOrder', 'items')},
 	}};
 	canvas.swimItems.forEach((i) => {{ i.start = new Date(i.start); i.end = new Date(i.end); }});
 	retime.call(canvas, 'T1');


### PR DESCRIPTION
Follow-up to **#6876** (merged), on the same work item. Reported while testing: *"There should be synchronization between the itinerary sequence and table on trip builder and the shipment details drawer."*

## Drag-to-reorder was cosmetic

`onStopDrop` does its job — it renumbers `stopIndex` and rewrites each block's times, so the blocks move and the drawer shows the new order. **Every other reader then put the run back into shift order**, because all of them re-derived it from each card's own times via `arrival_order`:

| | |
|---|---|
| `get_merge_preview` | the Trip Builder's itinerary and legs table |
| `merge_trip_shipments` | what **Confirm & Apply** commits |
| `_stamp_leg_details` | the stop order written on save |
| `_cards_for_itinerary` | the capacity leg-walk and the manifest |

They agreed with *each other*, which is why this held together — `_cards_for_itinerary` even carries a comment about a previous attempt to sort on `stop_index` being reverted because *"the modal would accept a merge the save then refused"*. **That invariant was right and is kept.** What changes is which order they all read.

```python
run_order(shipment, placed)   # arrival_order's tie-breaks kept
```

`placed` is the second of the day the block actually sits at, passed by each caller from the plan row using whichever ISO parser it already has. Two stops the operator has at the same minute are still served drop-off first, and a run nobody has ordered by hand reads exactly as it did.

The two endpoints **honour the order they are given** — the canvas is what knows it. The two row-readers take it off `start_time`, which is what `onStopDrop` rewrites and which nothing overwrites on save — unlike `stop_index`, the *physical* stop number stamped from the itinerary with camp stops counted in.

## Two live faults, not just tidying

On the canvas, `_inRunOrder` is that order and everything needing it goes through it. Two of those substitutions fixed real bugs:

- **`_retimeTrip`** laid the stops out in `stop_index` order, so re-timing any leg **silently undid a reorder**.
- **`onStopDrop`** resolved the drag's source and target indices against a `stop_index`-sorted array, while the drawer had listed the stops in `start` order — so **a reorder could move a stop the operator was not dragging**.

`tripOccupancy` walks it too, or the lane and the save can reach different peaks again.

## Verified on the live plan

S-106 carries an Alghanim outward, a Salmiya outward and an Alghanim return.

```
return card last (shift-time order — what was reported)
  Seq 1: Mahboula Camp             BOARDING · 2                     on board 2
  Seq 2: Alghanim Guest House      DROPPING OFF · 1                 on board 1
  Seq 3: Salmiya Salem Mubarak St. DROPPING OFF · 1                 on board 0
  Seq 4: Alghanim Guest House      BOARDING · 1                     on board 1
  Seq 5: Mahboula Camp             DROPPING OFF · 1                 on board 0

dragged to the middle (what was asked for)
  Seq 1: Mahboula Camp             BOARDING · 2                     on board 2
  Seq 2: Alghanim Guest House      DROPPING OFF · 1 + BOARDING · 1  on board 2  [Combined]
  Seq 3: Salmiya Salem Mubarak St. DROPPING OFF · 1                 on board 1
  Seq 4: Mahboula Camp             DROPPING OFF · 1                 on board 0
```

Four stops, one visit to Alghanim. `_cards_for_itinerary` returns TS-0491 → TS-0488 → TS-0711, and `walk_occupancy` / `_trip_peak` build that same run — so the legs table, the capacity check and the driver's manifest all follow the drawer.

## Two test fixes come with it

- **`test_the_lane_lays_out_the_run`** extracts `_retimeTrip` and runs it in node. It now extracts `_inRunOrder` as well rather than stubbing it — which order the walk takes is part of what those tests check.
- **`test_a_card_that_was_never_merged_is_left_alone`** forced `trip_direction` on an *arbitrary production shipment* and never put it back. The rollback there is per class, so it handed the later generation-key assertion a card whose key says `|Outward`, and which card that was changed with the table. Its sibling already restores. **Pre-existing**, and unrelated to this ticket beyond surfacing here — the invariant itself holds 0/789 in real data.

## Tests

**All green** across 23 modules. The one failure in `test_manifest_mixed_ui` is pre-existing, verified by stashing against a clean `staging`.

## Deploy

```
bench build --app one_fm
bench clear-cache
```

No schema change and no patch in this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)