### PR TITLE
fix(amp): point demo email patch at WI-001328 and self-test recipient

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -537,7 +537,7 @@ one_fm.patches.v15_0.seed_app_services
 one_fm.patches.v15_0.set_candidate_title_fields
 one_fm.patches.v15_0.update_attendance_check
 one_fm.patches.v15_0.update_employee_and_user_references
-one_fm.patches.v15_0.send_work_item_notify_assignee_demo_email #2026-08-18
+one_fm.patches.v15_0.send_work_item_notify_assignee_demo_email #2026-09-11
 one_fm.patches.v15_0.mark_present_auto_attendance_missed_checkin_jul13
 one_fm.patches.v15_0.add_employee_schedule_suspension_workflow #2026-07-24
 one_fm.patches.v15_0.add_accommodation_leave_movement_assignment_rules #2026-07-30

--- a/one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py
+++ b/one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py
@@ -6,22 +6,19 @@ SENDER = "notifications@one-fm.com"
 # https://amp.dev/documentation/guides-and-tutorials/start/email_sender_distribution)
 # — Gmail and Yahoo/Verizon Media require a production-ready AMP email sent
 # directly to these addresses as part of allowlisting one-fm.com as a sender.
+# Self-test run: deliver to our own inbox only. Restore the registration
+# addresses once the Gmail developer-settings check passes.
 RECIPIENTS = [
-	"ampforemail.whitelisting@gmail.com",
-	"ampverification@yahoo.com",
+	"notifications@one-fm.com",
+	# "ampforemail.whitelisting@gmail.com",
+	# "ampverification@yahoo.com",
 ]
 
-# Real, live BPMN Process Instance task for WI-001663's "Start Work" step —
-# not a synthetic demo. Confirmed via both the instance's `workflow_state`
-# (task state 16 = READY) and its `active_tasks` child table (status
-# "Waiting", task_name "Start Work"). Must stay in READY (16) or WAITING (8)
-# state at the time this runs; look these up fresh from the BPMN Process
-# Instance's `workflow_state` (not the older, possibly-stale
-# `serialized_spec`) if reusing this pattern for a different task.
-INSTANCE_NAME = "orj9cj8ajr"
-TASK_ID = "bb085897-1b90-488a-836a-846672b4aacd"
-WORK_ITEM_ID = "WI-001663"
-WORK_ITEM_TITLE = "Refactor AI Model, AI Provider and AI Model pricing doctype"
+# Real, live Work Item whose "Start Work" user task is waiting in its BPMN
+# Process Instance. The instance and task id are looked up at run time from
+# `BPMN Active Task` so the token always matches the live task.
+WORK_ITEM_ID = "WI-001328"
+TASK_NAME = "Start Work"
 
 # The task's real assignee — the token must be issued for this user (not
 # RECIPIENTS) since handle_amp_action checks it against the task's actual
