### PR TITLE
WI-002437: let a double shift reach the approver, and stop showing it once it has been refused

### DIFF
--- a/one_fm/one_fm/page/roster/employee_map.py
+++ b/one_fm/one_fm/page/roster/employee_map.py
@@ -19,6 +19,36 @@ def get_workflow_state_select():
 	return "NULL as workflow_state"
 
 
+# WI-002437: the two states an Employee Schedule is in when it is not a shift anybody is
+# working. A double shift waiting on the DSOT Approver is not one yet, and a rejected one
+# never will be - the hours are gone, whether it was refused outright or nobody answered
+# before the shift ended.
+#
+# Only the DSOT flow reaches either: the workflow's Rejected state has one way in, from
+# Pending DSOT Approval, so the suspension flow this shares a workflow with is untouched.
+NOT_A_WORKED_SHIFT = ("Pending DSOT Approval", "Rejected")
+
+
+def get_schedule_state_filter():
+	"""WHERE fragment that keeps those rows out of the Roster Matrix (WI-002437).
+
+	Conditional on the column for the same reason get_workflow_state_select() is: it is a
+	Custom Field the suspension workflow creates, and a site without it must still load
+	the roster.
+
+	The blank-availability half is not conditional - employee_availability is a real field
+	on every site. No row here has one today; what it guards is that a schedule carrying
+	no availability at all never renders as a shift cell (AC 1.5).
+	"""
+	clauses = ["ifnull(es.employee_availability, '') != ''"]
+
+	if "workflow_state" in frappe.db.get_table_columns("Employee Schedule"):
+		states = ", ".join(f"'{state}'" for state in NOT_A_WORKED_SHIFT)
+		clauses.append(f"ifnull(es.workflow_state, '') not in ({states})")
+
+	return " AND ".join(clauses)
+
+
 def safe_value(val):
 	"""Convert pandas NaN/NaT and other non-JSON-serializable values to None."""
 	if val is None:
@@ -226,11 +256,12 @@ class CreateMap:
 				es.day_off_ot, es.project, es.site, emp.project as actual_project,
 				emp.site as actual_site, emp.shift as actual_shift, es.event_location, es.client_event,
 				es.on_the_job_training, {get_workflow_state_select()}
-			FROM `tabEmployee Schedule` es 
+			FROM `tabEmployee Schedule` es
 			JOIN `tabEmployee` emp
 			ON es.employee = emp.name
 			WHERE {self.str_filter}
 			AND es.employee IN {self.employees}
+			AND {get_schedule_state_filter()}
 			ORDER BY es.employee, es.date, es.roster_type ASC
 		"""
 

--- a/one_fm/operations/doctype/employee_schedule/employee_schedule.py
+++ b/one_fm/operations/doctype/employee_schedule/employee_schedule.py
@@ -43,6 +43,16 @@ def hold_overtime_for_approval(names):
 	somebody already working a basic shift that day is a double shift. A state already
 	set is left alone, so re-running the roster over a decided request does not drag it
 	back to Pending.
+
+	WI-002437: except a Rejected one. The roster names its rows
+	"<date>_<employee>_<roster type>", so re-rostering overtime for a day already refused
+	writes over the same row rather than making a new one - and its ON DUPLICATE KEY
+	UPDATE does not touch workflow_state. Without this the row stayed Rejected, was
+	skipped here, and was then filtered out of the Shift Assignment job for being
+	Rejected: the supervisor's new request vanished with no way to tell why.
+
+	Only for the rows the caller just wrote, which is the whole reason this cannot drag a
+	decided request back: it is handed the names of that one INSERT.
 	"""
 	names = [name for name in (names or []) if name]
 	if not names:
@@ -54,7 +64,7 @@ def hold_overtime_for_approval(names):
 			"name": ["in", names],
 			"roster_type": OVERTIME,
 			"employee_availability": WORKING,
-			"workflow_state": ["in", [None, ""]],
+			"workflow_state": ["in", [None, "", DSOT_REJECTED]],
 		},
 		fields=["name", "employee", "date"],
 	)
@@ -187,13 +197,15 @@ class EmployeeSchedule(Document):
 			self.employee_availability = "Suspended"
 
 	def before_insert(self):
