### PR TITLE
WI-002447: offer the four hiring windows on Urgency of Hire

### DIFF
--- a/one_fm/one_fm/doctype/erf/erf.json
+++ b/one_fm/one_fm/doctype/erf/erf.json
@@ -1046,7 +1046,7 @@
    "fieldname": "urgency_of_hire",
    "label": "Urgency of Hire",
    "fieldtype": "Select",
-   "options": "\nHire Now"
+   "options": "\nUrgent (30 days)\nHigh (1-2 months)\nMedium (2-3 months)\nLow (Above 3 months)"
   }
  ],
  "is_submittable": 1,

--- a/one_fm/one_fm/doctype/erf/test_erf_doctype_config.py
+++ b/one_fm/one_fm/doctype/erf/test_erf_doctype_config.py
@@ -41,10 +41,28 @@ class TestERFReasonForRequest(FrappeTestCase):
 
 
 class TestERFFieldConfiguration(FrappeTestCase):
-	def test_urgency_of_hire_exists(self):
+	def test_urgency_of_hire_offers_the_four_windows(self):
+		"""WI-002447: the analyst replaced the single "Hire Now" with the four hiring
+		windows below. Read off the meta, so a Property Setter that overrode the file
+		would fail here rather than silently on the form."""
 		field = _field("urgency_of_hire")
 		self.assertEqual(field.fieldtype, "Select")
-		self.assertEqual(field.options.split("\n"), ["", "Hire Now"])
+		self.assertEqual(
+			field.options.split("\n"),
+			[
+				"",
+				"Urgent (30 days)",
+				"High (1-2 months)",
+				"Medium (2-3 months)",
+				"Low (Above 3 months)",
+			],
+		)
+
+	def test_no_erf_is_left_carrying_the_retired_option(self):
+		""""Hire Now" is no longer offered, and a Select value that is no longer an option
+		fails Frappe's own validation on the next save - a workflow action saves the
+		document, so such an ERF would become unactionable."""
+		self.assertEqual(frappe.db.count("ERF", {"urgency_of_hire": "Hire Now"}), 0)
 
 	def test_expected_date_of_deployment_is_optional(self):
 		self.assertFalse(_field("expected_date_of_deployment").reqd)


### PR DESCRIPTION
## What

The analyst replaced the single `Hire Now` option on **ERF → Urgency of Hire** with the four windows the business plans against. Taken verbatim from the ERF DocType on the BA site, spacing and casing included:

- `Urgent (30 days)`
- `High (1-2 months)`
- `Medium (2-3 months)`
- `Low (Above 3 months)`

## Why it is safe

No data migration. `urgency_of_hire` is blank on all 373 ERFs here and the field does not exist on production yet, so no record is left carrying a value the Select no longer offers — which would fail Frappe's own validation on the next save, and a workflow action saves the document. The new test guards that for the day one does.

## Testing

`bench run-tests --module one_fm.one_fm.doctype.erf.test_erf_doctype_config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)