@@ -32,34 +29,22 @@ ASSIGNEE_USER = "k.sharma@one-fm.com"
 
 def execute():
 	"""One-time trigger: send a real "Start Work" notification email — tied
-	to the actual live BPMN task for WI-001663 — from
-	notifications@one-fm.com to Gmail's and Yahoo/Verizon Media's AMP for
-	Email sender-registration addresses, as the "production-ready AMP email"
-	submission required by their allowlisting process, through the actual
-	production sending pipeline.
+	to the actual live BPMN task for WORK_ITEM_ID — from
+	notifications@one-fm.com to RECIPIENTS, through the actual production
+	sending pipeline.
 
 	The email's "Start Work" action is a genuine one-click AMP action tied
-	to a real, live BPMN Process Instance task — not a static registry
-	entry. Work Item's "Start Work" step is a `userTask` inside the
-	"Software Development v3" BPMN process (see
-	`one_bpmn.api.bpmn_task_actions.handle_amp_action`), so the token is
-	generated the same way the engine itself would
+	to a real, live BPMN Process Instance task. The token is generated the
+	same way the engine itself would
 	(`one_bpmn.utils.token.generate_action_token`, keyed on `instance_name`
-	+ `task_id`) — not `generate_doc_action_token` + the
-	`amp_workflow_actions` static allowlist, which is reserved for
-	documents with no BPMN engine behind them at all. Clicking the button
-	calls `complete_task` on the real Process Instance, genuinely advancing
-	it — a deliberate, confirmed side effect for this specific task, for
-	whoever actually clicks it (the token is issued to ASSIGNEE_USER, not
-	RECIPIENTS — so a reviewer at Gmail/Yahoo clicking "Start Work" during
-	their allowlisting review would genuinely complete this production task).
+	+ `task_id`). Clicking the button calls `complete_task` on the real
+	Process Instance, genuinely advancing it — a deliberate, confirmed side
+	effect for this specific task, for whoever actually clicks it.
 
 	This runs automatically, once, the first time `bench migrate` executes
 	on any site with this patch present (Frappe's Patch Log ensures it
-	never re-runs after that) — including production, which is the whole
-	point: the SMTP connection needs to originate from production's
-	registered IP for Google Workspace's SMTP relay to accept it, and
-	`bench migrate` is the one thing guaranteed to execute there.
+	never re-runs after that). Bump the date comment in patches.txt to
+	re-run it.
 
 	Deliberately does not raise — a transient email/SMTP failure must
 	never block or fail a production migration. Check the Email Queue
@@ -69,9 +54,46 @@ def execute():
 		send()
 	except Exception:
 		frappe.log_error(
-			title="WI-001663 Start Work AMP notify failed",
+			title=f"{WORK_ITEM_ID} Start Work AMP notify failed",
 			message=frappe.get_traceback(),
 		)
+
+
+def _find_live_task() -> tuple[str, str]:
+	"""Return (instance_name, task_id) of the waiting TASK_NAME task for WORK_ITEM_ID."""
+	instances = frappe.get_all(
+		"BPMN Process Instance",
+		filters={"context_doctype": "Work Item", "context_docname": WORK_ITEM_ID},
+		pluck="name",
+	)
+	if not instances:
+		frappe.throw(
+			_("No BPMN Process Instance found for Work Item {0}.").format(WORK_ITEM_ID),
+			frappe.ValidationError,
+		)
+
+	task = frappe.get_all(
+		"BPMN Active Task",
+		filters={
+			"parent": ["in", instances],
+			"task_name": TASK_NAME,
+			"status": "Waiting",
+		},
+		fields=["parent", "task_id"],
+		limit=1,
+	)
+	if not task:
+		frappe.throw(
+			_("No waiting '{0}' task found for Work Item {1} (instances: {2}).").format(
+				TASK_NAME, WORK_ITEM_ID, ", ".join(instances)
+			),
+			frappe.ValidationError,
+		)
+	return task[0].parent, task[0].task_id
+
+
+def _yes_no(value) -> str:
+	return "Yes" if frappe.utils.cint(value) else "No"
 
 
 def send():
@@ -92,35 +114,40 @@ def send():
 	from one_bpmn.email_builder.renderer import render_amp, render_html_fallback
 	from one_bpmn.email_builder.email_actions import build_email_actions
 
+	instance_name, task_id = _find_live_task()
+	wi = frappe.get_doc("Work Item", WORK_ITEM_ID)
+	epic_title = frappe.db.get_value("Work Item", wi.epic, "title") if wi.epic else ""
+
 	work_item_url = f"https://one-fm.com/app/work-item/{WORK_ITEM_ID}"
-	title = f"[{WORK_ITEM_ID}] Assigned to you: {WORK_ITEM_TITLE} (Medium priority)"
+	title = f"[{WORK_ITEM_ID}] Assigned to you: {wi.title} ({wi.priority} priority)"
+	sprint = f"{wi.sprint} ({wi.sprint_status})" if wi.sprint_status else (wi.sprint or "")
 
 	body = f"""
-<p style="margin:1em 0!important">Hi,</p>
-<p style="margin:1em 0!important">A work item has been assigned to you and is ready to start.</p>
+<p>Hi,</p>
+<p>A work item has been assigned to you and is ready to start.</p>
 <table cellpadding="6" border="0">
 <tbody>
