### PR TITLE
fix(amp): render whole-number story points without trailing .0

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -537,7 +537,7 @@ one_fm.patches.v15_0.seed_app_services
 one_fm.patches.v15_0.set_candidate_title_fields
 one_fm.patches.v15_0.update_attendance_check
 one_fm.patches.v15_0.update_employee_and_user_references
-one_fm.patches.v15_0.send_work_item_notify_assignee_demo_email #2026-09-11
+one_fm.patches.v15_0.send_work_item_notify_assignee_demo_email #2026-09-11-2
 one_fm.patches.v15_0.mark_present_auto_attendance_missed_checkin_jul13
 one_fm.patches.v15_0.add_employee_schedule_suspension_workflow #2026-07-24
 one_fm.patches.v15_0.add_accommodation_leave_movement_assignment_rules #2026-07-30

--- a/one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py
+++ b/one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py
@@ -131,7 +131,7 @@ def send():
 <tr><td><b>Type</b></td><td>{wi.work_item_type or ""}</td></tr>
 <tr><td><b>Priority</b></td><td>{wi.priority or ""}</td></tr>
 <tr><td><b>Sprint</b></td><td>{sprint}</td></tr>
-<tr><td><b>Story Points</b></td><td>{wi.story_points or ""}</td></tr>
+<tr><td><b>Story Points</b></td><td>{frappe.utils.flt(wi.story_points):g}</td></tr>
 <tr><td><b>Epic</b></td><td>{frappe.utils.escape_html(epic_title or wi.epic or "")}</td></tr>
 <tr><td><b>Reported By</b></td><td><a href="mailto:{wi.reporter_user}">{wi.reporter_user}</a></td></tr>
 <tr><td><b>PR Required</b></td><td>{_yes_no(wi.pr_required)}</td></tr>

--- a/one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py
+++ b/one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py
@@ -17,7 +17,7 @@ RECIPIENTS = [
 # Real, live Work Item whose "Start Work" user task is waiting in its BPMN
 # Process Instance. The instance and task id are looked up at run time from
 # `BPMN Active Task` so the token always matches the live task.
-WORK_ITEM_ID = "WI-001328"
+WORK_ITEM_ID = "WI-002492"
 TASK_NAME = "Start Work"
 
 # The task's real assignee — the token must be issued for this user (not


### PR DESCRIPTION
## Problem

The WI-001328 demo email rendered "Story Points 5.0". The value is a Float field written straight into the body.

## Change

`one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py`: format story points with `:g`, so `5.0` renders `5`, `2.5` stays `2.5`, empty renders `0`.

The patch date in `patches.txt` is unchanged, so this does not re-send on its own. Bump the date when the next send is wanted.

Follows #6895.
