### PR TITLE
WI-002401: ask about the merge first, and let a return card board what the outward load leaves

### DIFF
--- a/one_fm/one_fm/page/transportation_schedule/test_seat_rule.js
+++ b/one_fm/one_fm/page/transportation_schedule/test_seat_rule.js
@@ -121,8 +121,8 @@ const RUN = { id: 'RUN', tripId: 'T-RUN', tripName: 'S-106', occupancy: 3, headc
     stops: [{ id: 's106a', direction: 'OUTBOUND', headcount: 3, stopIndex: 1 }] };
 rule._getLogicalTrips = () => [RUN];
 
-assert.strictEqual(rule._freeSeatsFor('BUS', null), 7, 'a run of its own gets the whole bus');
-assert.strictEqual(rule._freeSeatsFor('BUS', RUN.stops), 4, '7 seats less the 3 already on S-106');
+assert.strictEqual(rule._seatsAvailableFor({ headcount: 99 }, 'BUS', null), 7, 'a run of its own gets the whole bus');
+assert.strictEqual(rule._seatsAvailableFor({ id: 'C', direction: 'OUTBOUND', headcount: 99 }, 'BUS', RUN.stops), 4, '7 seats less the 3 already on S-106');
 
 // A concurrent run takes seats off the total too.
 const OVERLAP = { id: 'X', tripId: 'T-X', tripName: 'S-999', occupancy: 2, headcount: 2,
@@ -130,7 +130,7 @@ const OVERLAP = { id: 'X', tripId: 'T-X', tripName: 'S-999', occupancy: 2, headc
     stops: [{ id: 'x1', direction: 'OUTBOUND', headcount: 2, stopIndex: 1 }] };
 rule._getLogicalTrips = () => [RUN, OVERLAP];
 assert.ok(rule._sharesTheRoad(RUN.window, OVERLAP.window), 'these two overlap');
-assert.strictEqual(rule._freeSeatsFor('BUS', RUN.stops), 2, '7 less 3 on the run less 2 sharing the road');
+assert.strictEqual(rule._seatsAvailableFor({ id: 'C', direction: 'OUTBOUND', headcount: 99 }, 'BUS', RUN.stops), 2, '7 less 3 on the run less 2 sharing the road');
 
 // The gate: offered when the card is over the seats it can have, not over the bus.
 rule._getLogicalTrips = () => [RUN];
@@ -139,8 +139,8 @@ rule._openSplitModal = (card, vehicle, opts) => { offered = { card, opts }; };
 
 const card17 = { id: 'C', headcount: 17, direction: 'OUTBOUND' };
 assert.strictEqual(rule._splitIfOver(card17, BUS, RUN.stops, () => {}), true);
-assert.strictEqual(rule._freeSeatsFor('BUS', offered.opts.joining), 4,
-    'the modal is handed the run, so it sizes the split at 4 - not the 7 the bus takes');
+assert.strictEqual(offered.opts.free, 4,
+    'the modal is handed 4 - not the 7 the bus takes');
 
 // A card of 5 fits the BUS but not the RUN: it used to fall through the gate entirely
 // and get refused later with a flat capacity error.
@@ -154,5 +154,63 @@ assert.ok(offered, 'so the split is offered rather than a refusal');
 offered = null;
 assert.strictEqual(rule._splitIfOver({ id: 'E', headcount: 4 }, BUS, RUN.stops, () => {}), false);
 assert.strictEqual(offered, null, 'no dialog for a card that fits');
+
+
+// ── A return card boards the seats the outward load has left (WI-002401) ──────
+// The reported case: a run whose outbound legs already fill the bus must still accept
+// a return card. Subtracting the run's peak said zero seats and put a split, or a
+// "No Seats Free", in front of a merge that fits perfectly well.
+rule.cardOwnDirection = (i) => (i.direction === 'RETURN' ? 'RETURN' : 'OUTBOUND');
+rule.tripOccupancy = function (trip) {
+    if (trip.direction !== 'MIXED') return trip.headcount;
+    const stops = this._inRunOrder(trip.stops);
+    const boards = (i) => this.cardOwnDirection(i) === 'RETURN';
+    let onBoard = stops.reduce((n, s) => n + (boards(s) ? 0 : (s.headcount || 0)), 0);
+    let peak = onBoard;
+    stops.forEach(s => {
+        onBoard += boards(s) ? (s.headcount || 0) : -(s.headcount || 0);
+        peak = Math.max(peak, onBoard);
+    });
+    return peak;
+};
+rule._inRunOrder = (items) => [...items].sort(
+    (a, b) => (new Date(a.start) - new Date(b.start)) || (a.stopIndex || 0) - (b.stopIndex || 0));
+
+// 7-seat bus, an outbound run carrying all 7 - completely full outbound.
+const FULL = { id: 'FULL', tripId: 'T-FULL', tripName: 'S-201', occupancy: 7, headcount: 7,
+    window: rule._dayWindow.call(rule, '2026-09-07T02:30:00Z', '2026-09-07T03:05:00Z'),
+    stops: [{ id: 'f1', direction: 'OUTBOUND', headcount: 7, stopIndex: 1,
+              start: '2026-09-07T02:30:00Z' }] };
+rule._getLogicalTrips = () => [FULL];
+
+const ret3 = { id: 'R', direction: 'RETURN', headcount: 3 };
+assert.strictEqual(rule._seatsAvailableFor(ret3, 'BUS', FULL.stops), 3,
+    'all 3 returning riders fit a bus that is full outbound');
+assert.strictEqual(rule._splitIfOver(ret3, BUS, FULL.stops, () => {}), false,
+    'so no split modal, and no "No Seats Free"');
+
+// A full busload of returning riders also fits; one more does not.
+assert.strictEqual(rule._seatsAvailableFor({ id: 'R', direction: 'RETURN', headcount: 7 },
+    'BUS', FULL.stops), 7);
+assert.strictEqual(rule._seatsAvailableFor({ id: 'R', direction: 'RETURN', headcount: 9 },
+    'BUS', FULL.stops), 7, 'capped at the bus, and split rather than refused');
+
+// An OUTBOUND card onto the same full run still cannot ride - those riders DO share it.
+assert.strictEqual(rule._seatsAvailableFor({ id: 'O', direction: 'OUTBOUND', headcount: 3 },
+    'BUS', FULL.stops), 0, 'nothing outbound fits a bus that is already full outbound');
+
+// A run that already mixes: 4 out, 2 back. A further return card has the seats the
+// outward load leaves, not what is spare beside its peak.
+const MIX = { id: 'MIX', tripId: 'T-MIX', tripName: 'S-301', occupancy: 4, headcount: 6,
+    window: rule._dayWindow.call(rule, '2026-09-07T02:30:00Z', '2026-09-07T03:05:00Z'),
+    stops: [{ id: 'm1', direction: 'OUTBOUND', headcount: 4, stopIndex: 1,
+              start: '2026-09-07T02:30:00Z' },
+            { id: 'm2', direction: 'RETURN', headcount: 2, stopIndex: 2,
+              start: '2026-09-07T02:45:00Z' }] };
+rule._getLogicalTrips = () => [MIX];
+assert.strictEqual(rule._seatsAvailableFor({ id: 'R2', direction: 'RETURN', headcount: 5 },
+    'BUS', MIX.stops), 5, '2 already aboard on the way home plus 5 more is 7');
+assert.strictEqual(rule._seatsAvailableFor({ id: 'R2', direction: 'RETURN', headcount: 6 },
+    'BUS', MIX.stops), 5, 'the sixth would make 8 on a 7-seat bus');
 
 console.log('seat rule OK');

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
@@ -933,20 +933,34 @@ function mountRoutePlannerApp(wrapper, data) {
                         const newDirBadge =
                             (card.own_direction || card.direction) === 'RETURN' ? '← RET' : '→ OUT';
                         const newCamp = card.accommodation ? `<strong>${card.accommodation}</strong> — ` : '';
-                        // The split comes first when there is one run to join: the
-                        // seats free on THAT run are what the operator is agreeing to,
-                        // and they have to see the number before the confirm (WI-002401).
+                        // Merge or stand alone is the first question, because the answer
+                        // decides which seats the card can have - the ones left on that
+                        // run, or the whole bus. Only then is a split worth sizing, and
+                        // only then is it sized correctly. Asking first meant a card
+                        // split to a run's free seats and then placed on a run of its own
+                        // anyway, carrying fewer people than the bus could take.
                         const joining = tripMap[tripKeys[0]];
-                        const askToChain = (dropped) => frappe.confirm(
+                        frappe.confirm(
                             `<strong>${this.vehicleString(vehicle)}</strong> already has an active trip:<br><br>` +
                             existingStops.map((s, i) => `&nbsp;&nbsp;${i + 1}. ${s}`).join('<br>') +
-                            `<br><br>Add ${newCamp}<strong>${dropped.site_location}</strong> <span style="font-size:11px;color:#888">(${newDirBadge})</span> as the next stop on this trip?`,
-                            () => this._chainToTrip(dropped, joining, vehicle.id),
-                            () => this._doPlaceWithDialog(dropped, vehicle.id)
+                            `<br><br>Add ${newCamp}<strong>${card.site_location}</strong> <span style="font-size:11px;color:#888">(${newDirBadge})</span> as the next stop on this trip?`,
+                            () => {
+                                // Yes, merge: sized to the seats free on THAT run.
+                                const chain = (dropped) =>
+                                    this._chainToTrip(dropped, joining, vehicle.id);
+                                if (!this._splitIfOver(card, vehicle, joining, chain)) {
+                                    chain(card);
+                                }
+                            },
+                            () => {
+                                // No, a run of its own: the whole bus.
+                                const place = (dropped) =>
+                                    this._doPlaceWithDialog(dropped, vehicle.id);
+                                if (!this._splitIfOver(card, vehicle, null, place)) {
+                                    place(card);
+                                }
+                            }
                         );
-                        if (!this._splitIfOver(card, vehicle, joining, askToChain)) {
-                            askToChain(card);
-                        }
                     } else {
                         // ── Multiple trips: let user pick which trip to join ──
                         const self = this;
@@ -1219,7 +1233,11 @@ function mountRoutePlannerApp(wrapper, data) {
                 opts = opts || {};
                 const joining = opts.joining || null;
                 const seats = this.passengerSeats(vehicle);
-                const free = joining ? this._freeSeatsFor(vehicle.id, joining) : seats;
+                // The gate already worked this out and its answer is what the split
+                // keeps, so it is passed rather than computed twice.
+                const free = opts.free != null
+                    ? opts.free
+                    : this._seatsAvailableFor(card, vehicle.id, joining);
                 const overflow = card.headcount - free;
                 const esc = (v) => frappe.utils.escape_html(String(v == null ? '' : v));
                 const runName = joining
@@ -1240,15 +1258,17 @@ function mountRoutePlannerApp(wrapper, data) {
                     return;
                 }
 
+                // Only the figure that actually applies to this card. "Seats already
+                // taken" would be a lie for a return card joining an outbound run: it
+                // boards what the outward load has left, so none of those seats are
+                // taken at the moment these riders get on.
                 const onRun = joining
-                    ? `<tr><td>${__('Already on {0}', [esc(runName)])}</td>
-                           <td class="font-weight-bold text-right">${seats - free}</td></tr>
-                       <tr><td>${__('Seats free on {0}', [esc(runName)])}</td>
+                    ? `<tr><td>${__('Seats this card can have on {0}', [esc(runName)])}</td>
                            <td class="font-weight-bold text-right">${free}</td></tr>`
                     : '';
                 const lead = joining
-                    ? __('{0} takes {1} passengers and {2} of those seats are already used, so {3} are free. This card has {4} staff.',
-                         [esc(self.vehicleString(vehicle)), seats, seats - free, free, esc(card.headcount)])
+                    ? __('{0} takes {1} passengers, and {2} of this card\'s {3} staff can ride on {4}.',
+                         [esc(self.vehicleString(vehicle)), seats, free, esc(card.headcount), esc(runName)])
                     : __('{0} carries {1} passengers, and this card has {2} staff.',
                          [esc(self.vehicleString(vehicle)), seats, esc(card.headcount)]);
 
@@ -2189,35 +2209,48 @@ function mountRoutePlannerApp(wrapper, data) {
             // `joining` is the run the card is going onto, or null for a run of its own -
             // that is the whole difference between the three endings of handleDrop.
             _splitIfOver(card, vehicle, joining, next) {
-                const free = joining
-                    ? this._freeSeatsFor(vehicle.id, joining)
-                    : this.passengerSeats(vehicle);
+                const free = this._seatsAvailableFor(card, vehicle.id, joining);
                 if (card.headcount <= free) return false;
-                this._openSplitModal(card, vehicle, { joining, onSplit: next });
+                this._openSplitModal(card, vehicle, { joining, free, onSplit: next });
                 return true;
             },
 
-            // How many seats this drop can actually take.
+            // How many of THIS card's staff can ride on this drop.
             //
-            // For a run of its own that is the whole bus. For a card joining an existing
-            // run it is what is LEFT on that run - the bus minus what the run already
-            // carries minus the runs sharing its hours. Sizing a split on the whole bus
-            // regardless is what offered "17 staff, 7 stay, 10 move" for a 7-seat bus
-            // whose target run was already carrying 3: only 4 seats were free, so the
-            // card came back still 3 over and the drop was then refused (WI-002401).
-            _freeSeatsFor(vehicleId, joining) {
+            // For a run of its own that is the whole bus. For a card joining a run it is
+            // the most of them the merged run can carry - and that is not the bus minus
+            // what the run already holds, because how many fit depends on WHEN they
+            // board. A return card joining an outbound run takes the seats the outward
+            // load has already got out of, so a run that is full outbound can still
+            // carry it; subtracting the run's peak answered zero and put a split, or a
+            // "No Seats Free", in front of a merge that fits perfectly well (WI-002401).
+            //
+            // So the question is asked as the seat check asks it - the largest headcount
+            // whose merged run still fits, measured with the same leg walk - rather than
+            // re-derived per direction. The gate, the size the split keeps and the
+            // refusal downstream then cannot disagree, whatever shape the run is.
+            _seatsAvailableFor(card, vehicleId, joining) {
                 const vehicle = this.planData.vehicles.find(v => v.id === vehicleId);
                 if (!vehicle) return 0;
                 const seats = this.passengerSeats(vehicle);
                 if (!joining || !joining.length) return seats;
 
-                const ids = new Set(joining.map(i => i.id));
-                const target = this._getLogicalTrips(vehicleId)
-                    .find(t => t.stops.some(stop => ids.has(stop.id)));
-                const { total } = this.seatLoad(
-                    vehicleId, target ? target.occupancy : 0, { joining }
-                );
-                return Math.max(seats - total, 0);
+                const fits = (headcount) => this.seatLoad(
+                    vehicleId,
+                    this.mergedOccupancy(joining, { ...card, headcount }),
+                    { joining }
+                ).total <= seats;
+
+                if (fits(card.headcount)) return card.headcount;
+
+                // Monotone in headcount - a bigger load can only raise the peak - so the
+                // largest one that fits is a binary search away.
+                let lo = 0, hi = card.headcount;
+                while (lo < hi) {
+                    const mid = Math.ceil((lo + hi) / 2);
+                    if (fits(mid)) lo = mid; else hi = mid - 1;
+                }
+                return lo;
             },
 
             // ── Time-aware peak load helper ─────────────────────────────────

--- a/one_fm/tests/test_overcapacity_card_split.py
+++ b/one_fm/tests/test_overcapacity_card_split.py
@@ -177,12 +177,13 @@ class TestTheCanvasOffersTheSplit(FrappeTestCase):
 		"""
 		# No unconditional gate at the top of handleDrop any more.
 		self.assertNotIn("if (card.headcount > this.passengerSeats(vehicle)) {", self.source)
-		self.assertIn("_splitIfOver(card, vehicle, joining, askToChain)", self.source)
-
-		# One nearby run: sized to that run, and offered BEFORE the confirm.
+		# One nearby run: merge-or-stand-alone is asked FIRST, because the answer decides
+		# which seats the card can have, and each answer then sizes its own split.
+		self.assertIn("if (!this._splitIfOver(card, vehicle, joining, chain)) {", self.source)
+		self.assertIn("if (!this._splitIfOver(card, vehicle, null, place)) {", self.source)
 		self.assertLess(
-			self.source.index("_splitIfOver(card, vehicle, joining, askToChain)"),
-			self.source.index("askToChain(card);"),
+			self.source.index("as the next stop on this trip?"),
+			self.source.index("_splitIfOver(card, vehicle, joining, chain)"),
 		)
 		# Several nearby runs: after the picker, for the run actually chosen.
 		self.assertIn("_splitIfOver(card, vehicle, selected.items, chain)", self.source)
@@ -190,17 +191,30 @@ class TestTheCanvasOffersTheSplit(FrappeTestCase):
 		self.assertIn("_splitIfOver(card, vehicle, null, place)", self.source)
 
 	def test_the_split_is_sized_on_the_seats_the_drop_can_have(self):
-		self.assertIn("_freeSeatsFor(vehicleId, joining)", self.source)
-		# The run's own load and the runs sharing its hours both take seats off.
-		self.assertIn("vehicleId, target ? target.occupancy : 0, { joining }", self.source)
-		self.assertIn("return Math.max(seats - total, 0);", self.source)
+		self.assertIn("_seatsAvailableFor(card, vehicleId, joining)", self.source)
+		# Asked the way the seat check asks it, not derived by subtraction - so the gate,
+		# the size the split keeps and the refusal downstream cannot disagree.
+		self.assertIn("this.mergedOccupancy(joining, { ...card, headcount })", self.source)
+		self.assertIn(").total <= seats;", self.source)
+		self.assertNotIn("return Math.max(seats - total, 0);", self.source)
 		# And the split keeps exactly that, rather than a whole busload.
 		self.assertIn("args: { shipment: self._shipmentOf(card), keep: free }", self.source)
 
-	def test_the_modal_states_the_free_seats_it_sized_on(self):
+	def test_the_largest_load_that_fits_is_found_not_guessed(self):
+		# Monotone in headcount, so a binary search lands on it exactly.
+		self.assertIn("let lo = 0, hi = card.headcount;", self.source)
+		self.assertIn("if (fits(mid)) lo = mid; else hi = mid - 1;", self.source)
+
+	def test_the_modal_states_the_seats_this_card_can_have(self):
 		# The number the dispatcher agrees to decides how many people are left behind.
-		self.assertIn("Already on {0}", self.source)
-		self.assertIn("Seats free on {0}", self.source)
+		self.assertIn("Seats this card can have on {0}", self.source)
+		# And never a "seats already taken" figure, which is a lie for a return card
+		# joining an outbound run - it boards what the outward load has left.
+		self.assertNotIn("Already on {0}", self.source)
+
+	def test_the_gate_and_the_modal_agree_on_one_number(self):
+		self.assertIn("{ joining, free, onSplit: next }", self.source)
+		self.assertIn("const free = opts.free != null", self.source)
 
 	def test_a_run_with_no_free_seat_says_so_instead_of_offering_a_split(self):
 		# keep must leave at least one rider on the card being placed.
@@ -232,3 +246,32 @@ class TestTheCanvasOffersTheSplit(FrappeTestCase):
 	def test_the_pool_marks_an_overflow_card(self):
 		self.assertIn("card.is_split_overflow", self.source)
 		self.assertIn("SPLIT OVERFLOW", self.source)
+
+
+class TestAReturnCardBoardsWhatTheOutwardLoadLeaves(FrappeTestCase):
+	"""A run that is full outbound can still take a return card (WI-002401).
+
+	The outward riders are off the bus before the returning ones get on, so how many
+	fit depends on WHEN they board - not on what is spare beside the run's peak.
+	Subtracting the peak answered zero seats and put a split, or a "No Seats Free", in
+	front of a merge that fits perfectly well. Exercised as arithmetic against the
+	shipped helpers by test_seat_rule.js; what is pinned here is that the rule is asked
+	the way the seat check asks it rather than re-derived.
+	"""
+
+	def setUp(self):
+		self.source = CANVAS.read_text()
+
+	def test_the_question_is_whether_the_merged_run_fits(self):
+		self.assertIn("const fits = (headcount) => this.seatLoad(", self.source)
+		self.assertIn("this.mergedOccupancy(joining, { ...card, headcount })", self.source)
+
+	def test_the_walk_is_the_one_the_seat_check_uses(self):
+		# mergedOccupancy walks the stops for a mixed run, which is what makes a
+		# returning load board the seats the outward one vacated.
+		self.assertIn("mergedOccupancy(stops, card) {", self.source)
+		self.assertIn("direction: this.runDirection(merged),", self.source)
+
+	def test_nothing_subtracts_the_runs_peak_any_more(self):
+		self.assertNotIn("seats - total", self.source)
+		self.assertNotIn("target ? target.occupancy : 0", self.source)


### PR DESCRIPTION
Two corrections to the split-decision work from #6884 / #6888.

## 1. The confirm comes before the split

Merge or stand alone is now the **first** question, because the answer decides which seats the card can have — the ones left on that run, or the whole bus.

Asking the split first meant a card could be trimmed to a run's free seats and then placed on **a run of its own anyway**, carrying fewer people than the bus could take. Each answer now sizes its own split:

```js
frappe.confirm(
    `… add … as the next stop on this trip?`,
    () => {                                   // Yes, merge
        const chain = (dropped) => this._chainToTrip(dropped, joining, vehicle.id);
        if (!this._splitIfOver(card, vehicle, joining, chain)) chain(card);
    },
    () => {                                   // No, a run of its own
        const place = (dropped) => this._doPlaceWithDialog(dropped, vehicle.id);
        if (!this._splitIfOver(card, vehicle, null, place)) place(card);
    }
);
```

The picker path is **unchanged** — with two or more runs nearby the split still waits for the pick, which is the only point the target is known.

## 2. A return card boards the seats the outward load has left

The outward riders are off the bus before the returning ones get on, so **a run that is full outbound can still carry a return card**. The sizing was a subtraction — the bus minus the run's peak minus the runs sharing its hours — which answered **zero** for exactly that case: a split modal in front of a merge that fits, or `No Seats Free` when the outbound legs filled the bus.

How many fit depends on **when** they board, so it cannot be derived by subtraction per direction shape. `_seatsAvailableFor` asks the question the way the seat check asks it and binary-searches the answer (monotone in headcount):

```js
const fits = (headcount) => this.seatLoad(
    vehicleId, this.mergedOccupancy(joining, { ...card, headcount }), { joining }
).total <= seats;
```

The gate, the number the split keeps, and the refusal downstream then cannot disagree whatever shape the run is — and the modal is handed that one number rather than recomputing it (`{ joining, free, onSplit }`).

The modal also no longer prints a **"seats already taken"** figure. It is a lie for a return card joining an outbound run: none of those seats are taken at the moment those riders get on. It states *"Seats this card can have on S-201"* instead.

## Verified against the shipped helpers

`test_seat_rule.js` reads `_seatsAvailableFor` / `_splitIfOver` / `mergedOccupancy` out of the `.js` file, so these are exercised rather than copied:

| scenario | 7-seat bus | result |
|---|---|---|
| run **full outbound** (7), return card of 3 | | **3 fit** — no split, no `No Seats Free` |
| same run, return card of 7 | | **7 fit** |
| same run, return card of 9 | | capped at **7**, split rather than refused |
| same run, **outbound** card of 3 | | **0** — those riders do share the bus |
| run with 4 out + 2 back, return card of 5 | | **5 fit** |
| same run, return card of 6 | | **5** — the sixth would make 8 |

## Tests

**19 modules green on `staging`** (568 tests) and re-run on this branch after the cherry-pick. Nothing else changed behaviour; three assertions in `test_overcapacity_card_split` were re-pointed from the old subtraction to the new predicate, and `assertNotIn("Already on {0}")` now guards the misleading row from coming back.

## Deploy

```
bench build --app one_fm
bench clear-cache
```

Client-side only. No schema change, no patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)