### PR TITLE
fix(amp): send registration sample for WI-002493 to Gmail and Yahoo

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -537,7 +537,7 @@ one_fm.patches.v15_0.seed_app_services
 one_fm.patches.v15_0.set_candidate_title_fields
 one_fm.patches.v15_0.update_attendance_check
 one_fm.patches.v15_0.update_employee_and_user_references
-one_fm.patches.v15_0.send_work_item_notify_assignee_demo_email #2026-09-11-2
+one_fm.patches.v15_0.send_work_item_notify_assignee_demo_email #2026-09-11-3
 one_fm.patches.v15_0.mark_present_auto_attendance_missed_checkin_jul13
 one_fm.patches.v15_0.add_employee_schedule_suspension_workflow #2026-07-24
 one_fm.patches.v15_0.add_accommodation_leave_movement_assignment_rules #2026-07-30

--- a/one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py
+++ b/one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py
@@ -6,18 +6,15 @@ SENDER = "notifications@one-fm.com"
 # https://amp.dev/documentation/guides-and-tutorials/start/email_sender_distribution)
 # — Gmail and Yahoo/Verizon Media require a production-ready AMP email sent
 # directly to these addresses as part of allowlisting one-fm.com as a sender.
-# Self-test run: deliver to our own inbox only. Restore the registration
-# addresses once the Gmail developer-settings check passes.
 RECIPIENTS = [
-	"notifications@one-fm.com",
-	# "ampforemail.whitelisting@gmail.com",
-	# "ampverification@yahoo.com",
+	"ampforemail.whitelisting@gmail.com",
+	"ampverification@yahoo.com",
 ]
 
 # Real, live Work Item whose "Start Work" user task is waiting in its BPMN
 # Process Instance. The instance and task id are looked up at run time from
 # `BPMN Active Task` so the token always matches the live task.
-WORK_ITEM_ID = "WI-002492"
+WORK_ITEM_ID = "WI-002493"
 TASK_NAME = "Start Work"
 
 # The task's real assignee — the token must be issued for this user (not
@@ -119,7 +116,7 @@ def send():
 	epic_title = frappe.db.get_value("Work Item", wi.epic, "title") if wi.epic else ""
 
 	work_item_url = f"https://one-fm.com/app/work-item/{WORK_ITEM_ID}"
-	title = f"[{WORK_ITEM_ID}] Assigned to you: {wi.title} ({wi.priority} priority)"
+	title = f"Assigned: {wi.title}"
 	sprint = f"{wi.sprint} ({wi.sprint_status})" if wi.sprint_status else (wi.sprint or "")
 
 	body = f"""

--- a/one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py
+++ b/one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py
@@ -9,6 +9,7 @@ SENDER = "notifications@one-fm.com"
 RECIPIENTS = [
 	"ampforemail.whitelisting@gmail.com",
 	"ampverification@yahoo.com",
+	"notifications@one-fm.com"
 ]
 
 # Real, live Work Item whose "Start Work" user task is waiting in its BPMN


### PR DESCRIPTION
## Purpose

Send the AMP for Email registration sample to Google and Yahoo through the fixed pipeline (ONE-F-M/one_bpmn#740, #741, #742, #743). #6896 merged before this commit was pushed, so `version-15` still holds the WI-002492 self-test that goes to `notifications@one-fm.com`.

## Changes

`one_fm/patches/v15_0/send_work_item_notify_assignee_demo_email.py`

- `RECIPIENTS`: `ampforemail.whitelisting@gmail.com` and `ampverification@yahoo.com`. Self-test inbox removed. Sender stays `notifications@one-fm.com`.
- Subject is `Assigned: <work item title>`.
- `WORK_ITEM_ID` is `WI-002493`, a fresh Work Item whose "Start Work" task is waiting. Instance and task id are looked up at run time.

`one_fm/patches.txt`

- Marker `#2026-09-11-3`, so `bench migrate` sends once.

## Before merging

1. ONE-F-M/one_bpmn#743 deployed first (`bench restart`) so the completed badge fixes are in the sent email.
2. Confirm WI-002493 has a waiting "Start Work" task on production:
   ```
   bench --site one-fm.com execute frappe.get_all --kwargs '{"doctype":"BPMN Process Instance","filters":{"context_doctype":"Work Item","context_docname":"WI-002493"},"fields":["name","status"]}'
   ```
   If empty, the patch logs "WI-002493 Start Work AMP notify failed" and sends nothing.
3. Nobody clicks "Start Work" on WI-002493 until Google has reviewed.

After `bench migrate`, check Email Queue for both recipients, then submit the Gmail registration form.
