### PR TITLE
WI-002401: size a split on the seats the drop can actually have

### DIFF
--- a/one_fm/one_fm/page/transportation_schedule/test_seat_rule.js
+++ b/one_fm/one_fm/page/transportation_schedule/test_seat_rule.js
@@ -106,4 +106,53 @@ assert.strictEqual(
     10, 'two outward loads ride together'
 );
 
+
+// ── How big a split is (WI-002401) ────────────────────────────────────────────
+// The reported case: 60/59220 takes 7 passengers, the card has 17 staff, and the run
+// it is dropped on already carries 3. The split used to be sized on the bus (keep 7),
+// which came back still 3 over the run and was then refused. It is sized on the seats
+// free ON THAT RUN.
+const BUS = { id: 'BUS', label: '60/59220, Pajero', max_passenger_capacity: 7 };
+rule.planData = { vehicles: [BUS] };
+rule.passengerSeats = (v) => v.max_passenger_capacity;
+
+const RUN = { id: 'RUN', tripId: 'T-RUN', tripName: 'S-106', occupancy: 3, headcount: 3,
+    window: rule._dayWindow.call(rule, '2026-09-07T02:30:00Z', '2026-09-07T03:05:00Z'),
+    stops: [{ id: 's106a', direction: 'OUTBOUND', headcount: 3, stopIndex: 1 }] };
+rule._getLogicalTrips = () => [RUN];
+
+assert.strictEqual(rule._freeSeatsFor('BUS', null), 7, 'a run of its own gets the whole bus');
+assert.strictEqual(rule._freeSeatsFor('BUS', RUN.stops), 4, '7 seats less the 3 already on S-106');
+
+// A concurrent run takes seats off the total too.
+const OVERLAP = { id: 'X', tripId: 'T-X', tripName: 'S-999', occupancy: 2, headcount: 2,
+    window: rule._dayWindow.call(rule, '2026-09-07T02:45:00Z', '2026-09-07T03:30:00Z'),
+    stops: [{ id: 'x1', direction: 'OUTBOUND', headcount: 2, stopIndex: 1 }] };
+rule._getLogicalTrips = () => [RUN, OVERLAP];
+assert.ok(rule._sharesTheRoad(RUN.window, OVERLAP.window), 'these two overlap');
+assert.strictEqual(rule._freeSeatsFor('BUS', RUN.stops), 2, '7 less 3 on the run less 2 sharing the road');
+
+// The gate: offered when the card is over the seats it can have, not over the bus.
+rule._getLogicalTrips = () => [RUN];
+let offered = null;
+rule._openSplitModal = (card, vehicle, opts) => { offered = { card, opts }; };
+
+const card17 = { id: 'C', headcount: 17, direction: 'OUTBOUND' };
+assert.strictEqual(rule._splitIfOver(card17, BUS, RUN.stops, () => {}), true);
+assert.strictEqual(rule._freeSeatsFor('BUS', offered.opts.joining), 4,
+    'the modal is handed the run, so it sizes the split at 4 - not the 7 the bus takes');
+
+// A card of 5 fits the BUS but not the RUN: it used to fall through the gate entirely
+// and get refused later with a flat capacity error.
+offered = null;
+const card5 = { id: 'D', headcount: 5, direction: 'OUTBOUND' };
+assert.strictEqual(rule._splitIfOver(card5, BUS, RUN.stops, () => {}), true,
+    '5 is under the 7-seat bus but over the 4 seats free on the run');
+assert.ok(offered, 'so the split is offered rather than a refusal');
+
+// And a card that genuinely fits is left alone.
+offered = null;
+assert.strictEqual(rule._splitIfOver({ id: 'E', headcount: 4 }, BUS, RUN.stops, () => {}), false);
+assert.strictEqual(offered, null, 'no dialog for a card that fits');
+
 console.log('seat rule OK');

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
@@ -829,13 +829,19 @@ function mountRoutePlannerApp(wrapper, data) {
                     return;
                 }
 