-		self.set_dsot_state()
 		if frappe.db.exists("Employee Schedule", {"employee": self.employee, "date": self.date, "roster_type" : self.roster_type}):
 			frappe.throw(_("Employee Schedule already scheduled for {employee} on {date}.".format(employee=self.employee_name, date=cstr(self.date))))
 
 		# validate employee is active
 		if not frappe.db.exists("Employee", {'status':'Active', 'name':self.employee}):
 			frappe.throw(f"{self.employee} - {self.employee_name} is not active and cannot be scheduled.")
+
+	def after_insert(self):
+		self.set_dsot_state()
 
 	def on_update(self):
 		self.handle_dsot_decision()
@@ -235,8 +247,18 @@ class EmployeeSchedule(Document):
 		double shift, and somebody has to say yes to it. One raised for a day the
 		employee is not already working is ordinary overtime and goes through untouched.
 
-		Set before insert rather than on validate so it cannot be talked out of the state
-		by a later save: the workflow decides when it leaves.
+		WI-002437: written after the insert, not before it. Setting the field on the
+		document made Frappe's own workflow validation refuse the save outright -
+		"Workflow State transition not allowed from Active to Pending DSOT Approval",
+		because on an insert there is no before-state to transition from and the first
+		state is the only one a new document may carry. Every double shift raised through
+		the ORM failed at the supervisor with that message, and none ever reached the
+		approver; the roster's own path only worked because it writes its rows with raw
+		SQL and then calls hold_overtime_for_approval, which is exactly what this now does
+		for a single one.
+
+		Written rather than saved, so it cannot be talked out of the state by a later
+		save: the workflow decides when it leaves.
 		"""
 		if self.roster_type != OVERTIME or self.get("workflow_state") == PENDING_DSOT:
 			return
@@ -244,7 +266,8 @@ class EmployeeSchedule(Document):
 		if not self.has_working_basic_schedule():
 			return
 
-		self.workflow_state = PENDING_DSOT
+		self.db_set("workflow_state", PENDING_DSOT, update_modified=False)
+		self.request_dsot_approval()
 
 	def has_working_basic_schedule(self) -> bool:
 		"""Is the employee already working a basic shift on this date?"""

--- a/one_fm/operations/doctype/employee_schedule/test_dsot_approval.py
+++ b/one_fm/operations/doctype/employee_schedule/test_dsot_approval.py
@@ -206,6 +206,17 @@ class TestTheApprovalRaisesTheAssignmentOnlyForToday(FrappeTestCase):
 		schedule.employee_availability = WORKING
 		schedule.insert(ignore_permissions=True)
 		self.made.append(schedule.name)
+
+		# WI-002437: where the employee is already working a basic shift that day, the
+		# insert puts the schedule into the DSOT gate. This class is about what happens
+		# *after* an approval, so it is put where an approval would leave it - written
+		# rather than saved, which is how the workflow moves it too.
+		if schedule.workflow_state != ACTIVE:
+			frappe.db.set_value(
+				"Employee Schedule", schedule.name, "workflow_state", ACTIVE, update_modified=False
+			)
+			schedule.workflow_state = ACTIVE
+
 		return schedule
 
 	def _assignments(self, date):
@@ -439,7 +450,12 @@ class TestTheRosterPath(FrappeTestCase):
 		self.employee = frappe.db.get_value("Employee", {"status": "Active"}, "name")
 		if not self.employee:
 			self.skipTest("no active employee on this site")
-		self.date = add_days(today(), 45)
+		# Far enough out that the employee has no real roster there. At 45 days they did:
+		# the seeded rows collided with the live ones on the primary key, and
+		# "overtime on a day off" was being asked about a day they were in fact working.
+		self.date = add_days(today(), 900)
+		if frappe.db.exists("Employee Schedule", {"employee": self.employee, "date": self.date}):
+			self.skipTest("the employee is already rostered on the test date")
 		self.made = []
 
 	def tearDown(self):

--- a/one_fm/operations/doctype/employee_schedule/test_dsot_roster.py
+++ b/one_fm/operations/doctype/employee_schedule/test_dsot_roster.py
@@ -1,0 +1,424 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002437: a rejected double shift does not persist on the roster, and a new one can
+be raised for the same day.
+
+The two halves the story is really about:
+
+  * the Roster Matrix stops rendering a shift cell for an overtime schedule that is
+    waiting on the DSOT Approver or has been refused (AC 1.1, AC 1.3, AC 1.4, AC 1.5); and
+  * re-rostering overtime for a day already refused puts the request back in front of the
+    approver instead of silently leaving it rejected (AC 1.6).
+
+Approving still lands on Active rather than on a state called "Approved" - Frappe allows
+one workflow per doctype, and Active is both what the Shift Assignment job picks up and
+what the suspension flow starts from. Confirmed with the process owner.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, today
+
+from one_fm.one_fm.page.roster.employee_map import (
+	NOT_A_WORKED_SHIFT,
+	CreateMap,
+	get_schedule_state_filter,
+)
+from one_fm.operations.doctype.employee_schedule.employee_schedule import (
+	ACTIVE,
+	BASIC,
+	DSOT_REJECTED,
+	OVERTIME,
+	PENDING_DSOT,
+	WORKING,
+	hold_overtime_for_approval,
+)
+
+SEEDED = "WI-002437-SEED-"
+
+
+def _an_employee():
+	return frappe.db.get_value("Employee", {"status": "Active"}, "name")
+
+
+def _an_employee_who_is_not_leaving():
+	"""One the controller will accept a far-future schedule for.
+
+	validate_relieving_date refuses any date past the employee's leaving date, and the
+	first active employee on this site has one - so a schedule 900 days out is refused
+	before the rule under test is ever reached.
+	"""
+	return frappe.db.get_value(
+		"Employee", {"status": "Active", "relieving_date": ["is", "not set"]}, "name"
+	)
+
+
+def _seed(suffix, roster_type=OVERTIME, workflow_state=ACTIVE, availability=WORKING, employee=None, date=None):
+	"""A schedule row written the way the roster writes them - raw, no controller."""
+	frappe.db.sql(
+		"""INSERT INTO `tabEmployee Schedule`
+		   (`name`, `employee`, `date`, `roster_type`, `employee_availability`,
+		    `workflow_state`, `owner`, `modified_by`, `creation`, `modified`)
+		   VALUES (%s, %s, %s, %s, %s, %s, 'Administrator', 'Administrator', NOW(), NOW())""",
+		(SEEDED + suffix, employee, date, roster_type, availability, workflow_state),
+	)
+	return SEEDED + suffix
+
+
+def _clear():
+	frappe.db.sql("DELETE FROM `tabEmployee Schedule` WHERE name LIKE %s", SEEDED + "%")
+
+
+def _rows_the_roster_would_render():
+	"""The names the Roster Matrix's own WHERE clause leaves behind, over the seeded rows.
+
+	The clause is asked for rather than copied, so a change to it is a change here too.
+	"""
+	return {
+		row[0]
+		for row in frappe.db.sql(
+			f"""SELECT es.name FROM `tabEmployee Schedule` es
+			    WHERE es.name LIKE %s AND {get_schedule_state_filter()}""",
+			SEEDED + "%",
+		)
+	}
+
+
+class TestTheRosterQueryUsesTheFilter(FrappeTestCase):
+	"""Asked of the query the map actually builds - a filter nothing splices in would pass
+	every other test in this file and change nothing on the roster."""
+
+	def test_the_schedule_query_carries_it(self):
+		query = CreateMap.schedule_query(
+			frappe._dict(str_filter="1 = 1", employees="('_TEST')")
+		)
+
+		self.assertIn(get_schedule_state_filter(), query)
+
+	def test_the_filter_is_valid_sql(self):
+		frappe.db.sql(
+			f"SELECT es.name FROM `tabEmployee Schedule` es WHERE {get_schedule_state_filter()} LIMIT 1"
+		)
+
+	def test_it_names_the_two_states_the_story_names(self):
+		self.assertEqual(set(NOT_A_WORKED_SHIFT), {PENDING_DSOT, DSOT_REJECTED})
+
+	def test_both_states_exist_on_the_workflow(self):
+		"""Every one of these is a string comparison; a state named in the wrong case
+		filters nothing."""
+		workflow = frappe.db.get_value(
+			"Workflow", {"document_type": "Employee Schedule", "is_active": 1}, "name"
+		)
+		if not workflow:
+			self.skipTest("no active Employee Schedule workflow on this site")
+
+		states = frappe.get_all(
+			"Workflow Document State",
+			filters={"parent": workflow, "parenttype": "Workflow"},
+			pluck="state",
+		)
+		for state in NOT_A_WORKED_SHIFT:
+			with self.subTest(state=state):
+				self.assertIn(state, states)
+
+
+class TestWhatTheRosterRenders(FrappeTestCase):
+	def setUp(self):
+		self.employee = _an_employee()
+		if not self.employee:
+			self.skipTest("no active employee on this site")
+		self.date = add_days(today(), 60)
+		_clear()
+
+	def tearDown(self):
+		_clear()
+
+	def test_a_pending_double_shift_is_not_rendered(self):
+		"""AC 1.1 - nobody has said yes to it yet, so it is not a shift on the roster."""
+		_seed("PENDING", workflow_state=PENDING_DSOT, employee=self.employee, date=self.date)
+
+		self.assertEqual(_rows_the_roster_would_render(), set())
+
+	def test_a_rejected_double_shift_is_not_rendered(self):
+		"""AC 1.3 and AC 1.4 - refused outright, or left unanswered until the shift ended."""
+		_seed("REJECTED", workflow_state=DSOT_REJECTED, employee=self.employee, date=self.date)
+
+		self.assertEqual(_rows_the_roster_would_render(), set())
+
+	def test_an_approved_double_shift_is_rendered(self):
+		"""AC 1.2 - approving lands on Active, and the cell comes back."""
+		approved = _seed("ACTIVE", workflow_state=ACTIVE, employee=self.employee, date=self.date)
+
+		self.assertEqual(_rows_the_roster_would_render(), {approved})
+
+	def test_a_schedule_with_no_availability_is_not_rendered(self):
+		"""AC 1.5's second half. No row here carries a blank one today; what this pins is
+		that one never renders as a shift cell if anything ever writes it."""
+		_seed("NOAVAIL", availability=None, employee=self.employee, date=self.date)
+
+		self.assertEqual(_rows_the_roster_would_render(), set())
+
+	def test_the_basic_shift_underneath_is_untouched(self):
+		"""The employee is still working that day - only the double shift goes."""
+		basic = _seed("BASIC", roster_type=BASIC, employee=self.employee, date=self.date)
+		_seed("PENDING", workflow_state=PENDING_DSOT, employee=self.employee, date=self.date)
+
+		self.assertEqual(_rows_the_roster_would_render(), {basic})
+
+	def test_an_ordinary_schedule_with_no_state_at_all_is_rendered(self):
+		"""A site without the suspension workflow has no workflow_state to read, and its
+		roster has to keep working."""
+		ordinary = _seed(
+			"NOSTATE", roster_type=BASIC, workflow_state=None, employee=self.employee, date=self.date
+		)
+
+		self.assertEqual(_rows_the_roster_would_render(), {ordinary})
+
+
+class TestOvertimeCanBeAskedForAgainAfterARejection(FrappeTestCase):
+	"""AC 1.6. The roster names its rows "<date>_<employee>_<roster type>", so re-rostering
+	overtime for a refused day writes over the same row - and its ON DUPLICATE KEY UPDATE
+	does not touch workflow_state."""
+
+	def setUp(self):
+		self.employee = _an_employee()
+		if not self.employee:
+			self.skipTest("no active employee on this site")
+		# Far enough out that the employee has no real roster there: the rule reads every
+		# Basic schedule on the day, not only the seeded ones, so a date they are already
+		# rostered on would make the "no basic shift" case untestable.
+		# A day of its own: test_dsot_approval's roster-path class works on day 900, and
+		# both ask what basic shifts the employee has that day.
+		self.date = add_days(today(), 901)
+		if frappe.db.exists("Employee Schedule", {"employee": self.employee, "date": self.date}):
+			self.skipTest("the employee is already rostered on the test date")
+		_clear()
+
+	def tearDown(self):
+		_clear()
+
+	def _pair(self, overtime_state):
+		_seed("BASIC", roster_type=BASIC, employee=self.employee, date=self.date)
+		return _seed(
+			"OT", roster_type=OVERTIME, workflow_state=overtime_state,
+			employee=self.employee, date=self.date,
+		)
+
+	def _state(self, name):
+		return frappe.db.get_value("Employee Schedule", name, "workflow_state")
+
+	def test_a_rejected_request_goes_back_in_front_of_the_approver(self):
+		overtime = self._pair(DSOT_REJECTED)
+
+		self.assertEqual(hold_overtime_for_approval([overtime]), [overtime])
+		self.assertEqual(self._state(overtime), PENDING_DSOT)
+
+	def test_an_approved_one_is_still_not_dragged_back(self):
+		"""Re-running the roster over the same day must not undo a decision that stands."""
+		overtime = self._pair(ACTIVE)
+
+		self.assertEqual(hold_overtime_for_approval([overtime]), [])
+		self.assertEqual(self._state(overtime), ACTIVE)
+
+	def test_one_already_pending_is_left_where_it_is(self):
+		overtime = self._pair(PENDING_DSOT)
+
+		self.assertEqual(hold_overtime_for_approval([overtime]), [])
+		self.assertEqual(self._state(overtime), PENDING_DSOT)
+
+	def test_it_is_still_validated_against_the_basic_shift(self):
+		"""AC 1.6 asks for the new request to be checked against the employee's active
+		Basic shift. Overtime on a day they are not already working is ordinary overtime
+		and needs no approval - a rejected one included."""
+		overtime = _seed(
+			"OT", roster_type=OVERTIME, workflow_state=DSOT_REJECTED,
+			employee=self.employee, date=self.date,
+		)
+
+		self.assertEqual(hold_overtime_for_approval([overtime]), [])
+		self.assertEqual(self._state(overtime), DSOT_REJECTED)
+
+
+class TestADoubleShiftRaisedThroughTheOrmReachesTheGate(FrappeTestCase):
+	"""AC 1.6 end to end, on the path that was not working at all.
+
+	The state used to be set on the document in before_insert, and Frappe's own workflow
+	validation then refused the save: on an insert there is no before-state to transition
+	from, so the first state is the only one a new document may carry. Every double shift
+	raised through the ORM died with "Workflow State transition not allowed from Active to
+	Pending DSOT Approval" - it never reached the approver, and the supervisor saw an
+	error rather than a request.
+	"""
+
+	def setUp(self):
+		self.employee = _an_employee_who_is_not_leaving()
+		if not self.employee:
+			self.skipTest("no active employee without a leaving date on this site")
+		self.date = add_days(today(), 902)
+		if frappe.db.exists("Employee Schedule", {"employee": self.employee, "date": self.date}):
+			self.skipTest("the employee is already rostered on the test date")
+		self.made = []
+		_clear()
+
+	def tearDown(self):
+		for name in self.made:
+			frappe.db.sql("DELETE FROM `tabEmployee Schedule` WHERE name = %s", name)
+		_clear()
+
+	def _insert_overtime(self):
+		schedule = frappe.new_doc("Employee Schedule")
+		schedule.employee = self.employee
+		schedule.date = self.date
+		schedule.roster_type = OVERTIME
+		schedule.employee_availability = WORKING
+		schedule.insert(ignore_permissions=True)
+		self.made.append(schedule.name)
+		return schedule
+
+	def test_it_saves_and_lands_in_the_gate(self):
+		_seed("BASIC", roster_type=BASIC, employee=self.employee, date=self.date)
+
+		schedule = self._insert_overtime()
+
+		self.assertEqual(
+			frappe.db.get_value("Employee Schedule", schedule.name, "workflow_state"), PENDING_DSOT
+		)
+
+	def test_ordinary_overtime_is_left_active(self):
+		"""Overtime on a day the employee is not already working needs nobody's approval,
+		and must not be dragged into the gate."""
+		schedule = self._insert_overtime()
+
+		self.assertNotEqual(
+			frappe.db.get_value("Employee Schedule", schedule.name, "workflow_state"), PENDING_DSOT
+		)
+
+	def test_the_pending_request_does_not_render_on_the_roster(self):
+		"""AC 1.1, from the state a real save leaves behind rather than a seeded one."""
+		_seed("BASIC", roster_type=BASIC, employee=self.employee, date=self.date)
+		schedule = self._insert_overtime()
+
+		rendered = {
+			row[0]
+			for row in frappe.db.sql(
+				f"""SELECT es.name FROM `tabEmployee Schedule` es
+				    WHERE es.employee = %s AND es.date = %s AND {get_schedule_state_filter()}""",
+				(self.employee, self.date),
+			)
+		}
+
+		self.assertNotIn(schedule.name, rendered)
+
+
+class TestWhatTheShiftAssignmentJobPicksUp(FrappeTestCase):
+	"""No Shift Assignment while a double shift waits, and one once it is Active.
+
+	Asked of the job itself rather than of its source: overtime_shift_assignment hands the
+	rows it selected to a background job, so the enqueue call is where they can be read.
+	"""
+
+	def setUp(self):
+		self.employees = frappe.get_all("Employee", filters={"status": "Active"}, pluck="name", limit=3)
+		if len(self.employees) < 3:
+			self.skipTest("needs three active employees on this site")
+		_clear()
+
+	def tearDown(self):
+		_clear()
+
+	def _selected(self):
+		import one_fm.api.tasks as tasks
+
+		captured = {}
+		original = frappe.enqueue
+		frappe.enqueue = lambda *args, **kwargs: captured.setdefault("roster", kwargs.get("roster"))
+		try:
+			tasks.overtime_shift_assignment()
+		finally:
+			frappe.enqueue = original
+
+		return {row.get("name") for row in (captured.get("roster") or [])}
+
+	def _overtime_today(self, suffix, employee, workflow_state):
+		name = _seed(
+			suffix, roster_type=OVERTIME, workflow_state=workflow_state,
+			employee=employee, date=today(),
+		)
+		# The job also filters is_replaced = 0, which a raw INSERT leaves NULL.
+		frappe.db.set_value("Employee Schedule", name, "is_replaced", 0, update_modified=False)
+		return name
+
+	def test_a_pending_double_shift_is_not_given_one(self):
+		pending = self._overtime_today("PENDING", self.employees[0], PENDING_DSOT)
+
+		self.assertNotIn(pending, self._selected())
+
+	def test_a_rejected_one_is_not_given_one(self):
+		rejected = self._overtime_today("REJECTED", self.employees[1], DSOT_REJECTED)
+
+		self.assertNotIn(rejected, self._selected())
+
+	def test_an_approved_one_is(self):
+		"""The other half - once the request is Active the job has to pick it up, or an
+		approved double shift never becomes a Shift Assignment at all."""
+		approved = self._overtime_today("ACTIVE", self.employees[2], ACTIVE)
+
+		self.assertIn(approved, self._selected())
+
+
+class TestApprovalDoesNotDuplicateAnAssignment(FrappeTestCase):
+	"""Approving today's overtime raises the Shift Assignment straight away - but only if
+	the job has not already made one, which it does every five minutes."""
+
+	def setUp(self):
+		self.employee = _an_employee()
+		if not self.employee:
+			self.skipTest("no active employee on this site")
+		_clear()
+		for existing in frappe.get_all(
+			"Employee Schedule",
+			filters={"employee": self.employee, "date": today(), "roster_type": OVERTIME},
+			pluck="name",
+		):
+			frappe.db.sql("DELETE FROM `tabEmployee Schedule` WHERE name = %s", existing)
+
+		self.schedule = frappe.new_doc("Employee Schedule")
+		self.schedule.employee = self.employee
+		self.schedule.date = today()
+		self.schedule.roster_type = OVERTIME
+		self.schedule.employee_availability = WORKING
+		self.schedule.insert(ignore_permissions=True)
+
+	def tearDown(self):
+		frappe.db.sql("DELETE FROM `tabEmployee Schedule` WHERE name = %s", self.schedule.name)
+		_clear()
+
+	def _calls_to_the_builder(self):
+		import one_fm.api.tasks as tasks
+
+		calls = []
+		original = tasks.create_overtime_shift_assignment
+		tasks.create_overtime_shift_assignment = lambda *a, **k: calls.append(a)
+		try:
+			self.schedule.create_dsot_shift_assignment()
+		finally:
+			tasks.create_overtime_shift_assignment = original
+
+		return calls
+
+	def test_it_builds_one_when_there_is_none(self):
+		self.assertEqual(len(self._calls_to_the_builder()), 1)
+
+	def test_it_builds_nothing_when_one_already_exists(self):
+		assignment = frappe.get_doc({
+			"doctype": "Shift Assignment",
+			"employee": self.employee,
+			"start_date": today(),
+			"roster_type": OVERTIME,
+			"docstatus": 1,
+		})
+		assignment.db_insert()
+		try:
+			self.assertEqual(self._calls_to_the_builder(), [])
+		finally:
+			frappe.db.sql("DELETE FROM `tabShift Assignment` WHERE name = %s", assignment.name)

--- a/one_fm/operations/doctype/employee_schedule/test_employee_schedule_suspension.py
+++ b/one_fm/operations/doctype/employee_schedule/test_employee_schedule_suspension.py
@@ -69,9 +69,12 @@ class TestEmployeeScheduleSuspensionWorkflow(FrappeTestCase):
 		# Active -> Pending Suspension -> Suspended (Approve) / Active (Reject)
 		self.assertEqual(self.workflow["document_type"], "Employee Schedule")
 		self.assertEqual(self.workflow["workflow_state_field"], "workflow_state")
-		self.assertEqual(
-			{s["state"] for s in self.workflow["states"]},
+		# A subset rather than the whole set: Frappe allows one workflow per doctype, so
+		# WI-002283 put the DSOT approval states on this same workflow. What this guards is
+		# that the suspension flow still has its three, not that nothing else shares them.
+		self.assertLessEqual(
 			{"Active", "Pending Suspension", "Suspended"},
+			{s["state"] for s in self.workflow["states"]},
 		)
 
 		transitions = {(t["state"], t["action"], t["next_state"]) for t in self.workflow["transitions"]}


### PR DESCRIPTION
Three things, and between them everything the story asks for that was not already true.

## 1. A double shift raised through the ORM could not be saved at all

`set_dsot_state` put `Pending DSOT Approval` on the document in `before_insert`, and Frappe's own workflow validation then refused the insert — on a new document there is no before-state to transition from, so the workflow's first state is the only one it may carry. Every such schedule died with:

> Workflow State transition not allowed from **Active** to **Pending DSOT Approval**

The supervisor saw an error instead of a request, the approver was never assigned, and **nothing on this site has ever been in the DSOT gate** (`select workflow_state, count(*) from tabEmployee Schedule` → `Active: 2,294,831`, nothing else). The roster's own path worked only because it writes its rows with raw SQL and then calls `hold_overtime_for_approval`.

The state is now written *after* the insert and the approver assigned — the same thing that function already does for a batch. AC 1.6 needs this path to work at all.

## 2. The roster stops rendering a pending or rejected double shift

One WHERE clause on the map's own query, so it covers every way the roster reaches a schedule rather than one of them (AC 1.1, 1.3, 1.4, 1.5). A schedule carrying **no Employee Availability** is filtered out with them — no row has one today, and this is what stops one ever rendering as a shift.

Only the DSOT flow reaches either state: the workflow's `Rejected` state has one way in, from `Pending DSOT Approval`, so **the suspension flow it shares a workflow with is untouched**. The clause is conditional on the `workflow_state` column for the same reason the SELECT already is — it is a Custom Field the suspension workflow creates, and a site without it has to keep loading the roster.

## 3. Overtime can be asked for again after a rejection (AC 1.6)

The roster names its rows `<date>_<employee>_<roster type>`, so re-rostering overtime for a refused day **writes over the same row** rather than making a new one — and its `ON DUPLICATE KEY UPDATE` does not touch `workflow_state`. The row stayed `Rejected`, was skipped by the DSOT gate for already having a state, and was then filtered out of the Shift Assignment job for being `Rejected`. The supervisor's new request vanished with no way to tell why.

A `Rejected` row now goes back in front of the approver. A decided one that stands — `Active` — still does not, and the gate is only ever handed the names of the INSERT that just ran.

## Two decisions from the process owner

- **Employee Availability is left as it is, not blanked.** The field is mandatory, no row on this site carries a blank one, and the roster reads the workflow state directly — the same mechanism WI-001694 used for Pending Suspension. AC 1.1/1.3/1.4 ask for the field to be nulled; the visible outcome they describe is delivered, the field is not touched.
- **Approving still lands on `Active`, not a new `Approved` state.** Frappe allows one workflow per doctype; `Active` is what the Shift Assignment job picks up and what a suspension starts from, and a state of its own would have taken both away.

## Shift Assignment behaviour — asserted, not changed

Already correct, now covered: nothing is built while the request is pending or after it is rejected; approving today's overtime builds one straight away **unless the five-minute job has already made it**; and once the request is `Active` that job picks it up on its own.

## Three existing tests were measuring the live roster

- `TestTheRosterPath` worked 45 days out, where its employee is really rostered: the seeded rows collided with the live ones on the primary key, and *"overtime on a day off"* was being asked about a day they were in fact working. Both classes now work far enough out to have the day to themselves.
- WI-001694's workflow test demanded the workflow hold **exactly** its own three states, which stopped being true when WI-002283 put the DSOT states on the same workflow. It now asks that its three are there rather than that nothing else is.

## Testing

`test_dsot_roster` — 22 tests, all passing.
`test_dsot_approval` (35), `test_employee_schedule_suspension` (13), `test_roster_client_queries` (1), `test_roster_permissions` (9) — all passing; the first two were red before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)