### PR TITLE
WI-002465: list the days an Absence Case is about, and jump to them

### DIFF
--- a/one_fm/one_fm/doctype/absence_case/absence_case.js
+++ b/one_fm/one_fm/doctype/absence_case/absence_case.js
@@ -18,8 +18,43 @@ frappe.ui.form.on("Absence Case", {
 	},
 	unpaid_leave_request_decision(frm) {
 		setup_unpaid_leave_buttons(frm);
+	},
+	go_to_attendance(frm) {
+		open_attendance_list(frm);
 	}
 });
+
+// WI-002465: the days the case is about, as the server wrote them - one date per line.
+function absent_dates_list(frm) {
+	return (frm.doc.absent_dates || "")
+		.split("\n")
+		.map((date) => date.trim())
+		.filter((date) => date);
+}
+
+// AC 2: open the Attendance list filtered to exactly those days.
+//
+// route_options rather than a query string: list_view.js::parse_filters_from_route_options
+// reads an array value as [operator, value], which is the only way to get an "in" filter
+// across rather than a chain of equals that would match nothing.
+function open_attendance_list(frm) {
+	const dates = absent_dates_list(frm);
+
+	if (!dates.length) {
+		frappe.msgprint({
+			message: __("There are no absent dates on this case to look up yet."),
+			indicator: "orange",
+			title: __("No Absent Dates")
+		});
+		return;
+	}
+
+	frappe.route_options = {
+		employee: frm.doc.employee,
+		attendance_date: ["in", dates]
+	};
+	frappe.set_route("List", "Attendance");
+}
 
 function set_leave_application_query(frm) {
 	frm.set_query("leave_application", function() {

--- a/one_fm/one_fm/doctype/absence_case/absence_case.json
+++ b/one_fm/one_fm/doctype/absence_case/absence_case.json
@@ -29,6 +29,8 @@
   "employee_id",
   "under_company_accommodation",
   "absence_type",
+  "absent_dates",
+  "go_to_attendance",
   "absence_case_details_section",
   "location_status",
   "has_contact_been_made",
@@ -110,6 +112,23 @@
    "label": "Absence Type",
    "options": "\n5 Days Consecutive Absence\n7 Days Consecutive Absence\n16 Days Absence in a Year\n21 Days Absence in a Year",
    "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.absence_type",
+   "description": "Captures and lists all specific dates on which the employee was marked absent for the selected absence case.",
+   "fieldname": "absent_dates",
+   "fieldtype": "Long Text",
+   "label": "Absent Dates",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "bold": 1,
+   "depends_on": "eval:doc.absence_type",
+   "description": "Triggers a direct navigation route to the Attendance DocType list view, automatically filtering attendance records matching the dates listed in the Absent Dates field.",
+   "fieldname": "go_to_attendance",
+   "fieldtype": "Button",
+   "label": "Go to Attendance"
   },
   {
    "fieldname": "absence_case_details_section",

--- a/one_fm/one_fm/doctype/absence_case/absence_case.py
+++ b/one_fm/one_fm/doctype/absence_case/absence_case.py
@@ -1,13 +1,139 @@
+import re
+
 import frappe
 from frappe import throw, _
 from frappe.model.document import Document
-from frappe.utils import get_datetime, now_datetime, flt
+from frappe.utils import add_days, get_datetime, getdate, now_datetime, flt, today
 from frappe.model.mapper import get_mapped_doc
+
+# WI-002465: what counts as an absence here, and it is the same test the nightly job uses
+# to raise these cases in the first place (api/tasks.attendance_query_script) - a case and
+# the dates on it must not disagree about who was absent.
+ABSENT = "Absent"
+
+# How far back a consecutive run is looked for when the case does not carry an Absence
+# Start Date. Only the job that raises a 5-day case passes one; the 7-day path never has,
+# so without a fallback the field the story is about would stay empty for exactly the type
+# AC 3 names. A run of five or seven days sits within days of the case being raised, so
+# the window is generous rather than unbounded.
+CONSECUTIVE_LOOKBACK_DAYS = 90
+
+# The number and the kind are both in the Absence Type: "7 Days Consecutive Absence" is
+# seven contiguous days, "21 Days Absence in a Year" is that calendar year's absences.
+# Read from the option rather than matched against a list of them, because this site offers
+# four - 5 and 16 day thresholds exist here as well as the two the story names - and all
+# four have to behave.
+_THRESHOLD = re.compile(r"^\s*(\d+)\s+Days", re.I)
+
+
+def threshold_days(absence_type: str) -> int | None:
+	"""How many days the Absence Type is named after, or None if it names no number."""
+	match = _THRESHOLD.match(absence_type or "")
+	return int(match.group(1)) if match else None
+
+
+def is_consecutive(absence_type: str) -> bool:
+	return "consecutive" in (absence_type or "").lower()
+
+
+def absent_attendance_dates(employee: str, from_date, to_date) -> list:
+	"""Every day this employee was marked absent in the window, oldest first.
+
+	Submitted Attendance only, and status Absent - the same two conditions the nightly job
+	counts on. A draft or cancelled Attendance is not a day anybody was marked absent.
+	"""
+	return frappe.get_all(
+		"Attendance",
+		filters={
+			"employee": employee,
+			"docstatus": 1,
+			"status": ABSENT,
+			"attendance_date": ["between", [from_date, to_date]],
+		},
+		pluck="attendance_date",
+		order_by="attendance_date asc",
+	)
+
+
+def consecutive_run(dates: list, start=None) -> list:
+	"""One unbroken run of days out of a sorted list.
+
+	From `start` when the case names one, so the run is the one the case was raised for.
+	Otherwise the most recent run, which is what a case raised days ago is about.
+	"""
+	if not dates:
+		return []
+
+	runs, current = [], [dates[0]]
+	for previous, day in zip(dates, dates[1:]):
+		if (day - previous).days == 1:
+			current.append(day)
+		else:
+			runs.append(current)
+			current = [day]
+	runs.append(current)
+
+	if start:
+		start = getdate(start)
+		for run in runs:
+			if run[0] <= start <= run[-1]:
+				return [day for day in run if day >= start]
+		return []
+
+	return runs[-1]
 
 
 class AbsenceCase(Document):
 	def validate(self):
+		self.set_absent_dates()
 		self.validate_formal_hearing_datetime()
+
+	def set_absent_dates(self):
+		"""List the days this case is about, for AC 2 to filter Attendance by (WI-002465).
+
+		Recomputed on every save rather than written once at creation: the nightly job
+		raises these as drafts and an Attendance correction before the case is submitted
+		should be reflected in them. The field is not allow_on_submit, so submitting the
+		case freezes the list, which is what makes it a record of the period.
+		"""
+		self.absent_dates = "\n".join(str(day) for day in self.get_absent_dates())
+
+	def get_absent_dates(self) -> list:
+		if not (self.employee and self.absence_type):
+			return []
+
+		anchor = getdate(self.posting_date or today())
+
+		if is_consecutive(self.absence_type):
+			return self.consecutive_absent_dates(anchor)
+
+		return self.yearly_absent_dates(anchor)
+
+	def consecutive_absent_dates(self, anchor) -> list:
+		"""The run of contiguous absent days this case was raised for.
+
+		Capped at the number the Absence Type names: a case called "7 Days Consecutive
+		Absence" lists seven days even where the employee went on to be absent for ten, so
+		the field says what the case is about rather than everything since.
+		"""
+		start = getdate(self.absence_start_date) if self.absence_start_date else None
+		from_date = min(start, anchor) if start else add_days(anchor, -CONSECUTIVE_LOOKBACK_DAYS)
+
+		run = consecutive_run(absent_attendance_dates(self.employee, from_date, anchor), start)
+
+		days = threshold_days(self.absence_type)
+		return run[:days] if days else run
+
+	def yearly_absent_dates(self, anchor) -> list:
+		"""Every absent day in the case's own calendar year.
+
+		All of them, not the number the Absence Type names: the threshold is what raised
+		the case, and an employee absent twenty-five days is not verified by being shown
+		twenty-one of them.
+		"""
+		return absent_attendance_dates(
+			self.employee, anchor.replace(month=1, day=1), anchor.replace(month=12, day=31)
+		)
 
 	def validate_formal_hearing_datetime(self):
 		if not self.formal_hearing_start_datetime:

--- a/one_fm/one_fm/doctype/absence_case/test_absence_case_absent_dates.py
+++ b/one_fm/one_fm/doctype/absence_case/test_absence_case_absent_dates.py
@@ -1,0 +1,317 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""WI-002465: the absent dates an Absence Case is about, and the jump to Attendance.
+
+The dates are read off Attendance rather than typed, so the fixtures here are Attendance
+rows written straight into the table: Attendance has its own validations - a shift, a
+duplicate check, a leave application - and none of them has anything to do with which days
+somebody was marked absent.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, getdate, today
+
+from one_fm.one_fm.doctype.absence_case.absence_case import (
+	ABSENT,
+	CONSECUTIVE_LOOKBACK_DAYS,
+	absent_attendance_dates,
+	consecutive_run,
+	is_consecutive,
+	threshold_days,
+)
+
+SEEDED = "WI-002465-ATT-"
+EMPLOYEE = "WI-002465-EMPLOYEE"
+
+
+def _clear():
+	"""FrappeTestCase rolls back per class, not per test."""
+	frappe.db.sql("DELETE FROM `tabAttendance` WHERE name LIKE %s", SEEDED + "%")
+
+
+def _attendance(date, status=ABSENT, docstatus=1, employee=EMPLOYEE, suffix=None):
+	"""One Attendance row, written without running Attendance's own validations."""
+	name = SEEDED + (suffix or f"{employee}-{date}")
+	frappe.db.sql(
+		"""INSERT INTO `tabAttendance`
+		   (`name`, `employee`, `attendance_date`, `status`, `docstatus`,
+		    `owner`, `modified_by`, `creation`, `modified`)
+		   VALUES (%s, %s, %s, %s, %s, 'Administrator', 'Administrator', NOW(), NOW())""",
+		(name, employee, date, status, docstatus),
+	)
+	return name
+
+
+def _case(absence_type, absence_start_date=None, posting_date=None, employee=EMPLOYEE):
+	"""An Absence Case as validate sees it. Built in memory - the rule reads four fields,
+	and inserting one would drag in the formal-hearing rules and a real Employee."""
+	doc = frappe.new_doc("Absence Case")
+	doc.employee = employee
+	doc.absence_type = absence_type
+	doc.absence_start_date = absence_start_date
+	doc.posting_date = posting_date or today()
+	return doc
+
+
+def _dates(doc):
+	doc.set_absent_dates()
+	return [line for line in (doc.absent_dates or "").split("\n") if line]
+
+
+class TestReadingTheAbsenceType(FrappeTestCase):
+	"""Both halves of the behaviour are read out of the option's own words, so every
+	option the field offers has to parse - this site has four, not the two the story
+	names."""
+
+	def test_every_option_the_field_offers_names_a_number(self):
+		options = [
+			option
+			for option in frappe.get_meta("Absence Case").get_field("absence_type").options.split("\n")
+			if option
+		]
+
+		self.assertTrue(options)
+		for option in options:
+			with self.subTest(option=option):
+				self.assertIsNotNone(threshold_days(option), f"{option!r} names no number")
+
+	def test_the_two_the_story_names_are_offered(self):
+		options = frappe.get_meta("Absence Case").get_field("absence_type").options
+
+		self.assertIn("7 Days Consecutive Absence", options)
+		self.assertIn("21 Days Absence in a Year", options)
+
+	def test_the_site_s_other_two_are_still_offered(self):
+		"""5 and 16 day cases are raised by attendance_query_script and must not be lost."""
+		options = frappe.get_meta("Absence Case").get_field("absence_type").options
+
+		self.assertIn("5 Days Consecutive Absence", options)
+		self.assertIn("16 Days Absence in a Year", options)
+
+	def test_consecutive_is_told_from_yearly(self):
+		self.assertTrue(is_consecutive("7 Days Consecutive Absence"))
+		self.assertTrue(is_consecutive("5 Days Consecutive Absence"))
+		self.assertFalse(is_consecutive("21 Days Absence in a Year"))
+		self.assertFalse(is_consecutive("16 Days Absence in a Year"))
+
+	def test_the_number_is_the_one_in_the_name(self):
+		self.assertEqual(threshold_days("7 Days Consecutive Absence"), 7)
+		self.assertEqual(threshold_days("21 Days Absence in a Year"), 21)
+		self.assertIsNone(threshold_days(None))
+		self.assertIsNone(threshold_days("Absence"))
+
+
+class TestFindingOneRun(FrappeTestCase):
+	"""consecutive_run on its own - no database, so the date arithmetic is checked
+	without a fixture."""
+
+	def _days(self, *offsets):
+		return [getdate(add_days("2026-06-10", offset)) for offset in offsets]
+
+	def test_an_empty_list_has_no_run(self):
+		self.assertEqual(consecutive_run([]), [])
+
+	def test_the_latest_run_is_taken_when_no_start_is_given(self):
+		dates = self._days(0, 1, 2, 9, 10)
+
+		self.assertEqual(consecutive_run(dates), self._days(9, 10))
+
+	def test_a_start_picks_the_run_it_falls_in(self):
+		dates = self._days(0, 1, 2, 9, 10)
+
+		self.assertEqual(consecutive_run(dates, "2026-06-10"), self._days(0, 1, 2))
+
+	def test_a_start_inside_a_run_takes_the_rest_of_it(self):
+		dates = self._days(0, 1, 2, 3)
+
+		self.assertEqual(consecutive_run(dates, "2026-06-12"), self._days(2, 3))
+
+	def test_a_start_in_no_run_finds_nothing(self):
+		dates = self._days(0, 1, 2)
+
+		self.assertEqual(consecutive_run(dates, "2026-06-20"), [])
+
+	def test_one_day_is_a_run(self):
+		self.assertEqual(consecutive_run(self._days(0)), self._days(0))
+
+
+class TestWhichAttendanceCounts(FrappeTestCase):
+	def setUp(self):
+		_clear()
+
+	def tearDown(self):
+		_clear()
+
+	def test_only_submitted_absences_count(self):
+		_attendance(add_days(today(), -3), suffix="a")
+		_attendance(add_days(today(), -2), status="Present", suffix="b")
+		_attendance(add_days(today(), -1), docstatus=0, suffix="c")
+		_attendance(today(), docstatus=2, suffix="d")
+
+		found = absent_attendance_dates(EMPLOYEE, add_days(today(), -10), today())
+
+		self.assertEqual(found, [getdate(add_days(today(), -3))])
+
+	def test_another_employee_is_not_counted(self):
+		_attendance(add_days(today(), -1), employee="WI-002465-OTHER", suffix="other")
+
+		self.assertEqual(absent_attendance_dates(EMPLOYEE, add_days(today(), -10), today()), [])
+
+
+class TestAConsecutiveCase(FrappeTestCase):
+	"""AC 3, first half."""
+
+	def setUp(self):
+		_clear()
+		self.start = add_days(today(), -9)
+		for offset in range(9):
+			_attendance(add_days(self.start, offset), suffix=f"run{offset}")
+
+	def tearDown(self):
+		_clear()
+
+	def test_it_lists_the_days_the_type_names(self):
+		"""Nine absent days in a row, on a seven day case - seven of them."""
+		dates = _dates(_case("7 Days Consecutive Absence", absence_start_date=self.start))
+
+		self.assertEqual(dates, [str(getdate(add_days(self.start, n))) for n in range(7)])
+
+	def test_a_five_day_case_lists_five(self):
+		dates = _dates(_case("5 Days Consecutive Absence", absence_start_date=self.start))
+
+		self.assertEqual(len(dates), 5)
+		self.assertEqual(dates[0], str(getdate(self.start)))
+
+	def test_it_starts_where_the_case_says(self):
+		dates = _dates(
+			_case("7 Days Consecutive Absence", absence_start_date=add_days(self.start, 2))
+		)
+
+		self.assertEqual(dates[0], str(getdate(add_days(self.start, 2))))
+
+	def test_it_finds_the_run_without_a_start_date(self):
+		"""The nightly job only passes a start date for a 5 day case; the 7 day path never
+		has, so without this the field would stay empty for the type AC 3 names."""
+		dates = _dates(_case("7 Days Consecutive Absence"))
+
+		self.assertEqual(dates, [str(getdate(add_days(self.start, n))) for n in range(7)])
+
+	def test_a_gap_ends_the_run(self):
+		_clear()
+		for offset in (0, 1, 2, 4, 5):
+			_attendance(add_days(self.start, offset), suffix=f"gap{offset}")
+
+		dates = _dates(_case("7 Days Consecutive Absence", absence_start_date=self.start))
+
+		self.assertEqual(dates, [str(getdate(add_days(self.start, n))) for n in range(3)])
+
+	def test_nothing_to_find_is_an_empty_field(self):
+		_clear()
+
+		self.assertEqual(_dates(_case("7 Days Consecutive Absence")), [])
+
+	def test_an_absence_older_than_the_lookback_is_not_dragged_in(self):
+		_clear()
+		old = add_days(today(), -(CONSECUTIVE_LOOKBACK_DAYS + 5))
+		_attendance(old, suffix="old")
+
+		self.assertEqual(_dates(_case("7 Days Consecutive Absence")), [])
+
+
+class TestAYearlyCase(FrappeTestCase):
+	"""AC 3, second half."""
+
+	def setUp(self):
+		_clear()
+		self.year = getdate(today()).year
+
+	def tearDown(self):
+		_clear()
+
+	def test_it_lists_the_year_s_absences(self):
+		days = [f"{self.year}-01-05", f"{self.year}-03-17", f"{self.year}-07-02"]
+		for day in days:
+			_attendance(day, suffix=day)
+
+		self.assertEqual(_dates(_case("21 Days Absence in a Year")), days)
+
+	def test_another_year_is_left_out(self):
+		_attendance(f"{self.year - 1}-12-31", suffix="prev")
+		_attendance(f"{self.year}-01-01", suffix="this")
+
+		self.assertEqual(_dates(_case("21 Days Absence in a Year")), [f"{self.year}-01-01"])
+
+	def test_it_is_not_capped_at_the_threshold(self):
+		"""The number in the type is what raised the case; an employee absent more days
+		than that is not verified by being shown fewer of them."""
+		days = [f"{self.year}-02-{day:02d}" for day in range(1, 26)]
+		for day in days:
+			_attendance(day, suffix=day)
+
+		self.assertEqual(len(_dates(_case("21 Days Absence in a Year"))), 25)
+
+	def test_the_year_is_the_case_s_own(self):
+		"""Read off posting_date, so a case raised last year still describes last year."""
+		_attendance(f"{self.year - 1}-05-04", suffix="prev")
+
+		dates = _dates(
+			_case("21 Days Absence in a Year", posting_date=f"{self.year - 1}-12-01")
+		)
+
+		self.assertEqual(dates, [f"{self.year - 1}-05-04"])
+
+
+class TestWhenNothingIsAsked(FrappeTestCase):
+	def setUp(self):
+		_clear()
+		_attendance(add_days(today(), -1), suffix="one")
+
+	def tearDown(self):
+		_clear()
+
+	def test_no_absence_type_means_no_dates(self):
+		"""The fields are hidden in that state, and a stale list behind a hidden field is
+		worse than an empty one."""
+		self.assertEqual(_dates(_case(None)), [])
+
+	def test_no_employee_means_no_dates(self):
+		self.assertEqual(_dates(_case("7 Days Consecutive Absence", employee=None)), [])
+
+
+class TestTheFieldsTheStoryAdds(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.meta = frappe.get_meta("Absence Case")
+
+	def test_absent_dates_matches_the_ba_site(self):
+		field = self.meta.get_field("absent_dates")
+
+		self.assertIsNotNone(field)
+		self.assertEqual(field.fieldtype, "Long Text")
+		self.assertEqual(field.label, "Absent Dates")
+		self.assertTrue(field.read_only)
+
+	def test_go_to_attendance_matches_the_ba_site(self):
+		field = self.meta.get_field("go_to_attendance")
+
+		self.assertIsNotNone(field)
+		self.assertEqual(field.fieldtype, "Button")
+		self.assertEqual(field.label, "Go to Attendance")
+		# The case is submittable and the jump has to work on a submitted one.
+		self.assertTrue(field.allow_on_submit)
+
+	def test_both_hide_until_an_absence_type_is_chosen(self):
+		"""AC 1, and the same expression the BA site uses."""
+		for fieldname in ("absent_dates", "go_to_attendance"):
+			with self.subTest(fieldname=fieldname):
+				self.assertEqual(self.meta.get_field(fieldname).depends_on, "eval:doc.absence_type")
+
+	def test_they_sit_under_the_absence_type(self):
+		order = [field.fieldname for field in self.meta.fields]
+
+		self.assertEqual(
+			order[order.index("absence_type") : order.index("absence_type") + 3],
+			["absence_type", "absent_dates", "go_to_attendance"],
+		)


### PR DESCRIPTION
Two fields brought over from the BA site's Absence Case — **Absent Dates** and a **Go to Attendance** button — and the behaviour behind them. Every property of both fields matches theirs exactly (label, type, `read_only`, `bold`, `allow_on_submit`, `depends_on`, description), and the field order is now identical to theirs.

## AC 1 — Conditional visibility

Both fields carry `depends_on: eval:doc.absence_type`, the same expression the BA site uses. Hidden with no Absence Type, visible with any.

## AC 3 — Populating the dates

Read off Attendance on every save rather than typed: **submitted** records with **status Absent**, which is the same test `attendance_query_script` counts on when it raises these cases — so a case and the dates on it cannot disagree about who was absent.

Recomputed each save because the job raises these as drafts and an attendance correction before submission should reach them. The field is **not** `allow_on_submit`, so submitting freezes the list — which is what makes it a record of the period.

The Absence Type says both *what kind* of case it is and *how many days* triggered it, and both are read out of the option rather than matched against a hard-coded pair. **This site offers four options where the story names two** — `5 Days Consecutive Absence` and `16 Days Absence in a Year` are raised by the nightly job as well — and all four behave. The BA site has only the two; their list is **not** copied, because narrowing it would break the 5-day and 16-day cases this site already raises.

## AC 2 — Route and filter

`frappe.route_options` rather than a query string: `list_view.js::parse_filters_from_route_options` reads an array value as `[operator, value]`, which is the only way to get an `in` filter across rather than a chain of equals that would match nothing.

## Three judgement calls — please confirm

1. **A consecutive case with no Absence Start Date.** AC 3 says "Given an Employee and Absence Start Date are selected". Only the **5-day** path ever sets that date — `create_absence_case` is called without it for the 7-day case, which is the type AC 3 names — so a literal reading leaves the field empty for that type. With no date, the most recent run within 90 days is used. **Nothing in the nightly job is touched**, so the notification behaviour is unchanged.
2. **A yearly case lists every absent day in its year, not 21 of them.** The threshold is what raised the case; an employee absent 25 days is not verified by being shown 21. Say the word if you want it capped.
3. **The button also filters on the employee.** AC 2 names only the Attendance Date filter, but without the employee the list shows everyone's attendance on those days, which does not serve "quick verification". Easy to drop.

## Not applied

The BA site also sets `in_list_view` / `in_standard_filter` on `employee`, `absence_type`, `location_status` and `under_company_accommodation`. **No criterion asks for a list view change**, so they are left alone rather than swept in — flagging in case they are wanted.

## Testing

`bench run-tests --module one_fm.one_fm.doctype.absence_case.test_absence_case_absent_dates` — 30 tests. The 25 behavioural ones pass now; the 5 that read the two fields off the meta go green on `bench migrate`.

`test_absence_case` (the existing formal-hearing rules) still passes.

**Needs `bench migrate`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)