-                // ── AC 2.1: a card bigger than the whole bus is a split, not a refusal ──
-                // Checked before the seat gate below, which would otherwise throw and the
-                // dispatcher would never be offered the split.
-                if (card.headcount > this.passengerSeats(vehicle)) {
-                    this._openSplitModal(card, vehicle);
-                    return;
-                }
+                // ── AC 2.1: a card too big for the seats it can have is a split, not a
+                // refusal - but WHICH seats depends on how this drop resolves, so the
+                // offer is made at each of the three endings below rather than here
+                // (WI-002401):
+                //
+                //   * a run of its own          -> the whole bus
+                //   * one nearby run            -> what is free on that run, offered
+                //                                  before the confirm
+                //   * several nearby runs       -> after the picker, for the run chosen
+                //
+                // Sizing it here meant sizing it on the bus for every drop, so a card
+                // joining a run that was already half full was split too big, came back
+                // still over, and was then refused.
 
                 // No seat check here. Which run this card joins has not been decided
                 // yet - the picker below offers every nearby run and a new independent
@@ -927,13 +933,20 @@ function mountRoutePlannerApp(wrapper, data) {
                         const newDirBadge =
                             (card.own_direction || card.direction) === 'RETURN' ? '← RET' : '→ OUT';
                         const newCamp = card.accommodation ? `<strong>${card.accommodation}</strong> — ` : '';
-                        frappe.confirm(
+                        // The split comes first when there is one run to join: the
+                        // seats free on THAT run are what the operator is agreeing to,
+                        // and they have to see the number before the confirm (WI-002401).
+                        const joining = tripMap[tripKeys[0]];
+                        const askToChain = (dropped) => frappe.confirm(
                             `<strong>${this.vehicleString(vehicle)}</strong> already has an active trip:<br><br>` +
                             existingStops.map((s, i) => `&nbsp;&nbsp;${i + 1}. ${s}`).join('<br>') +
-                            `<br><br>Add ${newCamp}<strong>${card.site_location}</strong> <span style="font-size:11px;color:#888">(${newDirBadge})</span> as the next stop on this trip?`,
-                            () => this._chainToTrip(card, tripMap[tripKeys[0]], vehicle.id),
-                            () => this._doPlaceWithDialog(card, vehicle.id)
+                            `<br><br>Add ${newCamp}<strong>${dropped.site_location}</strong> <span style="font-size:11px;color:#888">(${newDirBadge})</span> as the next stop on this trip?`,
+                            () => this._chainToTrip(dropped, joining, vehicle.id),
+                            () => this._doPlaceWithDialog(dropped, vehicle.id)
                         );
+                        if (!this._splitIfOver(card, vehicle, joining, askToChain)) {
+                            askToChain(card);
+                        }
                     } else {
                         // ── Multiple trips: let user pick which trip to join ──
                         const self = this;
@@ -1001,15 +1014,22 @@ function mountRoutePlannerApp(wrapper, data) {
                                 d.hide();
                                 const choice = vals.trip_choice;
 
+                                // The split waits for the pick: only now is it known
+                                // which run's free seats the card has to fit, and a run
+                                // of its own has the whole bus (WI-002401).
                                 if (choice === 'Create New Independent Trip') {
-                                    self._doPlaceWithDialog(card, vehicle.id);
+                                    const place = (dropped) => self._doPlaceWithDialog(dropped, vehicle.id);
+                                    if (!self._splitIfOver(card, vehicle, null, place)) place(card);
                                     return;
                                 }
 
                                 // Find selected trip
                                 const selected = tripOptions.find(t => t.label === choice);
-                                if (selected) {
-                                    self._chainToTrip(card, selected.items, vehicle.id, vals.transit_min);
+                                if (!selected) return;
+                                const chain = (dropped) => self._chainToTrip(
+                                    dropped, selected.items, vehicle.id, vals.transit_min);
+                                if (!self._splitIfOver(card, vehicle, selected.items, chain)) {
+                                    chain(card);
                                 }
                             }
                         });
@@ -1018,7 +1038,11 @@ function mountRoutePlannerApp(wrapper, data) {
                     return;
                 }
 
-                this.placeCard(card, vehicle.id);
+                // Nothing near it: a run of its own, so the seats it can have are the
+                // whole bus - which is what the split has always been sized on and stays
+                // correct here.
+                const place = (dropped) => this.placeCard(dropped, vehicle.id);
+                if (!this._splitIfOver(card, vehicle, null, place)) place(card);
             },
 
             // Fresh placement dialog — bypasses "already placed" direction check
