### PR TITLE
fix: stop new OJTs from queuing their own schedule cleanup

### DIFF
--- a/one_fm/one_fm/doctype/on_the_job_training/on_the_job_training.py
+++ b/one_fm/one_fm/doctype/on_the_job_training/on_the_job_training.py
@@ -147,6 +147,15 @@ class OntheJobTraining(Document):
                 self.handle_end_date_change()
 
     def handle_workflow_cleanup(self):
+        # has_value_changed() returns True on insert (there is no before-save doc), so
+        # without this guard every newly created OJT - which starts in Draft - enqueues
+        # delete_related_records_async. A fresh OJT has nothing to clean up, and because
+        # the delete runs in a background job it can land *after* the Pending Approval
+        # and Approve saves have created the Employee Schedules, wiping them again. That
+        # is why fast create-then-approve OJTs end up with no schedules on the roster.
+        if self.flags.in_insert or self.is_new():
+            return
+
         today = getdate(frappe.utils.nowdate())
         if not self.start_date: return
         


### PR DESCRIPTION
has_value_changed() returns True on insert because there is no before-save doc, and on_update runs on insert. A new OJT starts in Draft, so every creation enqueued delete_related_records_async, which deletes every Employee Schedule and Shift Assignment linked to the OJT.

The job is usually harmless because it runs before anything is tagged, but when the worker is backlogged it lands after the Pending Approval and Approve saves have created the schedules and wipes them. Prod data for Sept 2026 shows six of the seven OJTs approved within ~140s of creation lost some or all of their roster entries, while those approved after ~800s were intact.

- return early from handle_workflow_cleanup on insert, since a fresh OJT has no related records to clean up