-<tr><td><b>Work Item</b></td><td>{WORK_ITEM_ID} &mdash; {WORK_ITEM_TITLE}</td></tr>
-<tr><td><b>Type</b></td><td>User Story</td></tr>
-<tr><td><b>Priority</b></td><td>Medium</td></tr>
-<tr><td><b>Sprint</b></td><td>AI-017 (Active)</td></tr>
-<tr><td><b>Story Points</b></td><td>3</td></tr>
-<tr><td><b>Epic</b></td><td>Processa</td></tr>
-<tr><td><b>Reported By</b></td><td><a href="mailto:k.sharma@one-fm.com">k.sharma@one-fm.com</a></td></tr>
-<tr><td><b>PR Required</b></td><td>No</td></tr>
-<tr><td><b>Research Required</b></td><td>No</td></tr>
+<tr><td><b>Work Item</b></td><td>{WORK_ITEM_ID} &mdash; {frappe.utils.escape_html(wi.title)}</td></tr>
+<tr><td><b>Type</b></td><td>{wi.work_item_type or ""}</td></tr>
+<tr><td><b>Priority</b></td><td>{wi.priority or ""}</td></tr>
+<tr><td><b>Sprint</b></td><td>{sprint}</td></tr>
+<tr><td><b>Story Points</b></td><td>{wi.story_points or ""}</td></tr>
+<tr><td><b>Epic</b></td><td>{frappe.utils.escape_html(epic_title or wi.epic or "")}</td></tr>
+<tr><td><b>Reported By</b></td><td><a href="mailto:{wi.reporter_user}">{wi.reporter_user}</a></td></tr>
+<tr><td><b>PR Required</b></td><td>{_yes_no(wi.pr_required)}</td></tr>
+<tr><td><b>Research Required</b></td><td>{_yes_no(wi.research_required)}</td></tr>
 </tbody>
 </table>
-<p style="margin:1em 0!important"><b>Description</b><br></p>
-<p style="margin:0!important">{WORK_ITEM_TITLE}</p>
+<p><b>Description</b></p>
+{wi.description or ""}
 """.strip()
 
 	# Real BPMN-instance-tied token — the same mechanism
 	# compose_and_send_task_email uses for every other task action.
 	actions = build_email_actions(
-		instance_name=INSTANCE_NAME,
-		task_id=TASK_ID,
-		actions=[{"label": "Start Work", "primary": True}],
+		instance_name=instance_name,
+		task_id=task_id,
+		actions=[{"label": TASK_NAME, "primary": True}],
 		user=ASSIGNEE_USER,
 	)
 
@@ -131,13 +158,12 @@ def send():
 		"open_link": work_item_url,
 		"doctype": "Work Item",
 		"name": WORK_ITEM_ID,
-		"action_endpoint": "https://one-fm.com/api/method/one_bpmn.api.bpmn_task_actions.handle_amp_action",
 	}
 	amp_html = render_amp(task_content)
 	html_body = render_html_fallback(task_content)
 
 	frappe.flags.amp_html = amp_html
-	email_queue = frappe.sendmail(
+	frappe.sendmail(
 		recipients=RECIPIENTS,
 		sender=SENDER,
 		subject=title,


### PR DESCRIPTION
## Purpose

Re-run the AMP for Email registration sample as a self-test before resubmitting to Google. Google rejected the first submission because the email pointed at a removed endpoint and its token expired before review. The one_bpmn fixes are in ONE-F-M/one_bpmn#740, #741 and #742. This patch sends the sample through the fixed pipeline.

## Changes

`one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py`

- Work Item is `WI-001328`. The BPMN Process Instance and the waiting "Start Work" `BPMN Active Task` are looked up at run time (`_find_live_task`) instead of hardcoding instance and task ids. If no task is waiting, the patch logs a clear error and sends nothing rather than sending a dead token.
- Body is built from the `Work Item` document (title, type, priority, sprint and status, story points, epic title, reporter, PR and research flags, description). No pasted copy.
- Removed the hardcoded `action_endpoint` pointing at `one_bpmn.api.bpmn_task_actions.handle_amp_action`. That module no longer exists on production and was the cause of the CORS failure Google saw. The renderer default `todo_actions` is the live endpoint.
- `RECIPIENTS` is `notifications@one-fm.com` only. The Gmail and Yahoo registration addresses stay in the file, commented out, for the real submission run.
- Removed inline `style` attributes from the body. The AMP sanitizer strips them anyway.

`one_fm/patches.txt`

- Date comment bumped to `#2026-09-11` so `bench migrate` runs the patch once more.

## Verification

- Rendered the WI-001328 body (Quill description with `<h3><a rel="noopener noreferrer">`, table, mailto link) through `render_amp` and validated with `amphtml-validator --html_format AMP4EMAIL`: PASS.
- Fieldnames confirmed against `frappe_agile` Work Item and `one_bpmn` BPMN Process Instance / BPMN Active Task JSON.

## Deploy order

1. Merge and deploy ONE-F-M/one_bpmn#742 first. The patch renders through that template.
2. Confirm WI-001328 has a waiting "Start Work" task on production.
3. `bench migrate`, then check Email Queue for the message to `notifications@one-fm.com`.
4. Test in Gmail with `notifications@one-fm.com` allowlisted under Dynamic email developer settings: open, click, reopen.
5. For the real submission: restore the commented recipients, bump the date again, redeploy.