@@ -1178,27 +1202,70 @@ function mountRoutePlannerApp(wrapper, data) {
             // A shift larger than the bus is not a mistake to refuse - it is two runs.
             // The bus is filled to its usable seats and the rest becomes a fresh card in
             // the pool, which can itself be split again onto a smaller vehicle.
-            _openSplitModal(card, vehicle) {
+            // Fill what is free and move the rest to a new card in the pool (AC 2.1).
+            //
+            // `opts.joining` is the run the card is going onto, when one has been chosen:
+            // the split is then sized to the seats left ON THAT RUN and the table says so,
+            // because the number the dispatcher has to agree to is the one that decides
+            // how many people get left behind. A card starting a run of its own has the
+            // whole bus, which is the figure this used to use for every drop regardless
+            // (WI-002401).
+            //
+            // `opts.onSplit` is what to do once the roster has actually moved. The caller
+            // owns that, because a split reached through the trip picker must carry on to
+            // the run the operator already picked rather than start the drop again.
+            _openSplitModal(card, vehicle, opts) {
                 const self = this;
+                opts = opts || {};
+                const joining = opts.joining || null;
                 const seats = this.passengerSeats(vehicle);
-                const overflow = card.headcount - seats;
+                const free = joining ? this._freeSeatsFor(vehicle.id, joining) : seats;
+                const overflow = card.headcount - free;
                 const esc = (v) => frappe.utils.escape_html(String(v == null ? '' : v));
+                const runName = joining
+                    ? (joining.find(i => i.tripName) || {}).tripName || __('this trip')
+                    : null;
+
+                // Nothing can be filled, so nothing can be split: keep must leave at
+                // least one rider on the card being placed. Say why instead of opening a
+                // dialog whose only honest answer is "cancel".
+                if (free < 1) {
+                    this.flashShell();
+                    frappe.msgprint({
+                        title: __('No Seats Free'),
+                        indicator: 'red',
+                        message: __('{0} has no seats free on {1}, so none of these {2} staff can be added. Free a seat on that run, or place this card on a run of its own.',
+                            [esc(self.vehicleString(vehicle)), esc(runName), esc(card.headcount)])
+                    });
+                    return;
+                }
+
+                const onRun = joining
+                    ? `<tr><td>${__('Already on {0}', [esc(runName)])}</td>
+                           <td class="font-weight-bold text-right">${seats - free}</td></tr>
+                       <tr><td>${__('Seats free on {0}', [esc(runName)])}</td>
+                           <td class="font-weight-bold text-right">${free}</td></tr>`
+                    : '';
+                const lead = joining
+                    ? __('{0} takes {1} passengers and {2} of those seats are already used, so {3} are free. This card has {4} staff.',
+                         [esc(self.vehicleString(vehicle)), seats, seats - free, free, esc(card.headcount)])
+                    : __('{0} carries {1} passengers, and this card has {2} staff.',
+                         [esc(self.vehicleString(vehicle)), seats, esc(card.headcount)]);
 
                 const d = new frappe.ui.Dialog({
                     title: __('Too many staff for this vehicle'),
                     fields: [{
                         fieldtype: 'HTML', fieldname: 'summary',
                         options: `
-                            <p class="small">${__('{0} carries {1} passengers, and this card has {2} staff.', [
-                                esc(self.vehicleString(vehicle)), seats, esc(card.headcount)
-                            ])}</p>
+                            <p class="small">${lead}</p>
                             <table class="table table-sm table-bordered small mb-3">
                                 <tr><td>${__('Total shift headcount')}</td>
                                     <td class="font-weight-bold text-right">${esc(card.headcount)}</td></tr>
                                 <tr><td>${__('Usable vehicle capacity')}</td>
                                     <td class="font-weight-bold text-right">${seats}</td></tr>
+                                ${onRun}
                                 <tr><td>${__('Staying on this card')}</td>
-                                    <td class="font-weight-bold text-right">${seats}</td></tr>
+                                    <td class="font-weight-bold text-right">${free}</td></tr>
                                 <tr class="text-warning"><td>${__('Moving to a new card')}</td>
                                     <td class="font-weight-bold text-right">${overflow}</td></tr>
                             </table>
@@ -1208,17 +1275,20 @@ function mountRoutePlannerApp(wrapper, data) {
                     primary_action() {
                         frappe.call({
                             method: 'one_fm.one_fm.doctype.transportation_shipment.transportation_shipment.split_shipment_for_capacity',
-                            args: { shipment: self._shipmentOf(card), keep: seats },
+                            args: { shipment: self._shipmentOf(card), keep: free },
                             freeze: true,
                             callback(r) {
                                 if (!r.message) return;
                                 d.hide();
                                 // The card's roster changed on the server, so the pool is
-                                // re-read rather than patched, and the drop is replayed
+                                // re-read rather than patched, and the caller carries on
                                 // against the card that comes back.
                                 self.refreshCards((cards) => {
                                     const placed = cards.find((c) => c.id === card.id);
-                                    if (placed) self.handleDrop(placed, vehicle);
+                                    if (placed) {
+                                        if (opts.onSplit) opts.onSplit(placed);
+                                        else self.handleDrop(placed, vehicle);
+                                    }
                                     frappe.show_alert({
                                         message: __('{0} staff moved to a new card in the pool.',
                                             [r.message.overflow_headcount]),
@@ -2112,6 +2182,44 @@ function mountRoutePlannerApp(wrapper, data) {
                 };
             },
 
+            // Offer the split when the card is bigger than the seats this drop can
+            // have, then carry on. Returns true when the split was offered, so the
+            // caller stops and resumes from `next` once the roster has moved.
+            //
+            // `joining` is the run the card is going onto, or null for a run of its own -
+            // that is the whole difference between the three endings of handleDrop.
+            _splitIfOver(card, vehicle, joining, next) {
+                const free = joining
+                    ? this._freeSeatsFor(vehicle.id, joining)
+                    : this.passengerSeats(vehicle);
+                if (card.headcount <= free) return false;
+                this._openSplitModal(card, vehicle, { joining, onSplit: next });
+                return true;
+            },
+
+            // How many seats this drop can actually take.
+            //
+            // For a run of its own that is the whole bus. For a card joining an existing
+            // run it is what is LEFT on that run - the bus minus what the run already
+            // carries minus the runs sharing its hours. Sizing a split on the whole bus
+            // regardless is what offered "17 staff, 7 stay, 10 move" for a 7-seat bus
+            // whose target run was already carrying 3: only 4 seats were free, so the
+            // card came back still 3 over and the drop was then refused (WI-002401).
+            _freeSeatsFor(vehicleId, joining) {
+                const vehicle = this.planData.vehicles.find(v => v.id === vehicleId);
+                if (!vehicle) return 0;
+                const seats = this.passengerSeats(vehicle);
+                if (!joining || !joining.length) return seats;
+
+                const ids = new Set(joining.map(i => i.id));
+                const target = this._getLogicalTrips(vehicleId)
+                    .find(t => t.stops.some(stop => ids.has(stop.id)));
+                const { total } = this.seatLoad(
+                    vehicleId, target ? target.occupancy : 0, { joining }
+                );
+                return Math.max(seats - total, 0);
+            },
+
             // ── Time-aware peak load helper ─────────────────────────────────
             // The trips a vehicle actually runs today. One tripId is one bus run,
             // however its stops are headed: keying the direction in as well (WI-002000)
@@ -2827,7 +2935,8 @@ function mountRoutePlannerApp(wrapper, data) {
                 // Build options for the vehicle selector (exclude current vehicle)
                 const vehicleOpts = this.planData.vehicles
                     .filter(v => v.id !== item.vehicleId)
-                    .map(v => `${v.label} (${v.seats} seats)`);
+                    // The capacity the move will be judged against, not the raw count.
+                    .map(v => `${v.label} (${this.passengerSeats(v)} seats)`);
 
                 if (vehicleOpts.length === 0) {
                     frappe.show_alert({ message: 'No other vehicles available', indicator: 'orange' });
@@ -4283,9 +4392,14 @@ function injectRPVueTemplate() {
                   {{ card.direction === 'OUTBOUND' ? '→ OUT' : '← RET' }}
                 </span>
                 <span :class="['rp-card-type', card.type === 'OLM' ? 'rp-tag-olm' : 'rp-tag-osm']">{{ card.type }}</span>
-                <!-- AC 2.5: this card holds the staff who did not fit on the bus its
-                     parent was assigned to. -->
-                <span v-if="card.is_split_overflow" class="rp-card-type rp-tag-split"
+              </div>
+              <!-- AC 2.5: this card holds the staff who did not fit on the bus its
+                   parent was assigned to. On its own line, not in the header: every badge
+                   up there refuses to shrink and the site name is the only flexible item,
+                   so a third one squeezed "Kuwait Airways - T4" down to "K." in the
+                   sidebar (WI-002401). -->
+              <div v-if="card.is_split_overflow" class="rp-card-split-row">
+                <span class="rp-card-type rp-tag-split"
                       :title="'Split from ' + (card.split_root || 'another card')">SPLIT OVERFLOW</span>
               </div>
               <div class="rp-card-shift">{{ card.shift_name }}</div>
@@ -4391,7 +4505,11 @@ function injectRPVueTemplate() {
                 <span v-if="lockedLaneIds.has(vehicle.id)" class="rp-lock-badge" title="Reserved for a multi-day run — blocked for other shipments">&#x1F512;</span>
                 <span v-else-if="upcomingLockByVehicle[vehicle.id]" class="rp-lock-upcoming" :title="'Reserved for an upcoming multi-day run from ' + upcomingLockByVehicle[vehicle.id]">&#x1F512; from {{ upcomingLockByVehicle[vehicle.id] }}</span>
               </div>
-              <div class="rp-gv-meta">{{ vehicle.driver }} &middot; {{ vehicle.seats }} seats</div>
+              <!-- Max Passenger Capacity, which is what every seat check is against.
+                   The raw seat count is one higher on a bus whose count includes the
+                   driver, so the lane advertised 4 on a RAIZE that may carry 3
+                   (WI-002401). -->
+              <div class="rp-gv-meta">{{ vehicle.driver }} &middot; {{ passengerSeats(vehicle) }} seats</div>
               <div class="rp-gv-acc">{{ vehicle.accommodation }}</div>
             </div>
 
@@ -5336,6 +5454,7 @@ function injectRPStyles() {
         .rp-card-site   { font-size: 14px; font-weight: 600; color: var(--md-sys-color-on-surface); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
         .rp-card-type   { font-size: 11px; font-weight: 700; letter-spacing: .06em; padding: 2px 7px; border-radius: 4px; flex-shrink: 0; }
         .rp-tag-split   { background: #fef3c7; color: #92400e; }
+        .rp-card-split-row { display: flex; margin-bottom: 4px; }
         .rp-card-dir    { font-size: 10px; font-weight: 700; letter-spacing: .04em; padding: 2px 7px; border-radius: 4px; text-transform: uppercase; flex-shrink: 0; }
         .rp-dir-out     { background: #e3f2fd; color: #1565c0; }
         .rp-dir-ret     { background: #fce4ec; color: #c62828; }

--- a/one_fm/tests/test_overcapacity_card_split.py
+++ b/one_fm/tests/test_overcapacity_card_split.py
@@ -168,18 +168,48 @@ class TestTheCanvasOffersTheSplit(FrappeTestCase):
 	def setUp(self):
 		self.source = CANVAS.read_text()
 
-	def test_the_drop_is_intercepted_before_the_run_is_chosen(self):
-		# A card bigger than the whole bus is the one refusal that belongs before the
-		# picker, because no run on that lane can take it. Everything else waits until
-		# the operator has chosen a run (WI-002401 AC5), so the pooled seat gate that
-		# used to sit here - and would have thrown before the split was ever offered -
-		# is gone.
-		self.assertIn("if (card.headcount > this.passengerSeats(vehicle)) {", self.source)
-		self.assertIn("this._openSplitModal(card, vehicle);", self.source)
+	def test_the_split_is_offered_at_each_ending_not_before_them(self):
+		"""Which seats the card can have depends on how the drop resolves (WI-002401).
+
+		Sizing the split up front meant sizing it on the whole bus for every drop, so a
+		card joining a run that was already half full was split too big, came back still
+		over, and was then refused. There are three endings and each asks for itself.
+		"""
+		# No unconditional gate at the top of handleDrop any more.
+		self.assertNotIn("if (card.headcount > this.passengerSeats(vehicle)) {", self.source)
+		self.assertIn("_splitIfOver(card, vehicle, joining, askToChain)", self.source)
+
+		# One nearby run: sized to that run, and offered BEFORE the confirm.
 		self.assertLess(
-			self.source.index("_openSplitModal(card, vehicle);"),
-			self.source.index("// ── Trip chaining: detect nearby blocks"),
+			self.source.index("_splitIfOver(card, vehicle, joining, askToChain)"),
+			self.source.index("askToChain(card);"),
 		)
+		# Several nearby runs: after the picker, for the run actually chosen.
+		self.assertIn("_splitIfOver(card, vehicle, selected.items, chain)", self.source)
+		# A run of its own: the whole bus, which is what it always was.
+		self.assertIn("_splitIfOver(card, vehicle, null, place)", self.source)
+
+	def test_the_split_is_sized_on_the_seats_the_drop_can_have(self):
+		self.assertIn("_freeSeatsFor(vehicleId, joining)", self.source)
+		# The run's own load and the runs sharing its hours both take seats off.
+		self.assertIn("vehicleId, target ? target.occupancy : 0, { joining }", self.source)
+		self.assertIn("return Math.max(seats - total, 0);", self.source)
+		# And the split keeps exactly that, rather than a whole busload.
+		self.assertIn("args: { shipment: self._shipmentOf(card), keep: free }", self.source)
+
+	def test_the_modal_states_the_free_seats_it_sized_on(self):
+		# The number the dispatcher agrees to decides how many people are left behind.
+		self.assertIn("Already on {0}", self.source)
+		self.assertIn("Seats free on {0}", self.source)
+
+	def test_a_run_with_no_free_seat_says_so_instead_of_offering_a_split(self):
+		# keep must leave at least one rider on the card being placed.
+		self.assertIn("if (free < 1) {", self.source)
+		self.assertIn("__('No Seats Free')", self.source)
+
+	def test_a_split_reached_through_the_picker_resumes_where_it_was(self):
+		# Not by replaying the drop: the operator has already picked a run.
+		self.assertIn("if (opts.onSplit) opts.onSplit(placed);", self.source)
 
 	def test_the_modal_states_the_four_numbers(self):
 		self.assertIn("Total shift headcount", self.source)
@@ -190,7 +220,10 @@ class TestTheCanvasOffersTheSplit(FrappeTestCase):
 	def test_confirming_splits_and_then_places_the_filled_card(self):
 		self.assertIn("__('Confirm & Split Remaining')", self.source)
 		self.assertIn("split_shipment_for_capacity", self.source)
-		self.assertIn("if (placed) self.handleDrop(placed, vehicle);", self.source)
+		# Resumes where the drop had got to - the caller's continuation when there is
+		# one, and only otherwise by replaying the drop (WI-002401).
+		self.assertIn("if (opts.onSplit) opts.onSplit(placed);", self.source)
+		self.assertIn("else self.handleDrop(placed, vehicle);", self.source)
 
 	def test_cancelling_leaves_the_card_alone(self):
 		# AC 2.6: nothing split, nothing placed.

--- a/one_fm/tests/test_transportation_seat_rule.py
+++ b/one_fm/tests/test_transportation_seat_rule.py
@@ -69,10 +69,13 @@ class TestCapacityIsJudgedPerRun(FrappeTestCase):
 		self.assertNotIn("peakLoadDuringCardWindows", self.source)
 		self.assertNotIn("cardLegWindow", self.source)
 
-	def test_a_card_bigger_than_the_bus_is_still_split_on_the_drop(self):
-		# The one refusal that does belong before the picker, because no run can take it.
-		self.assertIn("if (card.headcount > this.passengerSeats(vehicle)) {", self.source)
-		self.assertIn("this._openSplitModal(card, vehicle);", self.source)
+	def test_a_card_too_big_for_the_seats_it_can_have_is_split_not_refused(self):
+		# Sized on the seats the drop can actually have, at each of handleDrop's three
+		# endings rather than once up front on the whole bus (WI-002401 item 1) - see
+		# test_overcapacity_card_split for the flow.
+		self.assertIn("_splitIfOver(card, vehicle, joining, next) {", self.source)
+		self.assertIn("if (card.headcount <= free) return false;", self.source)
+		self.assertNotIn("if (card.headcount > this.passengerSeats(vehicle)) {", self.source)
 
 	def test_a_chain_is_judged_on_the_run_it_joins(self):
 		self.assertIn("this.mergedOccupancy(existingItems, newCard)", self.source)
@@ -246,3 +249,56 @@ class TestTheItineraryNamesBothMovements(FrappeTestCase):
 
 	def test_a_stop_where_nothing_happens_still_says_so(self):
 		self.assertIn("NOBODY BOARDS OR LEAVES", self.source)
+
+
+class TestTheBoardStatesTheCapacityItValidates(FrappeTestCase):
+	"""Max Passenger Capacity is what every seat check applies (WI-002401 item 3).
+
+	The raw seat count is one higher on a bus whose count includes the driver, so a
+	lane advertising the seat count promises a seat the save will refuse. On this site
+	that is 22/32135, the RAIZE: 4 seats, driver included, 3 passengers.
+	"""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_the_lane_label_states_the_passenger_capacity(self):
+		self.assertIn("{{ passengerSeats(vehicle) }} seats", self.source)
+		self.assertNotIn("{{ vehicle.seats }} seats", self.source)
+
+	def test_the_reassign_picker_states_it_too(self):
+		self.assertIn("`${v.label} (${this.passengerSeats(v)} seats)`", self.source)
+		self.assertNotIn("`${v.label} (${v.seats} seats)`", self.source)
+
+	def test_the_picker_still_parses_its_own_label_back(self):
+		# The option text is split on " (" to recover the vehicle, so the number inside
+		# the brackets is free to change but the separator is not.
+		self.assertIn("vals.target_vehicle.split(' (')[0]", self.source)
+
+
+class TestASplitCardKeepsItsName(FrappeTestCase):
+	"""Three badges that refuse to shrink left "Kuwait Airways - T4" as "K.".
+
+	.rp-card-site is the only flexible item in the header and carries min-width: 0, so
+	it absorbs the whole squeeze; SPLIT OVERFLOW is also the longest of the three.
+	"""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_the_split_badge_is_on_its_own_line(self):
+		self.assertIn('<div v-if="card.is_split_overflow" class="rp-card-split-row">', self.source)
+		self.assertIn(".rp-card-split-row { display: flex; margin-bottom: 4px; }", self.source)
+
+	def test_the_header_keeps_only_the_two_short_badges(self):
+		start = self.source.index('<div class="rp-card-header">')
+		header = self.source[start:self.source.index("</div>", start)]
+		self.assertIn("rp-card-dir", header)
+		self.assertIn("rp-card-type", header)
+		self.assertNotIn("SPLIT OVERFLOW", header)
+
+	def test_the_name_is_still_the_flexible_one(self):
+		# Unchanged: the fix is which badges share the row, not how the name behaves.
+		self.assertIn(".rp-card-site   { font-size: 14px; font-weight: 600;", self.source)
+		self.assertIn("flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis;",
+					  self.source)


### PR DESCRIPTION
Three findings from testing, all on the drop path. Items 1–3 of the latest round; **item 4 (the stale Mixed flags on S-704/S-602) is deliberately not in here** — see the bottom.

## 1. The split was sized on the bus, not on the run

The gate sat at the **top of `handleDrop`**, before any run had been chosen, so it could only ever use the whole vehicle:

```js
if (card.headcount > this.passengerSeats(vehicle)) { this._openSplitModal(card, vehicle); return; }
```

A 17-staff card dropped on the 7-seat Pajero was offered *"7 stay, 10 move"* — but the run it was joining already carried **3**, so only **4** seats were free. The card came back still 3 over and the drop was then refused.

The same gate **never fired at all** for a card that fits the bus but not the run — 5 staff onto a 7-seat bus with 3 aboard — which got a flat capacity error instead of the split it should have been offered.

Which seats a card can have depends on how the drop resolves, so the offer moves to each of `handleDrop`'s three endings and sizes itself there:

| ending | seats it can have | when the modal appears |
|---|---|---|
| a run of its own | the whole bus | unchanged |
| one nearby run | what is free **on that run** | **before** the confirm |
| several nearby runs | what is free on the run chosen | **after** the picker |

`_freeSeatsFor` takes the run's own load *and* the runs sharing its hours off the capacity. The modal now prints `Already on S-106` and `Seats free on S-106` beside the totals, so the number being agreed to is the one that decides who gets left behind. A run with no free seat says so rather than opening a dialog whose only honest answer is cancel. And a split reached through the picker **resumes into the run already chosen** instead of replaying the drop.

## 2. A split card lost its name

```css
.rp-card-header { display: flex; gap: 6px; }
.rp-card-site   { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
.rp-card-dir    { flex-shrink: 0; }   /* ← RET */
.rp-card-type   { flex-shrink: 0; }   /* OSM, and SPLIT OVERFLOW shares this class */
```

Every badge refuses to shrink and the site name is the only flexible item, with `min-width: 0` — so it absorbs the entire squeeze. A third badge, and the longest of the three, left **"Kuwait Airways - T4" rendering as "K."**. `SPLIT OVERFLOW` moves to its own line; the name keeps the width it had before the split.

## 3. The board advertised a seat the save would refuse

Every seat check applies **Max Passenger Capacity** (`passengerSeats()`), but two labels printed the **raw seat count**:

| | before | after |
|---|---|---|
| Lane label | `{{ vehicle.seats }} seats` | `{{ passengerSeats(vehicle) }} seats` |
| Reassign Vehicle picker | `${v.seats} seats` | `${this.passengerSeats(v)} seats` |
| Split modal | already correct | unchanged |

They agree on **27 of the 28** transport vehicles here and disagree on one:

```
VHL-L-0006   22/32135 (RAIZE)   seats=4   includes_driver=1   max_pax=3
```

The lane said "4 seats" while validation allowed 3.

Two details worth noting for review: the picker recovers the vehicle by splitting its option text on `" ("`, so the number inside the brackets is free to change — asserted. And the capacity call in that block had to use `this`, not `self` — `self` is declared seven lines further down, so `self.passengerSeats(...)` there would have thrown a `ReferenceError` and broken the button.

## Tests

**574 green across 22 modules.** The seat-rule self-check gains the reported case as arithmetic:

```
7 seats, 3 aboard          -> 4 free
5 staff                    -> under the bus, over the run  -> split offered
a concurrent run of 2      -> 2 free
a card of 4                -> fits, no dialog
```

`_freeSeatsFor` and `_splitIfOver` were placed inside the region `test_seat_rule.js` reads **out of the shipped file**, so they are exercised rather than copied.

Three existing assertions were updated because they pinned the old up-front gate — the intent is preserved and re-pointed, not deleted.

## Not in this PR

**Item 4 — S-704 and S-602 stuck showing Mixed.** Diagnosed but left alone on request. For the record: both cards serve **only Inactive Operations Shifts**, so WI-002307 hides them from the pool; `_resyncTripDirection` refuses to guess a heading for a card it cannot resolve, and `_unmerge_unmixed_placements` decides from the canvas's `item.direction`, which is still `MIXED`. So they can never self-heal — which is why removing cards fixed S-201/S-203 (Active shifts, cards in the pool) and not these two. The fix is to decide the unmerge from the server's own `own_direction()`, which needs no pool visibility.

## Deploy

```
bench build --app one_fm
bench clear-cache
```

Client-side only. No schema change, no patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)