### PR TITLE
WI-002448: give PAM License Details its LG Details section

### DIFF
--- a/one_fm/grd/doctype/pam_license_details/pam_license_details.json
+++ b/one_fm/grd/doctype/pam_license_details/pam_license_details.json
@@ -16,6 +16,10 @@
   "label_name",
   "classification",
   "status",
+  "lg_details_section",
+  "lg_number",
+  "column_break_mtwm",
+  "lg_expiry_date",
   "pam_stats_section",
   "pam_license_stats"
  ],
@@ -81,6 +85,25 @@
    "in_list_view": 1,
    "label": "Status",
    "options": "\nNot suspended\nDetained\nInactive"
+  },
+  {
+   "fieldname": "lg_details_section",
+   "fieldtype": "Section Break",
+   "label": "LG Details"
+  },
+  {
+   "fieldname": "lg_number",
+   "fieldtype": "Data",
+   "label": "LG Number"
+  },
+  {
+   "fieldname": "column_break_mtwm",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "lg_expiry_date",
+   "fieldtype": "Date",
+   "label": "LG Expiry Date"
   },
   {
    "fieldname": "pam_stats_section",

--- a/one_fm/grd/doctype/pam_license_details/test_pam_license_configuration.py
+++ b/one_fm/grd/doctype/pam_license_details/test_pam_license_configuration.py
@@ -67,6 +67,42 @@ class TestPAMLicenseConfiguration(FrappeTestCase):
 			with self.subTest(fieldname=fieldname):
 				self.assertTrue(meta.get_field(fieldname).read_only)
 
+	def test_the_lg_section_is_on_the_form(self):
+		"""WI-002448: the LG Details section the analyst added, and the two fields in it.
+
+		The section is asserted as well as the fields: a Data and a Date sitting loose
+		somewhere on the form would pass a field-only check while the form still looked
+		nothing like the BA site's.
+		"""
+		meta = frappe.get_meta("PAM License Details")
+
+		section = meta.get_field("lg_details_section")
+		self.assertIsNotNone(section, "PAM License Details has no LG Details section")
+		self.assertEqual(section.fieldtype, "Section Break")
+		self.assertEqual(section.label, "LG Details")
+
+		for fieldname, fieldtype, label in (
+			("lg_number", "Data", "LG Number"),
+			("lg_expiry_date", "Date", "LG Expiry Date"),
+		):
+			with self.subTest(fieldname=fieldname):
+				field = meta.get_field(fieldname)
+				self.assertIsNotNone(field, f"PAM License Details has no {fieldname}")
+				self.assertEqual(field.fieldtype, fieldtype)
+				self.assertEqual(field.label, label)
+
+		order = [field.fieldname for field in meta.fields]
+		self.assertLess(
+			order.index("lg_details_section"),
+			order.index("lg_number"),
+			"LG Number is not inside the LG Details section",
+		)
+		self.assertLess(
+			order.index("lg_expiry_date"),
+			order.index("pam_stats_section"),
+			"the LG fields spill past the LG Details section into PAM Stats",
+		)
+
 	def test_the_pam_file_tracks_its_licenses(self):
 		meta = frappe.get_meta("PAM File")
 		for fieldname in ("file_status", "number_of_active_licenses", "number_of_inactive_licenses"):


### PR DESCRIPTION
## What

The analyst added an **LG Details** section to the PAM License Details DocType on the BA site, holding the letter of guarantee's number and expiry date. Brought over verbatim — fieldnames, labels and the column break included — and placed where the BA site puts it, between `status` and `pam_stats_section`:

| field | type | label |
|---|---|---|
| `lg_details_section` | Section Break | LG Details |
| `lg_number` | Data | LG Number |
| `column_break_mtwm` | Column Break | — |
| `lg_expiry_date` | Date | LG Expiry Date |

## Note

Nothing else on the DocType is touched. The BA copy has no leading "PAM License Details" section break, which this one has always had; that is a difference in the shipped layout rather than something the story asks to change, so it stays.

WI-002449 (the one-week LG expiry notification that reads `lg_expiry_date`) is **not** in this PR — it is parked pending a decision on who the recipients are.

## Testing

`bench run-tests --module one_fm.grd.doctype.pam_license_details.test_pam_license_configuration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)