### PR TITLE
WI-002401: a run closes up over a stop it no longer makes

### DIFF
--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
@@ -1840,7 +1840,13 @@ function mountRoutePlannerApp(wrapper, data) {
             },
 
             tripEndsAt() {
-                return this.selectedTripLegs.arrival || this.lastStopEndsAt();
+                // The blocks first, the stored arrival only for a run that has none left
+                // to read. They are the same moment - a block ends when the bus reaches
+                // the next place, so the last one ends at the camp it goes home to - but
+                // the stored value is a copy, and a copy can be left behind by anything
+                // that shortens the run. That is what had a run that lost a stop still
+                // reading "13:00 -> 14:21 (81 min)" over blocks that ended at 14:11.
+                return this.lastStopEndsAt() || this.selectedTripLegs.arrival;
             },
 
             // A stored Time reads back as HH:MM:SS; the drawer shows clock times.
@@ -2895,15 +2901,89 @@ function mountRoutePlannerApp(wrapper, data) {
                 ]);
             },
 
+            // Take the time a departed stop was using back off the run (WI-002401).
+            //
+            // The bus no longer calls there, so everything it did afterwards happens that
+            // much earlier and the run is over that much sooner. Without this the blocks
+            // after the removed one kept their old positions, a hole was left where the
+            // stop had been, and the drawer went on reading the run's stored arrival - so
+            // a three-stop run that lost a stop still said "13:00 -> 14:21 (81 min)".
+            //
+            // The stops are MOVED rather than re-timed: _retimeTrip chains one stop after
+            // another, which would pull apart the two blocks of a combined stop (one visit
+            // where some riders get off and others get on) - they share a window on
+            // purpose. For the same reason nothing is freed while another stop still
+            // occupies the window: the bus is still standing there and there is no hole.
+            //
+            // The departure is left where it is. It is a decision the dispatcher typed
+            // into the Trip Builder, and the camp leg that follows it is unchanged; only
+            // the far end of the run moves.
+            _closeTripGap(tripId, removed) {
+                if (!tripId || !removed) return;
+                const from = new Date(removed.start).getTime();
+                const to = new Date(removed.end).getTime();
+                const held = (this.legTimings || {})[tripId];
+                const rest = this.swimItems.filter((i) => i.tripId === tripId);
+
+                if (!rest.length) {
+                    // Nothing left to time: the camp and home legs went with the run.
+                    if (held) {
+                        const legs = { ...this.legTimings };
+                        delete legs[tripId];
+                        this.legTimings = legs;
+                    }
+                    return;
+                }
+
+                const stillThere = rest.some((i) =>
+                    new Date(i.start).getTime() < to && new Date(i.end).getTime() > from);
+                const freed = to - from;
+                if (stillThere || freed <= 0) return;
+
+                rest.forEach((i) => {
+                    // Only what the bus had not reached yet; the stops before the hole
+                    // happened exactly as they did.
+                    if (new Date(i.start).getTime() < to) return;
+                    i.start = new Date(new Date(i.start).getTime() - freed);
+                    i.end = new Date(new Date(i.end).getTime() - freed);
+                });
+                this.swimItems = [...this.swimItems];
+
+                if (held && held.arrival) {
+                    // Read off the run rather than moved by the same offset: a block's
+                    // second moment is when the bus reaches the NEXT place, so the last
+                    // one already ends at the camp it goes home to - which is exactly
+                    // what the arrival is (verified: every run on the live plan agrees,
+                    // and the only one that did not was one a stop had been taken off).
+                    // Deriving it also repairs a run left drifted by an earlier removal.
+                    this.legTimings = {
+                        ...this.legTimings,
+                        [tripId]: { ...held, arrival: this._runEndsAt(rest) },
+                    };
+                }
+            },
+
+            // When the bus is back: the end of the last block on the run.
+            _runEndsAt(stops) {
+                if (!stops || !stops.length) return null;
+                return new Date(
+                    Math.max(...stops.map((i) => new Date(i.end).getTime()))
+                ).toISOString();
+            },
+
             removeSelectedFromLane() {
                 if (!this.selectedItem) return;
                 const itemId = this.selectedItem.id;
                 const cid = this.selectedItem.cardId;
                 const dir = this.selectedItem.direction;
+                const removed = this.selectedItem;
 
                 // Remove only the selected block, not both directions
                 const tripId = this.selectedItem.tripId;
                 this.swimItems = this.swimItems.filter(i => i.id !== itemId);
+
+                // The run closes up over the stop it no longer makes.
+                this._closeTripGap(tripId, removed);
 
                 // What is left of the run may now travel only one way (AC3).
                 this._resyncTripDirection(tripId);

--- a/one_fm/tests/test_the_lane_lays_out_the_run.py
+++ b/one_fm/tests/test_the_lane_lays_out_the_run.py
@@ -125,6 +125,126 @@ class TestTheRunWalksForward(FrappeTestCase):
 		self.assertEqual(placed["R"]["end"], "2026-08-18T18:30:00.000Z")
 
 
+def remove(items, removed_card, leg_timings=None):
+	"""Take `removed_card` off the run and hand back the blocks and the run's two ends."""
+	script = f"""
+	const close = function (tripId, removed) {_method('_closeTripGap', 'tripId, removed')};
+	const all = {json.dumps(items)};
+	all.forEach((i) => {{ i.start = new Date(i.start); i.end = new Date(i.end); }});
+	const gone = all.find((i) => i.cardId === {json.dumps(removed_card)});
+	const canvas = {{
+		swimItems: all.filter((i) => i !== gone),
+		legTimings: {json.dumps(leg_timings or {})},
+		_runEndsAt: function (stops) {_method('_runEndsAt', 'stops')},
+	}};
+	close.call(canvas, 'T1', gone);
+	console.log(JSON.stringify({{
+		blocks: canvas.swimItems.map((i) => ({{
+			cardId: i.cardId,
+			start: new Date(i.start).toISOString(), end: new Date(i.end).toISOString(),
+		}})),
+		legs: canvas.legTimings,
+	}}));
+	"""
+	out = subprocess.run(["node", "-e", script], capture_output=True, text=True, timeout=30)
+	if out.returncode:
+		raise AssertionError(out.stderr)
+	result = json.loads(out.stdout)
+	return {row["cardId"]: row for row in result["blocks"]}, result["legs"]
+
+
+class TestTheRunClosesOverAStopItNoLongerMakes(FrappeTestCase):
+	"""WI-002401: removing a card has to take its time off the run.
+
+	The blocks after the removed one used to keep their old positions - a hole was left
+	where the stop had been and the drawer went on reading the run's stored arrival, so a
+	three-stop run that lost a stop still read "13:00 -> 14:21 (81 min)".
+	"""
+
+	# A run of three stops, each block running from where the bus leaves that stop to
+	# where it reaches the next, and an arrival that is the end of the last one.
+	RUN = [
+		_block("A", 1, "2026-08-18T10:27:00Z", "2026-08-18T10:54:00Z", transit=25, buffer=2),
+		_block("B", 2, "2026-08-18T10:54:00Z", "2026-08-18T11:04:00Z", transit=10, buffer=0),
+		_block("C", 3, "2026-08-18T11:04:00Z", "2026-08-18T11:21:00Z", transit=15, buffer=2),
+	]
+	LEGS = {"T1": {
+		"departure": "2026-08-18T10:00:00Z", "arrival": "2026-08-18T11:21:00Z",
+		"home": {"place": "Mahboula Camp", "transit_minutes": 0, "buffer_minutes": 0},
+		"camps": {"Mahboula Camp": {"transit_minutes": 25, "buffer_minutes": 2}},
+	}}
+
+	def setUp(self):
+		if not shutil.which("node"):
+			self.skipTest("node is not on this machine")
+
+	def test_the_stops_after_it_move_up_by_what_it_was_using(self):
+		blocks, _ = remove(self.RUN, "B", self.LEGS)
+
+		# B was 10 minutes of the run; C now happens 10 minutes earlier.
+		self.assertEqual(blocks["A"]["end"], "2026-08-18T10:54:00.000Z")
+		self.assertEqual(blocks["C"]["start"], "2026-08-18T10:54:00.000Z")
+		self.assertEqual(blocks["C"]["end"], "2026-08-18T11:11:00.000Z")
+
+	def test_the_stops_before_it_are_left_alone(self):
+		blocks, _ = remove(self.RUN, "B", self.LEGS)
+
+		self.assertEqual(blocks["A"]["start"], "2026-08-18T10:27:00.000Z")
+
+	def test_the_run_is_over_that_much_sooner(self):
+		_, legs = remove(self.RUN, "B", self.LEGS)
+
+		self.assertEqual(legs["T1"]["arrival"], "2026-08-18T11:11:00.000Z")
+
+	def test_the_departure_the_dispatcher_typed_is_not_moved(self):
+		# It is a decision, and the camp leg that follows it is unchanged.
+		_, legs = remove(self.RUN, "B", self.LEGS)
+
+		self.assertEqual(legs["T1"]["departure"], "2026-08-18T10:00:00Z")
+		self.assertEqual(legs["T1"]["camps"], self.LEGS["T1"]["camps"])
+
+	def test_losing_the_first_stop_shortens_the_run_rather_than_delaying_it(self):
+		blocks, legs = remove(self.RUN, "A", self.LEGS)
+
+		self.assertEqual(blocks["B"]["start"], "2026-08-18T10:27:00.000Z")
+		self.assertEqual(legs["T1"]["arrival"], "2026-08-18T10:54:00.000Z")
+
+	def test_losing_the_last_stop_ends_the_run_where_the_one_before_it_does(self):
+		blocks, legs = remove(self.RUN, "C", self.LEGS)
+
+		self.assertEqual(blocks["B"]["end"], "2026-08-18T11:04:00.000Z")
+		self.assertEqual(legs["T1"]["arrival"], "2026-08-18T11:04:00.000Z")
+
+	def test_a_combined_stop_keeps_its_window_when_one_of_its_cards_goes(self):
+		# One visit where some riders get off and others get on: both cards are drawn on
+		# the same window on purpose. The bus is still standing there, so no time is
+		# freed and nothing after it may move.
+		run = self.RUN + [
+			_block("B2", 4, "2026-08-18T10:54:00Z", "2026-08-18T11:04:00Z", transit=10, buffer=0),
+		]
+
+		blocks, legs = remove(run, "B", self.LEGS)
+
+		self.assertEqual(blocks["B2"]["start"], "2026-08-18T10:54:00.000Z")
+		self.assertEqual(blocks["C"]["start"], "2026-08-18T11:04:00.000Z")
+		self.assertEqual(legs["T1"]["arrival"], "2026-08-18T11:21:00Z")
+
+	def test_an_arrival_left_drifted_by_an_earlier_removal_is_repaired(self):
+		# Read off the run rather than moved by the offset, so a run that was already
+		# wrong comes back right instead of staying wrong by the same amount.
+		drifted = {"T1": dict(self.LEGS["T1"], arrival="2026-08-18T11:31:00Z")}
+
+		_, legs = remove(self.RUN, "B", drifted)
+
+		self.assertEqual(legs["T1"]["arrival"], "2026-08-18T11:11:00.000Z")
+
+	def test_the_last_stop_off_a_run_takes_the_runs_timings_with_it(self):
+		# Nothing left to time: the camp and home legs belonged to a run that is gone.
+		_, legs = remove([self.RUN[0]], "A", self.LEGS)
+
+		self.assertNotIn("T1", legs)
+
+
 class TestTheDrawerReadsTheRunInOrder(FrappeTestCase):
 	"""The stops are listed in the order the bus drives them, and the run's two ends
 	are the moment it leaves the camp and the moment it gets back.
@@ -147,7 +267,10 @@ class TestTheDrawerReadsTheRunInOrder(FrappeTestCase):
 		self.assertIn("{{ fmtISO(tripStartsAt()) }}", self.source)
 
 	def test_the_timeline_ends_when_the_bus_is_back(self):
-		self.assertIn("return this.selectedTripLegs.arrival || this.lastStopEndsAt();", self.source)
+		# The blocks say when that is; the stored arrival is a copy of the same moment and
+		# is only read when there are no blocks left to read (WI-002401). The copy is what
+		# had a run that lost a stop still reading its old, longer total.
+		self.assertIn("return this.lastStopEndsAt() || this.selectedTripLegs.arrival;", self.source)
 
 	def test_the_drive_out_of_the_camp_is_shown_before_the_first_stop(self):
 		# The timeline began at 06:45 and the first stop at 07:15, and the half hour

--- a/one_fm/tests/test_transportation_seat_rule.py
+++ b/one_fm/tests/test_transportation_seat_rule.py
@@ -143,8 +143,12 @@ class TestTheRunIsDrawnEndToEnd(FrappeTestCase):
 		self.assertIn("end: runEnd,", self.source)
 
 	def test_the_drawer_header_reads_the_same_two_ends(self):
+		# The departure is a decision nothing on the lane records, so it is read from what
+		# was stored. The arrival IS on the lane - it is where the last block ends - and
+		# the stored copy is only fallen back to when no block is left to read, so a run
+		# that loses a stop cannot go on showing the total it had before (WI-002401).
 		self.assertIn("const stored = this.selectedTripLegs.departure;", self.source)
-		self.assertIn("return this.selectedTripLegs.arrival || this.lastStopEndsAt();", self.source)
+		self.assertIn("return this.lastStopEndsAt() || this.selectedTripLegs.arrival;", self.source)
 
 	def test_the_existing_trips_list_shows_every_run_on_the_lane(self):
 		# AC1: filtering to OUTBOUND hid the return runs the new trip has to fit around,


### PR DESCRIPTION
### What was reported

> I realized that when I removed a card, the timing on the timeline doesn't adjust accordingly.

S-105, straight after a card was removed from it:

| | |
|---|---|
| blocks on the lane | 13:27 → 14:11 |
| drawer header | **13:00 → 14:21 (81 min)** |
| stored arrival | 14:21 — ten minutes past the last block |

The removed stop's ten minutes were still counted, and the hole it left was still on the lane.

### Why

`removeSelectedFromLane` took the block out and stopped there. Nothing moved the stops that came after it, and nothing touched the run's stored arrival — which is what the drawer header and the width of the block on the lane are both read from.

### The fix

`_closeTripGap(tripId, removed)`: the bus no longer calls there, so everything it did afterwards happens that much earlier and the run is over that much sooner.

* The stops are **moved**, not re-timed. `_retimeTrip` chains one stop after another, which would pull apart the two blocks of a **combined stop** — one visit where some riders get off and others get on — that share a window on purpose.
* For the same reason **nothing is freed while another stop still occupies the window**: the bus is still standing there and there is no hole to close. Removing one card of a combined stop moves nothing.
* The **departure is left alone**. It is a decision the dispatcher typed into the Trip Builder, and the camp leg that follows it is unchanged; only the far end of the run moves.
* Losing the **first** stop shortens the run rather than delaying it — the second stop moves up to where the first one was.
* The **last** card off a run takes the run's camp and home leg timings with it.

The arrival is read off the run rather than shifted by the same offset, and `tripEndsAt()` now reads the blocks first, falling back to the stored arrival only when no block is left to read. They are the same moment — a block ends when the bus reaches the *next* place, so the last one ends at the camp it goes home to. Verified against the live plan: every run with a stored arrival agrees with its last block, and the only one that did not was S-105, the run a stop had been taken off. Deriving it therefore **repairs a run left drifted by an earlier removal** instead of keeping it wrong by the same amount — including the block width on the lane, which is clamped to the same stored arrival.

### Not touched

`mergeSelectedBlock` is the other place a block leaves a run, and it cannot leave a hole: it refuses anything that is already part of a trip (`if (!this.selectedItem || this.selectedItem.tripId) return;`).

### Tests

`one_fm/tests/test_the_lane_lays_out_the_run.py` — nine new cases, run in node against the method lifted out of the shipped `.js` so they cannot drift from what ships: the stops after it move up by what it was using, the stops before it are left alone, the run is over that much sooner, the departure is not moved, first-stop and last-stop removal, a combined stop keeping its window, a drifted arrival being repaired, and the last card taking the run's timings with it. Both mutants (dropping the combined-stop guard, not shifting the later stops) are caught.

Two assertions that pinned the old `tripEndsAt()` re-pointed with their intent kept (`test_the_lane_lays_out_the_run`, `test_transportation_seat_rule`).

Full transportation suite green — 258 tests across 13 modules, plus `node test_seat_rule.js`. `test_manifest_mixed_ui` has one failure that is pre-existing and unrelated (confirmed by stashing this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)